### PR TITLE
Setting to save development artifacts and store them in a map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/iamdefinitelyahuman/brownie)
 ### Added
 - Project folder structure is now configurable ([#581](https://github.com/eth-brownie/brownie/pull/581))
+- Deployment artifacts can now be saved via project setting `dev_deployment_artifacts: true` ([#590](https://github.com/eth-brownie/brownie/pull/590))
+- All deployment artifacts are tracked in `deployments/map.json` ([#590](https://github.com/eth-brownie/brownie/pull/590))
 
 ### Changed
 - `tx.call_trace()` now displays internal and total gas usage ([#564](https://github.com/iamdefinitelyahuman/brownie/pull/564))

--- a/brownie/_config.py
+++ b/brownie/_config.py
@@ -44,6 +44,11 @@ class ConfigContainer:
                 raise ValueError(f"Multiple networks using ID '{key}'")
             self.networks[key] = value
 
+        # make sure chainids are always strings
+        for network, values in self.networks.items():
+            if "chainid" in values:
+                self.networks[network]["chainid"] = str(values["chainid"])
+
         self.argv = defaultdict(lambda: None)
         self.settings = _Singleton("settings", (ConfigDict,), {})(base_config)
         self._active_network = None

--- a/brownie/data/default-config.yaml
+++ b/brownie/data/default-config.yaml
@@ -49,3 +49,4 @@ hypothesis:
 
 autofetch_sources: false
 dependencies: null
+dev_deployment_artifacts: false

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -406,16 +406,18 @@ class _DeployedContractBase(_ContractBase):
             "chainid": chainid,
             "blockHeight": web3.eth.blockNumber,
         }
-        if path and not path.exists():
-            with path.open("w") as fp:
-                json.dump(deployment_build, fp)
-        self._project._add_to_deployment_map(self)
+        if path:
+            self._project._add_to_deployment_map(self)
+            if not path.exists():
+                with path.open("w") as fp:
+                    json.dump(deployment_build, fp)
 
     def _delete_deployment(self) -> None:
         path = self._deployment_path()
-        if path and path.exists():
-            path.unlink()
-        self._project._remove_from_deployment_map(self)
+        if path:
+            self._project._remove_from_deployment_map(self)
+            if path.exists():
+                path.unlink()
 
 
 class Contract(_DeployedContractBase):

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -398,9 +398,17 @@ class _DeployedContractBase(_ContractBase):
 
     def _save_deployment(self) -> None:
         path = self._deployment_path()
+        chainid = "dev" if CONFIG.network_type != "live" else CONFIG.active_network["chainid"]
+        deployment_build = self._build.copy()
+
+        deployment_build["deployment"] = {
+            "address": self.address,
+            "chainid": chainid,
+            "blockHeight": web3.eth.blockNumber,
+        }
         if path and not path.exists():
             with path.open("w") as fp:
-                json.dump(self._build, fp)
+                json.dump(deployment_build, fp)
         self._project._add_to_deployment_map(self)
 
     def _delete_deployment(self) -> None:

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -398,7 +398,7 @@ class _DeployedContractBase(_ContractBase):
 
     def _save_deployment(self) -> None:
         path = self._deployment_path()
-        if path and (not path.exists() or CONFIG.network_type != "live"):
+        if path and not path.exists():
             with path.open("w") as fp:
                 json.dump(self._build, fp)
         self._project._add_to_deployment_map(self)

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -387,18 +387,18 @@ class _DeployedContractBase(_ContractBase):
 
     def _deployment_path(self) -> Optional[Path]:
         if not self._project._path or (
-            CONFIG.network_type != "live" and not CONFIG.settings.get("dev_deployment_artifacts")
+            CONFIG.network_type != "live" and not CONFIG.settings["dev_deployment_artifacts"]
         ):
             return None
 
-        chainid = "dev" if CONFIG.network_type != "live" else CONFIG.active_network["chainid"]
+        chainid = CONFIG.active_network["chainid"] if CONFIG.network_type == "live" else "dev"
         path = self._project._build_path.joinpath(f"deployments/{chainid}")
         path.mkdir(exist_ok=True)
         return path.joinpath(f"{self.address}.json")
 
     def _save_deployment(self) -> None:
         path = self._deployment_path()
-        chainid = "dev" if CONFIG.network_type != "live" else CONFIG.active_network["chainid"]
+        chainid = CONFIG.active_network["chainid"] if CONFIG.network_type == "live" else "dev"
         deployment_build = self._build.copy()
 
         deployment_build["deployment"] = {

--- a/brownie/network/main.py
+++ b/brownie/network/main.py
@@ -47,7 +47,7 @@ def connect(network: str = None, launch_rpc: bool = True) -> None:
                 rpc.launch(active["cmd"], **active["cmd_settings"])
         else:
             Accounts()._reset()
-        if CONFIG.network_type == "live":
+        if CONFIG.network_type == "live" or CONFIG.settings["dev_deployment_artifacts"]:
             for p in project.get_loaded_projects():
                 p._load_deployments()
 

--- a/brownie/network/rpc.py
+++ b/brownie/network/rpc.py
@@ -14,6 +14,7 @@ from urllib.parse import urlparse
 
 import psutil
 
+import brownie
 from brownie._config import EVM_EQUIVALENTS
 from brownie._singleton import _Singleton
 from brownie.convert import Wei
@@ -353,6 +354,8 @@ class Rpc(metaclass=_Singleton):
         self._undo_buffer.clear()
         self._redo_buffer.clear()
         self._snapshot_id = self._current_id = self._revert(self._snapshot_id)
+        for project in brownie.project.get_loaded_projects():
+            project._clear_dev_deployments(web3.eth.blockNumber)
         return f"Block height reverted to {web3.eth.blockNumber}"
 
     def reset(self) -> str:
@@ -365,6 +368,8 @@ class Rpc(metaclass=_Singleton):
         self._undo_buffer.clear()
         self._redo_buffer.clear()
         self._reset_id = self._current_id = self._revert(self._reset_id)
+        for project in brownie.project.get_loaded_projects():
+            project._clear_dev_deployments()
         return f"Block height reset to {web3.eth.blockNumber}"
 
 

--- a/brownie/network/rpc.py
+++ b/brownie/network/rpc.py
@@ -14,7 +14,6 @@ from urllib.parse import urlparse
 
 import psutil
 
-import brownie
 from brownie._config import EVM_EQUIVALENTS
 from brownie._singleton import _Singleton
 from brownie.convert import Wei
@@ -354,8 +353,6 @@ class Rpc(metaclass=_Singleton):
         self._undo_buffer.clear()
         self._redo_buffer.clear()
         self._snapshot_id = self._current_id = self._revert(self._snapshot_id)
-        for project in brownie.project.get_loaded_projects():
-            project._clear_dev_deployments(web3.eth.blockNumber)
         return f"Block height reverted to {web3.eth.blockNumber}"
 
     def reset(self) -> str:
@@ -368,8 +365,6 @@ class Rpc(metaclass=_Singleton):
         self._undo_buffer.clear()
         self._redo_buffer.clear()
         self._reset_id = self._current_id = self._revert(self._reset_id)
-        for project in brownie.project.get_loaded_projects():
-            project._clear_dev_deployments()
         return f"Block height reset to {web3.eth.blockNumber}"
 
 

--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -376,9 +376,12 @@ class Project(_ProjectBase):
             return
         chainid = CONFIG.active_network["chainid"] if CONFIG.network_type == "live" else "dev"
         deployment_map = self._load_deployment_map()
-
         try:
             deployment_map[chainid][contract._name].remove(contract.address)
+            if not deployment_map[chainid][contract._name]:
+                del deployment_map[chainid][contract._name]
+            if not deployment_map[chainid]:
+                del deployment_map[chainid]
         except (KeyError, ValueError):
             pass
 

--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -210,7 +210,6 @@ class Project(_ProjectBase):
         self._compile(changed, self._compiler_config, False)
         self._compile_interfaces(interface_hashes)
         self._create_containers()
-        self._clear_dev_deployments()
         self._load_deployments()
 
         # add project to namespaces, apply import blackmagic

--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -338,11 +338,11 @@ class Project(_ProjectBase):
                     deployment_map[chainid][contract_name] = [contract_address]
             else:
                 deployment_map[chainid] = {contract_name: [contract_address]}
-        with self._path.joinpath("build/deployments/map.json").open("w") as fp:
+        with self._build_path.joinpath("deployments/map.json").open("w") as fp:
             json.dump(deployment_map, fp, sort_keys=True, indent=2, default=sorted)
 
     def _clear_dev_deployments(self, height: int = 0) -> None:
-        path = self._path.joinpath(f"build/deployments/dev")
+        path = self._build_path.joinpath(f"deployments/dev")
         if path.exists():
             deployment_map = self._load_deployment_map()
             for deployment in list(path.glob("*.json")):
@@ -366,14 +366,14 @@ class Project(_ProjectBase):
 
     def _load_deployment_map(self) -> Dict:
         deployment_map: Dict = {}
-        map_path = self._path.joinpath("build/deployments/map.json")
+        map_path = self._build_path.joinpath("deployments/map.json")
         if map_path.exists():
             with map_path.open("r") as fp:
                 deployment_map = json.load(fp)
         return deployment_map
 
     def _save_deployment_map(self, deployment_map: Dict) -> None:
-        with self._path.joinpath("build/deployments/map.json").open("w") as fp:
+        with self._build_path.joinpath("deployments/map.json").open("w") as fp:
             json.dump(deployment_map, fp, sort_keys=True, indent=2, default=sorted)
 
     def _remove_from_deployment_map(self, contract: ProjectContract) -> None:

--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -393,19 +393,13 @@ class Project(_ProjectBase):
 
         chainid = CONFIG.active_network["chainid"] if CONFIG.network_type == "live" else "dev"
         deployment_map = self._load_deployment_map()
-
-        if chainid in deployment_map:
-            if contract._name in deployment_map[chainid] and isinstance(
-                deployment_map[chainid][contract._name], list
-            ):
-                if contract.address in deployment_map[chainid][contract._name]:
-                    deployment_map[chainid][contract._name].remove(contract.address)
-                deployment_map[chainid][contract._name].insert(0, contract.address)
-            else:
-                deployment_map[chainid][contract._name] = [contract.address]
-        else:
-            deployment_map[chainid] = {contract._name: [contract.address]}
-
+        try:
+            deployment_map[chainid][contract._name].remove(contract.address)
+        except (ValueError, KeyError):
+            pass
+        deployment_map.setdefault(chainid, {}).setdefault(contract._name, []).insert(
+            0, contract.address
+        )
         self._save_deployment_map(deployment_map)
 
     def _update_and_register(self, dict_: Any) -> None:

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -240,3 +240,13 @@ Other Settings
             - defi.snakecharmers.eth/compound@1.1.0
 
     See the :ref:`Brownie Package Manager<package-manager>` to learn more about package dependencies.
+
+.. _dev_artifacts:
+
+.. py:attribute:: dev_deployment_artifacts
+
+    If enabled, Brownie will save deployment artifacts for contracts deployed on development networks and will include the "dev" network on the deployment map.
+
+    This is useful if another application, such as a front end framework, needs access to deployment artifacts while you are on a development network.
+
+    default value: ``false``

--- a/docs/deploy.rst
+++ b/docs/deploy.rst
@@ -48,6 +48,27 @@ See the documentation on :ref:`network management<network-management>` for more 
 
 .. _persistence:
 
+The Deployment Map
+==================
+
+Brownie will maintain a ``map.json`` file in your ``build/deployment/`` folder that lists all deployed contracts on live networks, sorted by chain and contract name.
+
+::
+
+    {
+      "1": {
+        "SolidityStorage": [
+          "0x73B74F5f1d1f7A00d8c33bFbD09744eD90220D12",
+          "0x189a7fBB0038D4b55Bd03840be0B0a38De034089"
+        ],
+        "VyperStorage": [
+          "0xF104A50668c3b1026E8f9B0d9D404faF8E42e642"
+        ]
+      }
+    }
+
+The list for each contract is sorted by the block number of the deployment with the most recent deployment first.
+
 Interacting with Deployed Contracts
 ===================================
 
@@ -67,3 +88,14 @@ The following actions WILL remove locally stored deployment data within your pro
     * Deleting the ``build/deployments/`` directory will erase all information about deployed contracts.
 
 To restore a deleted :func:`ProjectContract <brownie.network.contract.ProjectContract>` instance, or generate one for a deployment that was handled outside of Brownie, use the :func:`ContractContainer.at <ContractContainer.at>` method.
+
+
+Saving Deployments on Development Networks
+==========================================
+
+If you need deployment artifacts on a development network, set :attr:`dev_deployment_artifacts` to true in the in the project's ``brownie-config.yaml`` file.
+
+These temporary deployment artifacts and the corresponding entries in :ref:`the deployment map<persistence>`  will be removed whenever you (re-) load a project or connect, disconnect, revert or reset your local network.
+
+If you use a development network that is not started by brownie - for example an external instance of ganache - the deployment artifacts will not be deleted when disconnecting from that network.
+However, the network will be reset and the deployment artifacts deleted when you connect to such a network with brownie.

--- a/tests/project/main/test_deployment_map.py
+++ b/tests/project/main/test_deployment_map.py
@@ -1,0 +1,61 @@
+import json
+
+
+def test_dev_deployment_map_content(testproject, BrownieTester, config, accounts):
+    config.settings["dev_deployment_artifacts"] = True
+
+    # deploy and verify deployment of first contract
+    BrownieTester.deploy(True, {"from": accounts[0]})
+    map = testproject._build_path.joinpath("deployments/map.json")
+    assert map.exists()
+
+    with map.open("r") as fp:
+        content = json.load(fp)
+    assert len(content["dev"]["BrownieTester"]) == 1
+
+    artifacts = list(testproject._build_path.joinpath("deployments/dev/").glob("*.json"))
+    assert len(artifacts) == 1
+
+    # deploy and verify deployment of second contract
+    BrownieTester.deploy(True, {"from": accounts[0]})
+    address = BrownieTester[-1].address
+
+    with map.open("r") as fp:
+        content = json.load(fp)
+
+    assert len(content["dev"]["BrownieTester"]) == 2
+    assert content["dev"]["BrownieTester"][0] == address
+
+    artifacts = list(testproject._build_path.joinpath("deployments/dev/").glob("*.json"))
+    assert len(artifacts) == 2
+
+
+def test_dev_deployment_map_clear_on_disconnect(
+    devnetwork, testproject, BrownieTester, config, accounts
+):
+    config.settings["dev_deployment_artifacts"] = True
+
+    BrownieTester.deploy(True, {"from": accounts[0]})
+    map = testproject._build_path.joinpath("deployments/map.json")
+
+    devnetwork.disconnect()
+
+    with map.open("r") as fp:
+        content = json.load(fp)
+
+    assert not content
+
+
+def test_dev_deployment_map_clear_on_remove(testproject, BrownieTester, config, accounts):
+    config.settings["dev_deployment_artifacts"] = True
+
+    BrownieTester.deploy(True, {"from": accounts[0]})
+    BrownieTester.remove(BrownieTester[-1])
+
+    artifacts = list(testproject._build_path.joinpath("deployments/dev/").glob("*.json"))
+    assert len(artifacts) == 0
+
+    map = testproject._build_path.joinpath("deployments/map.json")
+    with map.open("r") as fp:
+        content = json.load(fp)
+    assert not content


### PR DESCRIPTION
### What I did

* Add a setting to save deployment artifacts in development networks
* Add a deployment map that keeps track of deployed contracts, sorted by time

closes #576

### How I did it
Save deployment artifacts for development networks at build/deployments/dev/
Maintain a deployment map (of all deployments) at build/depoyments/map.json in the form of
```
{
  "chainid": { 
    "contractName": [
      "contract address 1", 
      "contract address 2"
    ]
  }
```

### How to verify it
* Deploy a contract and check `build/deployments`
* I wrote tests for this PR

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [x] I have updated the documentation
- [x] I have added an entry to the changelog
