### PR TITLE
Hypothesis fixes

### DIFF
--- a/brownie/_config.py
+++ b/brownie/_config.py
@@ -241,6 +241,7 @@ def _modify_hypothesis_settings(settings, name, parent):
         name,
         parent=hp_settings.get_profile(parent),
         database=DirectoryBasedExampleDatabase(_get_data_folder().joinpath("hypothesis")),
+        report_multiple_bugs=False,
         **settings,
     )
     hp_settings.load_profile(name)


### PR DESCRIPTION
### What I did
* Adjust how snapshotting and reverts are handled when using `@given` property-based testing.
* Disable `report_multiple_bugs` - closes #567 

### How I did it
Previously, a snapshot was taken at the beginning of each test run and reverted to at the end. This caused an issue where if a test failed, the revert didn't occur and so the previous run's state leaked into future runs as hypothesis shrinks the failing example.

I have adjusted the logic so that the snapshot is only taken prior to the first run, and prior to each subsequent run a revert occurs.  Handling these actions before any test logic ensures they always occur, and moving the revert to the beginning means that if a test fails, it's still possible to use `-I` to drop in with the correct failing state.

Finally, I disabled `report_multiple_bugs` as a quick solution to the long and difficult-to-read traceback delivered from hypothesis' `MultipleFailures`.

### How to verify it
Run the tests.
