### PR TITLE
Dev artifacts

### DIFF
--- a/brownie/_config.py
+++ b/brownie/_config.py
@@ -44,6 +44,11 @@ class ConfigContainer:
                 raise ValueError(f"Multiple networks using ID '{key}'")
             self.networks[key] = value
 
+        # make sure chainids are always strings
+        for network, values in self.networks.items():
+            if "chainid" in values:
+                self.networks[network]["chainid"] = str(values["chainid"])
+
         self.argv = defaultdict(lambda: None)
         self.settings = _Singleton("settings", (ConfigDict,), {})(base_config)
         self._active_network = None

--- a/brownie/data/default-config.yaml
+++ b/brownie/data/default-config.yaml
@@ -41,3 +41,4 @@ hypothesis:
 
 autofetch_sources: false
 dependencies: null
+dev_deployment_artifacts: false

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -399,9 +399,17 @@ class _DeployedContractBase(_ContractBase):
 
     def _save_deployment(self) -> None:
         path = self._deployment_path()
+        chainid = "dev" if CONFIG.network_type != "live" else CONFIG.active_network["chainid"]
+        deployment_build = self._build.copy()
+
+        deployment_build["deployment"] = {
+            "address": self.address,
+            "chainid": chainid,
+            "blockHeight": web3.eth.blockNumber,
+        }
         if path and not path.exists():
             with path.open("w") as fp:
-                json.dump(self._build, fp)
+                json.dump(deployment_build, fp)
         self._project._add_to_deployment_map(self)
 
     def _delete_deployment(self) -> None:

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -399,7 +399,7 @@ class _DeployedContractBase(_ContractBase):
 
     def _save_deployment(self) -> None:
         path = self._deployment_path()
-        if path and (not path.exists() or CONFIG.network_type != "live"):
+        if path and not path.exists():
             with path.open("w") as fp:
                 json.dump(self._build, fp)
         self._project._add_to_deployment_map(self)

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -386,23 +386,29 @@ class _DeployedContractBase(_ContractBase):
         return Wei(balance)
 
     def _deployment_path(self) -> Optional[Path]:
-        if CONFIG.network_type != "live" or not self._project._path:
+        if not self._project._path or (
+            CONFIG.network_type != "live" and not CONFIG.settings.get("dev_deployment_artifacts")
+        ):
             return None
-        chainid = CONFIG.active_network["chainid"]
+
+        chainid = "dev" if CONFIG.network_type != "live" else CONFIG.active_network["chainid"]
+
         path = self._project._path.joinpath(f"build/deployments/{chainid}")
         path.mkdir(exist_ok=True)
         return path.joinpath(f"{self.address}.json")
 
     def _save_deployment(self) -> None:
         path = self._deployment_path()
-        if path and not path.exists():
+        if path and (not path.exists() or CONFIG.network_type != "live"):
             with path.open("w") as fp:
                 json.dump(self._build, fp)
+        self._project._add_to_deployment_map(self)
 
     def _delete_deployment(self) -> None:
         path = self._deployment_path()
         if path and path.exists():
             path.unlink()
+        self._project._remove_from_deployment_map(self)
 
 
 class Contract(_DeployedContractBase):

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -407,16 +407,18 @@ class _DeployedContractBase(_ContractBase):
             "chainid": chainid,
             "blockHeight": web3.eth.blockNumber,
         }
-        if path and not path.exists():
-            with path.open("w") as fp:
-                json.dump(deployment_build, fp)
-        self._project._add_to_deployment_map(self)
+        if path:
+            self._project._add_to_deployment_map(self)
+            if not path.exists():
+                with path.open("w") as fp:
+                    json.dump(deployment_build, fp)
 
     def _delete_deployment(self) -> None:
         path = self._deployment_path()
-        if path and path.exists():
-            path.unlink()
-        self._project._remove_from_deployment_map(self)
+        if path:
+            self._project._remove_from_deployment_map(self)
+            if path.exists():
+                path.unlink()
 
 
 class Contract(_DeployedContractBase):

--- a/brownie/network/rpc.py
+++ b/brownie/network/rpc.py
@@ -14,6 +14,7 @@ from urllib.parse import urlparse
 
 import psutil
 
+import brownie
 from brownie._config import EVM_EQUIVALENTS
 from brownie._singleton import _Singleton
 from brownie.convert import Wei
@@ -353,6 +354,8 @@ class Rpc(metaclass=_Singleton):
         self._undo_buffer.clear()
         self._redo_buffer.clear()
         self._snapshot_id = self._current_id = self._revert(self._snapshot_id)
