### PR TITLE
Configurable project structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/iamdefinitelyahuman/brownie)
+### Added
+- Project folder structure is now configurable ([#581](https://github.com/eth-brownie/brownie/pull/581))
+
 ### Changed
 - `tx.call_trace()` now displays internal and total gas usage ([#564](https://github.com/iamdefinitelyahuman/brownie/pull/564))
 

--- a/brownie/_cli/analyze.py
+++ b/brownie/_cli/analyze.py
@@ -5,7 +5,6 @@ import json
 import re
 import time
 from os import environ
-from pathlib import Path
 from typing import Dict
 
 from mythx_models.request import AnalysisSubmissionRequest
@@ -15,7 +14,7 @@ from pythx.middleware import ClientToolNameMiddleware, GroupDataMiddleware
 
 from brownie import project
 from brownie._cli.__main__ import __version__
-from brownie._config import CONFIG, _update_argv_from_docopt
+from brownie._config import CONFIG, _load_project_structure_config, _update_argv_from_docopt
 from brownie.exceptions import ProjectNotFound
 from brownie.utils import color, notify
 from brownie.utils.docopt import docopt
@@ -341,7 +340,9 @@ def main():
     submission.generate_highlighting_report()
 
     # erase previous report
-    report_path = Path("reports/security.json")
+    report_path = project_path.joinpath(_load_project_structure_config(project_path)["reports"])
+
+    report_path = report_path.joinpath("security.json")
     if report_path.exists():
         report_path.unlink()
 

--- a/brownie/_cli/compile.py
+++ b/brownie/_cli/compile.py
@@ -3,6 +3,7 @@
 import shutil
 
 from brownie import project
+from brownie._config import _load_project_structure_config
 from brownie.exceptions import ProjectNotFound
 from brownie.utils.docopt import docopt
 
@@ -24,10 +25,14 @@ def main():
     project_path = project.check_for_project(".")
     if project_path is None:
         raise ProjectNotFound
-    contract_artifact_path = project_path.joinpath("build/contracts")
-    interface_artifact_path = project_path.joinpath("build/interfaces")
+
+    build_path = project_path.joinpath(_load_project_structure_config(project_path)["build"])
+
+    contract_artifact_path = build_path.joinpath("contracts")
+    interface_artifact_path = build_path.joinpath("interfaces")
     if args["--all"]:
         shutil.rmtree(contract_artifact_path, ignore_errors=True)
         shutil.rmtree(interface_artifact_path, ignore_errors=True)
+
     project.load()
     print(f"Project has been compiled. Build artifacts saved at {contract_artifact_path}")

--- a/brownie/_cli/test.py
+++ b/brownie/_cli/test.py
@@ -3,7 +3,7 @@
 import pytest
 
 from brownie import project
-from brownie._config import CONFIG
+from brownie._config import CONFIG, _load_project_structure_config
 from brownie.exceptions import ProjectNotFound
 from brownie.utils.docopt import docopt
 
@@ -48,7 +48,8 @@ def main():
     project.main._add_to_sys_path(project_path)
 
     if args["<path>"] is None:
-        args["<path>"] = project_path.joinpath("tests").as_posix()
+        structure_config = _load_project_structure_config(project_path)
+        args["<path>"] = project_path.joinpath(structure_config["tests"]).as_posix()
 
     pytest_args = [args["<path>"]]
     for opt, value in [(i, args[i]) for i in sorted(args) if i.startswith("-") and args[i]]:

--- a/brownie/_config.py
+++ b/brownie/_config.py
@@ -223,7 +223,7 @@ def _load_project_structure_config(project_path):
     if path is None:
         return structure
 
-    data = _load_config(project_path).get("project_structure")
+    data = _load_config(project_path).get("project_structure", {})
     structure.update(data)
     return structure
 

--- a/brownie/_config.py
+++ b/brownie/_config.py
@@ -216,6 +216,18 @@ def _load_project_compiler_config(project_path: Optional[Path]) -> Dict:
     return compiler_data
 
 
+def _load_project_structure_config(project_path):
+    structure = CONFIG.settings["project_structure"]._copy()
+
+    path = _get_project_config_path(project_path)
+    if path is None:
+        return structure
+
+    data = _load_config(project_path).get("project_structure")
+    structure.update(data)
+    return structure
+
+
 def _load_project_dependencies(project_path: Path) -> List:
     data = _load_config(project_path.joinpath("brownie-config"))
     dependencies = data.get("dependencies", []) or []

--- a/brownie/_gui/source.py
+++ b/brownie/_gui/source.py
@@ -22,7 +22,9 @@ class SourceNoteBook(ttk.Notebook):
         self.bind_count = 0
         self.root.bind("<Left>", self.key_left)
         self.root.bind("<Right>", self.key_right)
-        base_path = self.root.active_project._path.joinpath("contracts")
+        base_path = self.root.active_project._path.joinpath(
+            self.root.active_project._structure["contracts"]
+        )
         for path in base_path.glob("**/*"):
             if path.suffix in (".sol", ".vy"):
                 self.add(path)

--- a/brownie/data/default-config.yaml
+++ b/brownie/data/default-config.yaml
@@ -5,6 +5,14 @@
 # a project. Missing or malformed fields in this file could break Brownie.
 # https://eth-brownie.readthedocs.io/en/stable/config.html
 
+project_structure:
+    build: build
+    contracts: contracts
+    interfaces: interfaces
+    reports: reports
+    scripts: scripts
+    tests: tests
+
 networks:
     default: development
     development:

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -389,7 +389,7 @@ class _DeployedContractBase(_ContractBase):
         if CONFIG.network_type != "live" or not self._project._path:
             return None
         chainid = CONFIG.active_network["chainid"]
-        path = self._project._path.joinpath(f"build/deployments/{chainid}")
+        path = self._project._build_path.joinpath(f"deployments/{chainid}")
         path.mkdir(exist_ok=True)
         return path.joinpath(f"{self.address}.json")
 

--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -47,17 +47,6 @@ from brownie.project.ethpm import get_deployment_addresses, get_manifest
 from brownie.project.sources import Sources, get_pragma_spec
 
 BUILD_FOLDERS = ["contracts", "deployments", "interfaces"]
-FOLDERS = [
-    "contracts",
-    "interfaces",
-    "scripts",
-    "tests",
-    "reports",
-    "build",
-    "build/contracts",
-    "build/deployments",
-    "build/interfaces",
-]
 MIXES_URL = "https://github.com/brownie-mix/{}-mix/archive/master.zip"
 
 GITIGNORE = """__pycache__
@@ -427,20 +416,14 @@ def check_for_project(path: Union[Path, str] = ".") -> Optional[Path]:
     for folder in [path] + list(path.parents):
 
         structure_config = _load_project_structure_config(folder)
-        contracts_path = structure_config["contracts"]
-        tests_path = structure_config["tests"]
+        contracts_path = folder.joinpath(structure_config["contracts"])
+        tests_path = folder.joinpath(structure_config["tests"])
 
-        if next(
-            (
-                i
-                for i in folder.joinpath(contracts_path).glob("**/*")
-                if i.suffix in (".vy", ".sol")
-            ),
-            None,
-        ):
+        if next((i for i in contracts_path.glob("**/*") if i.suffix in (".vy", ".sol")), None):
             return folder
-        if folder.joinpath(tests_path).is_dir() and folder.joinpath(tests_path).is_dir():
+        if contracts_path.is_dir() and tests_path.is_dir():
             return folder
+
     return None
 
 

--- a/brownie/project/scripts.py
+++ b/brownie/project/scripts.py
@@ -67,12 +67,10 @@ def _get_path(path_str: str) -> Tuple[Path, Project]:
     path = Path(path_str).with_suffix(".py")
 
     if not path.is_absolute():
-        if path.parts[0] != "scripts":
-            path = Path("scripts").joinpath(path)
         for project in get_loaded_projects():
-            if project._path.joinpath(path).exists():
-                path = project._path.joinpath(path)
-                return path, project
+            script_path = project._path.joinpath(project._structure["scripts"]).joinpath(path)
+            if script_path.exists():
+                return script_path, project
         raise FileNotFoundError(f"Cannot find {path_str}")
 
     if not path.exists():

--- a/brownie/test/managers/base.py
+++ b/brownie/test/managers/base.py
@@ -37,10 +37,10 @@ class PytestBrownieBase:
             (k, v["bytecodeSha1"]) for k, v in project._build.items() if v.get("bytecode")
         )
 
-        glob = self.project_path.glob("tests/**/conftest.py")
+        glob = self.project_path.joinpath(self.project._structure["tests"]).glob("**/conftest.py")
         self.conf_hashes = dict((self._path(i.parent), _get_ast_hash(i)) for i in glob)
         try:
-            with self.project_path.joinpath("build/tests.json").open() as fp:
+            with self.project._build_path.joinpath("tests.json").open() as fp:
                 hashes = json.load(fp)
         except (FileNotFoundError, json.decoder.JSONDecodeError):
             hashes = {"tests": {}, "contracts": {}, "tx": {}}
@@ -171,7 +171,9 @@ class PytestBrownieBase:
         if CONFIG.argv["coverage"]:
             output._print_coverage_totals(self.project._build, coverage_eval)
             output._save_coverage_report(
-                self.project._build, coverage_eval, self.project_path.joinpath("reports")
+                self.project._build,
+                coverage_eval,
+                self.project_path.joinpath(self.project._structure["reports"]),
             )
 
     def pytest_keyboard_interrupt(self):

--- a/brownie/test/managers/master.py
+++ b/brownie/test/managers/master.py
@@ -60,15 +60,17 @@ class PytestBrownieMaster(PytestBrownieBase):
                 "isolated with the module_isolation or fn_isolation fixtures.\n\n"
                 "https://eth-brownie.readthedocs.io/en/stable/tests.html#isolating-tests"
             )
+        build_path = self.project._build_path
+
         report = {"tests": {}, "contracts": self.contracts, "tx": {}}
-        for path in list(self.project_path.glob("build/tests-*.json")):
+        for path in list(build_path.glob("tests-*.json")):
             with path.open() as fp:
                 data = json.load(fp)
             assert data["contracts"] == report["contracts"]
             report["tests"].update(data["tests"])
             report["tx"].update(data["tx"])
             path.unlink()
-        with self.project_path.joinpath("build/tests.json").open("w") as fp:
+        with build_path.joinpath("tests.json").open("w") as fp:
             json.dump(report, fp, indent=2, sort_keys=True, default=sorted)
         coverage_eval = coverage.get_merged_coverage_eval(report["tx"])
         self._sessionfinish_coverage(coverage_eval)

--- a/brownie/test/managers/runner.py
+++ b/brownie/test/managers/runner.py
@@ -383,7 +383,7 @@ class PytestBrownieRunner(PytestBrownieBase):
         * Generates coverage report and outputs results to console
         * Closes all active projects
         """
-        self._sessionfinish("build/tests.json")
+        self._sessionfinish("tests.json")
         if CONFIG.argv["gas"]:
             output._print_gas_profile()
 
@@ -392,7 +392,7 @@ class PytestBrownieRunner(PytestBrownieBase):
         coverage_eval = dict((k, v) for k, v in coverage.get_coverage_eval().items() if k in txhash)
         report = {"tests": self.tests, "contracts": self.contracts, "tx": coverage_eval}
 
-        with self.project_path.joinpath(path).open("w") as fp:
+        with self.project._build_path.joinpath(path).open("w") as fp:
             json.dump(report, fp, indent=2, sort_keys=True, default=sorted)
         coverage_eval = coverage.get_merged_coverage_eval()
         self._sessionfinish_coverage(coverage_eval)
@@ -445,4 +445,4 @@ class PytestBrownieXdistRunner(PytestBrownieRunner):
         is then aggregated in `PytestBrownieMaster.pytest_sessionfinish`.
         """
         self.tests = dict((k, v) for k, v in self.tests.items() if k in self.results)
-        self._sessionfinish(f"build/tests-{self.workerid}.json")
+        self._sessionfinish(f"tests-{self.workerid}.json")

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -23,6 +23,49 @@ The following example shows all configuration settings and their default values:
 Settings
 ========
 
+Project Structure
+-----------------
+
+.. _config-project-structure:
+
+Project subdirectory names. Include these fields if you wish to modify the default structure of your project.
+
+.. py:attribute:: project_structure.build
+
+    Project subdirectory that stores data such as compiler artifacts and unit test results.
+
+    default value: ``build``
+
+.. py:attribute:: project_structure.contracts
+
+    Project subdirectory that stores contract source files.
+
+    default value: ``contracts``
+
+.. py:attribute:: project_structure.interfaces
+
+    Project subdirectory that stores interface source files and ABIs.
+
+    default value: ``interfaces``
+
+.. py:attribute:: project_structure.reports
+
+    Project subdirectory that stores JSON report files.
+
+    default value: ``reports``
+
+.. py:attribute:: project_structure.scripts
+
+    Project subdirectory that stores scripts for deployment and interaction.
+
+    default value: ``scripts``
+
+.. py:attribute:: project_structure.tests
+
+    Project subdirectory that stores unit tests.
+
+    default value: ``tests``
+
 Networks
 --------
 

--- a/docs/structure.rst
+++ b/docs/structure.rst
@@ -18,6 +18,8 @@ The following folders are also created, and used internally by Brownie for manag
 
 See :ref:`build-folder` for more information about Brownie internal project folders.
 
+If you require a different organization for your project, you can adjust the subdirectory names within the project :ref:`configuration file <config-project-structure>`.
+
 ``contracts/``
 ==============
 

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -8,7 +8,7 @@ from brownie._cli import __main__ as cli_main
 
 
 @pytest.fixture
-def cli_tester(monkeypatch, mocker, argv, config):
+def cli_tester(monkeypatch, mocker, argv, config, project):
     tester = CliTester(monkeypatch, mocker)
     tester.mocker.spy(tester, "mock_subroutines")
 

--- a/tests/project/test_project_structure.py
+++ b/tests/project/test_project_structure.py
@@ -1,0 +1,54 @@
+#!/usr/bin/python3
+
+from pathlib import Path
+
+import yaml
+
+structure = {
+    "project_structure": {
+        "build": "artifacts",
+        "contracts": "sources",
+        "interfaces": "abi",
+        "reports": "logs",
+        "scripts": "automation",
+        "tests": "checks",
+    }
+}
+
+
+def test_different_folders(project, tmp_path):
+
+    with tmp_path.joinpath("brownie-config.yaml").open("w") as fp:
+        yaml.dump(structure, fp)
+
+    project.main._create_folders(Path(tmp_path))
+    for path in ("contracts", "interfaces", "scripts", "reports", "tests", "build"):
+        assert not Path(tmp_path).joinpath(path).exists()
+
+    for path in ("artifacts", "sources", "abi", "logs", "automation", "checks"):
+        assert Path(tmp_path).joinpath(path).exists()
+
+
+def test_compiles(project, tmp_path):
+    with tmp_path.joinpath("brownie-config.yaml").open("w") as fp:
+        yaml.dump(structure, fp)
+
+    tmp_path.joinpath("sources").mkdir()
+    with tmp_path.joinpath("sources/Foo.vy").open("w") as fp:
+        fp.write(
+            """
+@public
+def foo() -> int128:
+    return 2
+"""
+        )
+
+    tmp_path.joinpath("abi").mkdir()
+    with tmp_path.joinpath("abi/Bar.json").open("w") as fp:
+        fp.write("[]")
+
+    proj = project.load(tmp_path)
+
+    assert "Foo" in proj._containers
+    assert proj._path.joinpath("artifacts/contracts/Foo.json").exists()
+    assert hasattr(proj.interface, "Bar")

--- a/tests/project/test_scripts.py
+++ b/tests/project/test_scripts.py
@@ -22,7 +22,6 @@ def test_kwargs(testproject):
 
 def test_paths(testproject, devnetwork):
     run("token")
-    run("scripts/token")
     run("token.py")
     run(testproject._path.joinpath("scripts/token").as_posix())
 


### PR DESCRIPTION
### What I did
Add config settings to modify the directory structure of a project.

Closes #578

### How I did it
* Add a config section `project_structure` which defines the expected directories.
* In `_config`, add a function `_load_project_structure_config` that checks a folder for a config file, and if yes returns the custom structure. If none is found it returns the default values.  This is necessary because we check for the existence of a brownie project based on the directory structure - so the settings must be loaded _prior_ to actually loading the project, in order to see that there is a project to load.
* Modified references to absolute directory names with references to the config settings throughout the code base.

### How to verify it
Run the tests. I added a couple of cases to confirm the basic functionality and have been using it locally to see that it works.  This is difficult to test extensively without simply parametrizing the whole test suite :unamused: 

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [x] I have updated the documentation
- [x] I have added an entry to the changelog
