### PR TITLE
Support for seed phrases

### DIFF
--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -98,8 +98,8 @@ class Accounts(metaclass=_Singleton):
 
         Arguments
         ---------
-        priv_key : int | bytes | str, optional
-        Private key of the account. If none is given, one is randomly generated.
+        private_key : int | bytes | str, optional
+            Private key of the account. If none is given, one is randomly generated.
 
         Returns
         -------
@@ -151,14 +151,18 @@ class Accounts(metaclass=_Singleton):
         return new_accounts
 
     def load(self, filename: str = None) -> Union[List, "LocalAccount"]:
-        """Loads a local account from a keystore file.
+        """
+        Load a local account from a keystore file.
 
-        Args:
-            filename: Keystore filename. If none is given, returns a list of
-                      available keystores.
+        Arguments
+        ---------
+        filename: str
+            Keystore filename. If `None`, returns a list of available keystores.
 
-        Returns:
-            Account instance."""
+        Returns
+        -------
+        LocalAccount
+        """
         base_accounts_path = _get_data_folder().joinpath("accounts")
         if not filename:
             return [i.stem for i in base_accounts_path.glob("*.json")]
@@ -185,14 +189,19 @@ class Accounts(metaclass=_Singleton):
         return self.add(priv_key)
 
     def at(self, address: str) -> "LocalAccount":
-        """Retrieves an Account instance from the address string. Raises
-        ValueError if the account cannot be found.
+        """
+        Retrieve an `Account` instance from the address string.
 
-        Args:
-            address: string of the account address.
+        Raises `ValueError` if the account cannot be found.
 