+        for project in brownie.project.get_loaded_projects():
+            project._clear_dev_deployments(web3.eth.blockNumber)
         return f"Block height reverted to {web3.eth.blockNumber}"
 
     def reset(self) -> str:
@@ -365,6 +368,8 @@ class Rpc(metaclass=_Singleton):
         self._undo_buffer.clear()
         self._redo_buffer.clear()
         self._reset_id = self._current_id = self._revert(self._reset_id)
+        for project in brownie.project.get_loaded_projects():
+            project._clear_dev_deployments()
         return f"Block height reset to {web3.eth.blockNumber}"
 
 

--- a/brownie/network/rpc.py
+++ b/brownie/network/rpc.py
@@ -14,7 +14,6 @@ from urllib.parse import urlparse
 
 import psutil
 
-import brownie
 from brownie._config import EVM_EQUIVALENTS
 from brownie._singleton import _Singleton
 from brownie.convert import Wei
@@ -354,8 +353,6 @@ class Rpc(metaclass=_Singleton):
         self._undo_buffer.clear()
         self._redo_buffer.clear()
         self._snapshot_id = self._current_id = self._revert(self._snapshot_id)
-        for project in brownie.project.get_loaded_projects():
-            project._clear_dev_deployments(web3.eth.blockNumber)
         return f"Block height reverted to {web3.eth.blockNumber}"
 
     def reset(self) -> str:
@@ -368,8 +365,6 @@ class Rpc(metaclass=_Singleton):
         self._undo_buffer.clear()
         self._redo_buffer.clear()
         self._reset_id = self._current_id = self._revert(self._reset_id)
-        for project in brownie.project.get_loaded_projects():
-            project._clear_dev_deployments()
         return f"Block height reset to {web3.eth.blockNumber}"
 
 

--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -314,20 +314,19 @@ class Project(_ProjectBase):
                 build = json.load(fp)
 
             contract_name = build["contractName"]
-            if CONFIG.network_type == "live":
-                if contract_name not in self._containers:
-                    build_json.unlink()
-                    continue
-                if "pcMap" in build:
-                    contract = ProjectContract(self, build, build_json.stem)
-                else:
-                    contract = Contract(  # type: ignore
-                        contract_name, build_json.stem, build["abi"]
-                    )
-                    contract._project = self
-                container = self._containers[contract_name]
-                _add_contract(contract)
-                container._contracts.append(contract)
+            if contract_name not in self._containers:
+                build_json.unlink()
+                continue
+            if "pcMap" in build:
+                contract = ProjectContract(self, build, build_json.stem)
+            else:
+                contract = Contract(  # type: ignore
+                    contract_name, build_json.stem, build["abi"]
+                )
+                contract._project = self
+            container = self._containers[contract_name]
+            _add_contract(contract)
+            container._contracts.append(contract)
 
             contract_address = build_json.stem
             if chainid in deployment_map:
@@ -342,12 +341,29 @@ class Project(_ProjectBase):
         with self._path.joinpath("build/deployments/map.json").open("w") as fp:
             json.dump(deployment_map, fp, sort_keys=True, indent=2, default=sorted)
 
-    def _clear_dev_deployments(self) -> None:
+    def _clear_dev_deployments(self, after_block: int = 0) -> None:
         path = self._path.joinpath(f"build/deployments/dev")
         if path.exists():
             deployments = list(path.glob("*.json"))
+            deployment_map = self._load_deployment_map()
             for deployment in deployments:
-                deployment.unlink()
+                if after_block == 0:
+                    deployment.unlink()
+                    if "dev" in deployment_map:
+                        del deployment_map["dev"]
+                    self._save_deployment_map(deployment_map)
+                else:
+                    with deployment.open("r") as fp:
+                        deployment_artifact = json.load(fp)
+                        block_height = deployment_artifact["deployment"]["blockHeight"]
+                        address = deployment_artifact["deployment"]["address"]
+                        contract_name = deployment_artifact["contractName"]
+                    if block_height > after_block:
+                        deployment.unlink()
+                        try:
+                            deployment_map["dev"][contract_name].remove(address)
+                        except (KeyError, ValueError):
+                            pass
 
     def _load_deployment_map(self) -> Dict:
         deployment_map: Dict = {}
@@ -364,7 +380,6 @@ class Project(_ProjectBase):
     def _remove_from_deployment_map(self, contract: ProjectContract) -> None:
         if CONFIG.network_type != "live" and not CONFIG.settings.get("dev_deployment_artifacts"):
             return
