### PR TITLE
Improve event decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Geth Traces depth reduced ([#562](https://github.com/iamdefinitelyahuman/brownie/pull/562))
 - Ganache gasCost in traces (ganache bug) ([#562](https://github.com/iamdefinitelyahuman/brownie/pull/562))
+- Decoding error when contracts use the same event signature with different argument indexing ([#575](https://github.com/iamdefinitelyahuman/brownie/pull/575))
 
 ## [1.8.9](https://github.com/iamdefinitelyahuman/brownie/tree/v1.8.9) - 2020-05-26
 ### Changed

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -39,7 +39,7 @@ from brownie.typing import AccountsType, TransactionReceiptType
 from brownie.utils import color
 
 from . import accounts, rpc
-from .event import _get_topics
+from .event import _add_deployment_topics, _get_topics
 from .rpc import _revert_register
 from .state import _add_contract, _add_deployment, _find_contract, _get_deployment, _remove_contract
 from .web3 import _resolve_address, web3
@@ -314,6 +314,7 @@ class _DeployedContractBase(_ContractBase):
         self._owner = owner
         self.tx = tx
         self.address = address
+        _add_deployment_topics(address, self.abi)
 
         fn_names = [i["name"] for i in self.abi if i["type"] == "function"]
         for abi in [i for i in self.abi if i["type"] == "function"]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 colorama>=0.4.1;platform_system=='Windows'
 eth-abi==2.1.1
-eth-event>=1.0.0,<2.0.0
+eth-event>=1.1.0,<2.0.0
 eth-hash[pycryptodome]==0.2.0
 eth-utils==1.9.0
 hexbytes==0.2.0


### PR DESCRIPTION
### What I did
Store event ABI data and decode events on a per-deployment basis, to avoid issues when different contracts have events with the same signature but different indexed elements.

Fixes #511 

### How I did it
* In `network/events.py`, event ABIs for specific addresses are held in `_deployment_topics`. When decoding an event, if the originating address has an event ABI, it is used.  If not, the global event ABI (`_topics`) is used.
* When updating `_topics`, if an ABI already exists it is only replaced if the previous record had no indexed values and the new one _has_ indexed values. So far, every occurrence of this bug that has been reported has been a result of no indexing, when the existing record does use indexing. Upstream in `eth_event`, providing an indexed ABI will now decode an unindexed event log.

### How to verify it
Run the tests. I added a test case for this specific issue.