-        Returns:
-            Account instance.
+        Arguments
+        ---------
+        address: string
+            Address of the account
+
+        Returns
+        -------
+        Account
         """
         address = _resolve_address(address)
         acct = next((i for i in self._accounts if i == address), None)
@@ -205,19 +214,25 @@ class Accounts(metaclass=_Singleton):
             return acct
         raise UnknownAccount(f"No account exists for {address}")
 
-    def remove(self, address: str) -> None:
-        """Removes an account instance from the container.
+    def remove(self, address: Union[str, "Account"]) -> None:
+        """
+        Remove an `Account` instance from the container.
 
-        Args:
-            address: Account instance or address string of account to remove."""
-        address = _resolve_address(address)
+        Arguments
+        ---------
+        address: str | Account
+            Account instance, or string of the account address.
+        """
+        address = _resolve_address(str(address))
         try:
             self._accounts.remove(address)
         except ValueError:
             raise UnknownAccount(f"No account exists for {address}")
 
     def clear(self) -> None:
-        """Empties the container."""
+        """
+        Empty the container.
+        """
         self._accounts.clear()
 
 

--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -491,6 +491,8 @@ class LocalAccount(_PrivateKeyAccount):
 
     def __init__(self, address: str, account: Account, priv_key: Union[int, bytes, str]) -> None:
         self._acct = account
+        if not isinstance(priv_key, str):
+            priv_key = HexBytes(priv_key).hex()
         self.private_key = priv_key
         self.public_key = eth_keys.keys.PrivateKey(HexBytes(priv_key)).public_key
         super().__init__(address)

--- a/brownie/network/rpc.py
+++ b/brownie/network/rpc.py
@@ -89,25 +89,26 @@ class Rpc(metaclass=_Singleton):
                 cmd = cmd.replace(" ", ".cmd ", 1)
             else:
                 cmd += ".cmd"
+        cmd_list = cmd.split(" ")
         kwargs.setdefault("evm_version", EVM_DEFAULT)  # type: ignore
         if kwargs["evm_version"] in EVM_EQUIVALENTS:
             kwargs["evm_version"] = EVM_EQUIVALENTS[kwargs["evm_version"]]  # type: ignore
         kwargs = _validate_cmd_settings(kwargs)
         for key, value in [(k, v) for k, v in kwargs.items() if v]:
             try:
-                cmd += f" {CLI_FLAGS[key]} {value}"
+                cmd_list.extend([CLI_FLAGS[key], str(value)])
             except KeyError:
                 warnings.warn(
                     f"Ignoring invalid commandline setting for ganache-cli: "
                     f'"{key}" with value "{value}".',
                     InvalidArgumentWarning,
                 )
-        print(f"Launching '{cmd}'...")
+        print(f"Launching '{' '.join(cmd_list)}'...")
         self._time_offset = 0
         self._snapshot_id = False
         self._reset_id = False
         out = DEVNULL if sys.platform == "win32" else PIPE
-        self._rpc = psutil.Popen(cmd.split(" "), stdin=DEVNULL, stdout=out, stderr=out)
+        self._rpc = psutil.Popen(cmd_list, stdin=DEVNULL, stdout=out, stderr=out)
         # check that web3 can connect
         if not web3.provider:
             _notify_registry(0)

--- a/docs/api-network.rst
+++ b/docs/api-network.rst
@@ -136,16 +136,22 @@ Accounts Attributes
 Accounts Methods
 ****************
 
-.. py:classmethod:: Accounts.add(priv_key=None)
+.. py:classmethod:: Accounts.add(private_key=None)
 
-    Creates a new :func:`LocalAccount <brownie.network.account.LocalAccount>` with private key ``priv_key``, appends it to the container, and returns the new account instance.  If no private key is entered, one is randomly generated via ``os.urandom(8192)``.
+    Creates a new :func:`LocalAccount <brownie.network.account.LocalAccount>` with private key ``private_key``, appends it to the container, and returns the new account instance.
+
+    .. code-block:: python
+
+        >>> accounts.add('8fa2fdfb89003176a16b707fc860d0881da0d1d8248af210df12d37860996fb2')
+        <Account object '0xc1826925377b4103cC92DeeCDF6F96A03142F37a'>
+
+    When no private key is given a new one is randomly generated. A seed phrase for the account is also printed to the console.
 
     .. code-block:: python
 
         >>> accounts.add()
-        <Account object '0xb094716BC0E9D3F3Fb42FF928bd76618435FeeAA'>
-        >>> accounts.add('8fa2fdfb89003176a16b707fc860d0881da0d1d8248af210df12d37860996fb2')
-        <Account object '0xc1826925377b4103cC92DeeCDF6F96A03142F37a'>
+        mnemonic: 'buffalo cinnamon glory chalk require inform strike ginger crop sell hidden cart'
+        <LocalAccount '0xf293C5E0b22802Bf5DCef3FB8112EaA4cA54fcCF'>
 
 .. py:classmethod:: Accounts.at(address)
 
@@ -163,6 +169,22 @@ Accounts Methods
     .. code-block:: python
 
         >>> accounts.clear()
+
+.. py:classmethod:: Accounts.from_mnemonic(mnemonic, count=1, offset=0)
+
+    Generates one or more :func:`LocalAccount <brownie.network.account.LocalAccount>` objects from a seed phrase.
+
+    * ``mnemonic`` : Space-separated list of BIP39 mnemonic seed words
+    * ``count`` : The number of `LocalAccount` objects to create
+    * ``offset`` : The initial account index to create accounts from
+
+    If ``count`` is greater than 1, a list of :func:`LocalAccount <brownie.network.account.LocalAccount>` objects are returned.
+
+    .. code-block:: python
+
+        >>> a.from_mnemonic('buffalo cinnamon glory chalk require inform strike ginger crop sell hidden cart')
+        <LocalAccount '0xf293C5E0b22802Bf5DCef3FB8112EaA4cA54fcCF'>
+
 
 .. py:classmethod:: Accounts.load(filename=None)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 colorama>=0.4.1;platform_system=='Windows'
 eth-abi==2.1.1
+eth-account==0.5.2
 eth-event>=1.1.0,<2.0.0
 eth-hash[pycryptodome]==0.2.0
 eth-utils==1.9.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ force_grid_wrap = 0
 include_trailing_comma = True
 known_standard_library = tkinter
 known_first_party = brownie
-known_third_party = _pytest,ens,eth_abi,eth_event,eth_hash,eth_keys,eth_utils,ethpm,hexbytes,hypothesis,mythx_models,prompt_toolkit,psutil,py,pygments,pytest,pythx,requests,semantic_version,setuptools,solcast,solcx,tqdm,vyper,web3,xdist,yaml
+known_third_party = _pytest,ens,eth_abi,eth_account,eth_event,eth_hash,eth_keys,eth_utils,ethpm,hexbytes,hypothesis,mythx_models,prompt_toolkit,psutil,py,pygments,pytest,pythx,requests,semantic_version,setuptools,solcast,solcx,tqdm,vyper,web3,xdist,yaml
 line_length = 100
 multi_line_output = 3
 use_parentheses = True
@@ -28,7 +28,7 @@ follow_imports = silent
 follow_imports = skip
 
 [tool:pytest]
-addopts = 
+addopts =
 	-p no:pytest-brownie
 	--cov brownie/
 	--cov-report term

--- a/tests/network/account/test_accounts.py
+++ b/tests/network/account/test_accounts.py
@@ -93,3 +93,41 @@ def test_default_cleared_on_disconnect(accounts, network):
     accounts.default = accounts[0]
     network.disconnect()
     assert accounts.default is None
+
+
+def test_from_mnemonic(accounts):
+    acct = accounts.from_mnemonic(
+        "street dutch license offer where music rice correct stomach there right surprise"
+    )
+
+    assert isinstance(acct, LocalAccount)
+    assert acct.address == "0x64483769Cd246aa69956B18bfd49F20426FdE2A6"
+
+
+def test_mnemonic_multiple(accounts):
+    acct = accounts.from_mnemonic(
+        "grant buyer family hybrid recipe motor cube general apart snow monster tunnel", 3
+    )
+    assert [str(i) for i in acct] == [
+        "0x4d44087e86DaEA4db7030F0558D083a75114F56C",
+        "0xD57D53eCEFAA99b9f1d67a8C4D21E46fC16Aa133",
+        "0x0efE90a99343A9AcF48501FAF3505b10822067c6",
+    ]
+
+
+def test_mnemonic_offset(accounts):
+    acct = accounts.from_mnemonic(
+        "retire basic saddle brief bridge path cradle credit angry vendor repair rhythm", offset=5
+    )
+
+    assert acct.address == "0x12ba8F2E54B1B57C54D1CA06c0a0b8d14E9abc62"
+
+
+def test_mnemonic_offset_multiple(accounts):
+    acct = accounts.from_mnemonic(
+        "day axis gallery size rebuild logic steak food palm victory useful kick", 2, 7
+    )
+    assert [str(i) for i in acct] == [
+        "0x44302d4c1e535b4FB77bc390e3053586ecA411b0",
+        "0x1F413d7E7B85E557D9997E6714479C7848A9Ea07",
+    ]

--- a/tests/network/rpc/test_launch.py
+++ b/tests/network/rpc/test_launch.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+import brownie
 from brownie.exceptions import RPCProcessError
 
 
@@ -21,6 +22,16 @@ def test_launch(no_rpc, temp_port):
     no_rpc.launch("ganache-cli", port=temp_port)
     assert no_rpc.is_active()
     assert no_rpc.is_child()
+
+
+def test_launch_with_mnemonic(no_rpc, temp_port):
+    no_rpc.kill(False)
+    no_rpc.launch(
+        "ganache-cli",
+        port=temp_port,
+        mnemonic="patient rude simple dog close planet oval animal hunt sketch suspect slim",
+    )
+    assert brownie.network.accounts[0] == "0x7cB87a59C85a0c6d8E2953ed54f1c9E4C28E25E5"
 
 
 def test_already_active(temp_rpc, temp_port):


### PR DESCRIPTION
### What I did
Add support for seed phrases.

Closes #334 

### How I did it
* Add the `Accounts.from_mnemonic` method, that relies on `eth_account` to do the heavy lifting.
* Display a seed phrase when generating a new account via `Accounts.add`
* Fix a bug preventing proper passing of mnemonics between `network-config.yaml` and `ganache-cli`

I also updated the docstring format in `Accounts` so everything is consistent.

### How to verify it
Run tests.  I added a few new cases.

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [x] I have updated the documentation
- [ ] I have added an entry to the changelog
