### PR TITLE
feat: warn when project being loaded is not in cwd

### DIFF
--- a/brownie/_cli/compile.py
+++ b/brownie/_cli/compile.py
@@ -29,5 +29,5 @@ def main():
     if args["--all"]:
         shutil.rmtree(contract_artifact_path, ignore_errors=True)
         shutil.rmtree(interface_artifact_path, ignore_errors=True)
-    project.load(project_path)
+    project.load()
     print(f"Project has been compiled. Build artifacts saved at {contract_artifact_path}")

--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -4,6 +4,7 @@ import json
 import os
 import shutil
 import sys
+import warnings
 import zipfile
 from base64 import b64encode
 from hashlib import sha1
@@ -23,7 +24,12 @@ from brownie._config import (
     _load_project_config,
     _load_project_dependencies,
 )
-from brownie.exceptions import InvalidPackage, ProjectAlreadyLoaded, ProjectNotFound
+from brownie.exceptions import (
+    BrownieEnvironmentWarning,
+    InvalidPackage,
+    ProjectAlreadyLoaded,
+    ProjectNotFound,
+)
 from brownie.network import web3
 from brownie.network.contract import (
     Contract,
@@ -524,6 +530,13 @@ def load(project_path: Union[Path, str, None] = None, name: Optional[str] = None
     # checks
     if project_path is None:
         project_path = check_for_project(".")
+        if project_path is not None and project_path != Path(".").absolute():
+            warnings.warn(
+                f"Loaded project has a root folder of '{project_path}' "
+                "which is different from the current working directory",
+                BrownieEnvironmentWarning,
+            )
+
     elif Path(project_path).resolve() != check_for_project(project_path):
         project_path = None
     if project_path is None:

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -74,9 +74,7 @@ def test_cli_bake(cli_tester):
 def test_cli_compile(cli_tester, testproject):
     cli_tester.monkeypatch.setattr("brownie.project.load", cli_tester.mock_subroutines)
 
-    args = (testproject._path,)
-    kwargs = {}
-    parameters = (args, kwargs)
+    parameters = ((), {})
     cli_tester.run_and_test_parameters("compile", parameters)
     cli_tester.run_and_test_parameters("compile --all", parameters)
 


### PR DESCRIPTION
### What I did
Raise `BrownieEnvironmentWarning` when loading a project from outside the current working directory.

Closes #566

### How I did it
* The warning is only raised if `project.load` is not called with an explicit directory.
* Made sure that all cli loading happens without a directory given (only had to modify compile)

### How to verify it
I didn't add any new tests - this is a pretty minor PR and it can't really break anything.