-
         chainid = CONFIG.active_network["chainid"] if CONFIG.network_type == "live" else "dev"
         deployment_map = self._load_deployment_map()
 
@@ -496,7 +511,7 @@ def check_for_project(path: Union[Path, str] = ".") -> Optional[Path]:
     return None
 
 
-def get_loaded_projects() -> List:
+def get_loaded_projects() -> List["Project"]:
     """Returns a list of currently loaded Project objects."""
     return _loaded_projects.copy()
 

--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -215,6 +215,7 @@ class Project(_ProjectBase):
         self._compile(changed, self._compiler_config, False)
         self._compile_interfaces(interface_hashes)
         self._create_containers()
+        self._clear_dev_deployments()
         self._load_deployments()
 
         # add project to namespaces, apply import blackmagic
@@ -300,29 +301,100 @@ class Project(_ProjectBase):
             self._build._add(abi)
 
     def _load_deployments(self) -> None:
-        if CONFIG.network_type != "live":
+        if CONFIG.network_type != "live" and not CONFIG.settings.get("dev_deployment_artifacts"):
             return
-        chainid = CONFIG.active_network["chainid"]
+        chainid = "dev" if CONFIG.network_type != "live" else CONFIG.active_network["chainid"]
         path = self._path.joinpath(f"build/deployments/{chainid}")
         path.mkdir(exist_ok=True)
         deployments = list(path.glob("*.json"))
         deployments.sort(key=lambda k: k.stat().st_mtime)
+        deployment_map: Dict = {}
         for build_json in deployments:
             with build_json.open() as fp:
                 build = json.load(fp)
-            if build["contractName"] not in self._containers:
-                build_json.unlink()
-                continue
-            if "pcMap" in build:
-                contract = ProjectContract(self, build, build_json.stem)
+
+            contract_name = build["contractName"]
+            if CONFIG.network_type == "live":
+                if contract_name not in self._containers:
+                    build_json.unlink()
+                    continue
+                if "pcMap" in build:
+                    contract = ProjectContract(self, build, build_json.stem)
+                else:
+                    contract = Contract(  # type: ignore
+                        contract_name, build_json.stem, build["abi"]
+                    )
+                    contract._project = self
+                container = self._containers[contract_name]
+                _add_contract(contract)
+                container._contracts.append(contract)
+
+            contract_address = build_json.stem
+            if chainid in deployment_map:
+                if contract_name in deployment_map[chainid] and isinstance(
+                    deployment_map[chainid][contract_name], list
+                ):
+                    deployment_map[chainid][contract_name].insert(0, contract_address)
+                else:
+                    deployment_map[chainid][contract_name] = [contract_address]
             else:
-                contract = Contract(  # type: ignore
-                    build["contractName"], build_json.stem, build["abi"]
-                )
-                contract._project = self
-            container = self._containers[build["contractName"]]
-            _add_contract(contract)
-            container._contracts.append(contract)
+                deployment_map[chainid] = {contract_name: [contract_address]}
+        with self._path.joinpath("build/deployments/map.json").open("w") as fp:
+            json.dump(deployment_map, fp, sort_keys=True, indent=2, default=sorted)
+
+    def _clear_dev_deployments(self) -> None:
+        path = self._path.joinpath(f"build/deployments/dev")
+        if path.exists():
+            deployments = list(path.glob("*.json"))
+            for deployment in deployments:
+                deployment.unlink()
+
+    def _load_deployment_map(self) -> Dict:
+        deployment_map: Dict = {}
+        map_path = self._path.joinpath("build/deployments/map.json")
+        if map_path.exists():
+            with map_path.open("r") as fp:
+                deployment_map = json.load(fp)
+        return deployment_map
+
+    def _save_deployment_map(self, deployment_map: Dict) -> None:
+        with self._path.joinpath("build/deployments/map.json").open("w") as fp:
+            json.dump(deployment_map, fp, sort_keys=True, indent=2, default=sorted)
+
+    def _remove_from_deployment_map(self, contract: ProjectContract) -> None:
+        if CONFIG.network_type != "live" and not CONFIG.settings.get("dev_deployment_artifacts"):
+            return
+
+        chainid = CONFIG.active_network["chainid"] if CONFIG.network_type == "live" else "dev"
+        deployment_map = self._load_deployment_map()
+
+        try:
+            deployment_map[chainid][contract._name].remove(contract.address)
+        except (KeyError, ValueError):
+            pass
+
+        self._save_deployment_map(deployment_map)
+
+    def _add_to_deployment_map(self, contract: ProjectContract) -> None:
+        if CONFIG.network_type != "live" and not CONFIG.settings.get("dev_deployment_artifacts"):
+            return
+
+        chainid = CONFIG.active_network["chainid"] if CONFIG.network_type == "live" else "dev"
+        deployment_map = self._load_deployment_map()
+
+        if chainid in deployment_map:
+            if contract._name in deployment_map[chainid] and isinstance(
+                deployment_map[chainid][contract._name], list
+            ):
+                if contract.address in deployment_map[chainid][contract._name]:
+                    deployment_map[chainid][contract._name].remove(contract.address)
+                deployment_map[chainid][contract._name].insert(0, contract.address)
+            else:
+                deployment_map[chainid][contract._name] = [contract.address]
+        else:
+            deployment_map[chainid] = {contract._name: [contract.address]}
+
+        self._save_deployment_map(deployment_map)
 
     def _update_and_register(self, dict_: Any) -> None:
         dict_.update(self)

--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -215,7 +215,6 @@ class Project(_ProjectBase):
         self._compile(changed, self._compiler_config, False)
         self._compile_interfaces(interface_hashes)
         self._create_containers()
-        self._clear_dev_deployments()
         self._load_deployments()
 
         # add project to namespaces, apply import blackmagic

--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -39,6 +39,7 @@ from brownie.network.contract import (
     InterfaceContainer,
     ProjectContract,
 )
+from brownie.network.rpc import _revert_register
 from brownie.network.state import _add_contract, _remove_contract
 from brownie.project import compiler, ethpm
 from brownie.project.build import BUILD_KEYS, INTERFACE_KEYS, Build
@@ -228,6 +229,10 @@ class Project(_ProjectBase):
             sys.modules["__main__"].__dict__,
             sys.modules["brownie.project"].__dict__,
         ]
+
+        # register project for revert and reset
+        _revert_register(self)
+
         self._active = True
         _loaded_projects.append(self)
 
@@ -340,29 +345,28 @@ class Project(_ProjectBase):
         with self._path.joinpath("build/deployments/map.json").open("w") as fp:
             json.dump(deployment_map, fp, sort_keys=True, indent=2, default=sorted)
 
-    def _clear_dev_deployments(self, after_block: int = 0) -> None:
+    def _clear_dev_deployments(self, height: int = 0) -> None:
         path = self._path.joinpath(f"build/deployments/dev")
         if path.exists():
-            deployments = list(path.glob("*.json"))
             deployment_map = self._load_deployment_map()
-            for deployment in deployments:
-                if after_block == 0:
+            for deployment in list(path.glob("*.json")):
+                if height == 0:
                     deployment.unlink()
-                    if "dev" in deployment_map:
-                        del deployment_map["dev"]
-                    self._save_deployment_map(deployment_map)
                 else:
                     with deployment.open("r") as fp:
                         deployment_artifact = json.load(fp)
                         block_height = deployment_artifact["deployment"]["blockHeight"]
                         address = deployment_artifact["deployment"]["address"]
                         contract_name = deployment_artifact["contractName"]
-                    if block_height > after_block:
+                    if block_height > height:
                         deployment.unlink()
                         try:
                             deployment_map["dev"][contract_name].remove(address)
                         except (KeyError, ValueError):
                             pass
+            if height == 0 and "dev" in deployment_map:
+                del deployment_map["dev"]
+            self._save_deployment_map(deployment_map)
 
     def _load_deployment_map(self) -> Dict:
         deployment_map: Dict = {}
@@ -480,6 +484,12 @@ class Project(_ProjectBase):
             sys.path.remove(str(self._path))
         except ValueError:
             pass
+
+    def _revert(self, height: int) -> None:
+        self._clear_dev_deployments(height)
+
+    def _reset(self) -> None:
+        self._clear_dev_deployments()
 
 
 class TempProject(_ProjectBase):


### PR DESCRIPTION
### What I did

* Add a setting to save deployment artifacts in development networks
* Add a deployment map that keeps track of deployed contracts, sorted by time

closes #576

### How I did it
Save deployment artifacts for development networks at build/deployments/dev/
Maintain a deployment map (of all deployments) at build/depoyments/map.json in the form of
```
{
  "chainid": { 
    "contractName": [
      "contract address 1", 
      "contract address 2"
    ]
  }
```

### How to verify it
Deploy a contract and check `build/deployments`

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
