### PR TITLE
Feat tx required confs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Project folder structure is now configurable ([#581](https://github.com/eth-brownie/brownie/pull/581))
 - Deployment artifacts can now be saved via project setting `dev_deployment_artifacts: true` ([#590](https://github.com/eth-brownie/brownie/pull/590))
 - All deployment artifacts are tracked in `deployments/map.json` ([#590](https://github.com/eth-brownie/brownie/pull/590))
+- `required_confs = n / {'required_confs: n}` argument for transactions. Will wait for n confirmations before processing the tx receipt. `n = 0` will immediately return a pending receipt. ([#587](https://github.com/eth-brownie/brownie/pull/587))
+- `tx.confirmations` shows number of confirmations, `tx.wait(n)` waits until `tx` has `n` or more confirmations. ([#587](https://github.com/eth-brownie/brownie/pull/587))
 
 ### Changed
 - `tx.call_trace()` now displays internal and total gas usage ([#564](https://github.com/iamdefinitelyahuman/brownie/pull/564))

--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -309,6 +309,7 @@ class _PrivateKeyAccount(PublicKeyAccount):
         gas_limit: Optional[int] = None,
         gas_price: Optional[int] = None,
         nonce: Optional[int] = None,
+        required_confs: int = 1,
     ) -> Any:
         """Deploys a contract.
 
@@ -354,7 +355,11 @@ class _PrivateKeyAccount(PublicKeyAccount):
             revert_data = (exc.revert_msg, exc.pc, exc.revert_type)
 
         receipt = TransactionReceipt(
-            txid, self, name=contract._name + ".constructor", revert_data=revert_data
+            txid,
+            self,
+            required_confs=required_confs,
+            name=contract._name + ".constructor",
+            revert_data=revert_data,
         )
         add_thread = threading.Thread(target=contract._add_from_tx, args=(receipt,), daemon=True)
         add_thread.start()
@@ -416,6 +421,7 @@ class _PrivateKeyAccount(PublicKeyAccount):
         gas_price: Optional[int] = None,
         data: str = None,
         nonce: Optional[int] = None,
+        required_confs: int = 1,
         silent: bool = False,
     ) -> "TransactionReceipt":
         """
@@ -454,7 +460,9 @@ class _PrivateKeyAccount(PublicKeyAccount):
             txid = exc.txid
             revert_data = (exc.revert_msg, exc.pc, exc.revert_type)
 
-        receipt = TransactionReceipt(txid, self, silent=silent, revert_data=revert_data)
+        receipt = TransactionReceipt(
+            txid, self, required_confs=required_confs, silent=silent, revert_data=revert_data
+        )
         if rpc.is_active():
             undo_thread = threading.Thread(
                 target=rpc._add_to_undo_buffer,

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -241,6 +241,7 @@ class ContractConstructor:
             gas_limit=tx["gas"],
             gas_price=tx["gasPrice"],
             nonce=tx["nonce"],
+            required_confs=tx["required_confs"],
         )
 
     def _autosuggest(self) -> List:
@@ -947,6 +948,7 @@ class _ContractMethod:
             gas_limit=tx["gas"],
             gas_price=tx["gasPrice"],
             nonce=tx["nonce"],
+            required_confs=tx["required_confs"],
             data=self.encode_input(*args),
         )
 
@@ -1062,7 +1064,14 @@ def _get_tx(owner: Optional[AccountsType], args: Tuple) -> Tuple:
         owner = None
 
     # seperate contract inputs from tx dict and set default tx values
-    tx = {"from": owner, "value": 0, "gas": None, "gasPrice": None, "nonce": None}
+    tx = {
+        "from": owner,
+        "value": 0,
+        "gas": None,
+        "gasPrice": None,
+        "nonce": None,
+        "required_confs": 1,
+    }
     if args and isinstance(args[-1], dict):
         tx.update(args[-1])
         args = args[:-1]

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -72,6 +72,8 @@ class TransactionReceipt:
         gas_limit: Gas limit
         gas_used: Gas used
         input: Hexstring input data
+        confirmations: The number of blocks since the transaction was confirmed
+        required_confs: Required confirmations before processing the receipt
         nonce: Transaction nonce
         block_number: Block number this transaction was included in
         timestamp: Timestamp of the block this transaction was included in
@@ -127,6 +129,7 @@ class TransactionReceipt:
         txid: Union[str, bytes],
         sender: Any = None,
         silent: bool = False,
+        required_confs: int = 1,
         name: str = "",
         revert_data: Optional[Tuple] = None,
     ) -> None:
@@ -135,6 +138,7 @@ class TransactionReceipt:
         Args:
             txid: hexstring transaction ID
             sender: sender as a hex string or Account object
+            required_confs: the number of required confirmations before processing the receipt
             silent: toggles console verbosity
             name: contract function being called
             revert_data: (revert string, program counter, revert type)
@@ -164,7 +168,7 @@ class TransactionReceipt:
         self.status = -1
         self.txid = txid
         self.fn_name = name
-        self.required_confs = 1
+        self.required_confs = required_confs
 
         if name and "." in name:
             self.contract_name, self.fn_name = name.split(".", maxsplit=1)

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -355,7 +355,8 @@ class TransactionReceipt:
                     if remaining_confs == 0:
                         sys.stdout.write("\n")
                     sys.stdout.flush()
-            time.sleep(1)
+            if remaining_confs > 0:
+                time.sleep(1)
 
         self._set_from_receipt(receipt)
         self._confirmed.set()

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python3
+
 import sys
 import threading
 import time
@@ -842,9 +844,11 @@ class TransactionReceipt:
     @trace_inspection
     def _source_string(self, idx: int, pad: int) -> str:
         """Displays the associated source code for a given stack trace step.
+
         Args:
             idx: Stack trace step index
             pad: Number of unrelated lines of code to include before and after
+
         Returns: source code string
         """
         trace = self.trace[idx]

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -345,15 +345,16 @@ class TransactionReceipt:
                     sys.stdout.write(f"\r{color('red')}Transaction was lost...{color}")
                     sys.stdout.flush()
                 continue
-            if self.required_confs - self.confirmations != remaining_confs and not self._silent:
+            if self.required_confs - self.confirmations != remaining_confs:
                 remaining_confs = self.required_confs - self.confirmations
-                sys.stdout.write(
-                    f"\rRequired confirmations: {color('bright yellow')}{self.confirmations}/"
-                    f"{self.required_confs}{color}"
-                )
-                if remaining_confs == 0:
-                    sys.stdout.write("\n")
-                sys.stdout.flush()
+                if not self._silent:
+                    sys.stdout.write(
+                        f"\rRequired confirmations: {color('bright yellow')}{self.confirmations}/"
+                        f"{self.required_confs}{color}"
+                    )
+                    if remaining_confs == 0:
+                        sys.stdout.write("\n")
+                    sys.stdout.flush()
             time.sleep(1)
 
         self._set_from_receipt(receipt)

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -74,7 +74,6 @@ class TransactionReceipt:
         gas_used: Gas used
         input: Hexstring input data
         confirmations: The number of blocks since the transaction was confirmed
-        required_confs: Required confirmations before processing the receipt
         nonce: Transaction nonce
         block_number: Block number this transaction was included in
         timestamp: Timestamp of the block this transaction was included in
@@ -118,7 +117,6 @@ class TransactionReceipt:
         "logs",
         "nonce",
         "receiver",
-        "_required_confs",
         "sender",
         "status",
         "txid",

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -263,6 +263,12 @@ class TransactionReceipt:
             return None
         return web3.eth.getBlock(self.block_number)["timestamp"]
 
+    @property
+    def confirmations(self) -> int:
+        if not self.block_number:
+            return 0
+        return web3.eth.blockNumber - self.block_number + 1
+
     def _raise_if_reverted(self, exc: Any) -> None:
         if self.status or CONFIG.mode == "console":
             return

--- a/docs/api-network.rst
+++ b/docs/api-network.rst
@@ -1998,17 +1998,6 @@ TransactionReceipt Attributes
         >>> tx.revert_msg
         None
 
-.. py:attribute:: TransactionReceipt.required_confs
-
-    The number of :attr:`confirmations<TransactionReceipt.confirmations>` needed before the ``TransactionReceipt`` is processesd.
-
-    .. code-block:: python
-
-        >>> tx
-        <Transaction '0x8c166b66b356ad7f5c58337973b89950f03105cdae896ac66f16cdd4fc395d05'>
-        >>> tx.required_confs
-        4
-
 .. py:attribute:: TransactionReceipt.return_value
 
     The value returned from the called function, if any. Only available if the RPC client allows ``debug_traceTransaction``.

--- a/docs/api-network.rst
+++ b/docs/api-network.rst
@@ -1798,6 +1798,17 @@ TransactionReceipt Attributes
         >>> tx.block_number
         2
 
+.. py:attribute:: TransactionReceipt.confirmations
+
+    The number of blocks mined since the transaction was confirmed, including the block the transaction was mined in: ``block_height - tx.block_number + 1``.
+
+    .. code-block:: python
+
+        >>> tx
+        <Transaction '0x8c166b66b356ad7f5c58337973b89950f03105cdae896ac66f16cdd4fc395d05'>
+        >>> tx.confirmations
+        11
+
 .. py:attribute:: TransactionReceipt.contract_address
 
     The address of the contract deployed in this transaction, if the transaction was a deployment.
@@ -1986,6 +1997,17 @@ TransactionReceipt Attributes
         <Transaction object '0xac54b49987a77805bf6bdd78fb4211b3dc3d283ff0144c231a905afa75a06db0'>
         >>> tx.revert_msg
         None
+
+.. py:attribute:: TransactionReceipt.required_confs
+
+    The number of :attr:`confirmations<TransactionReceipt.confirmations>` needed before the ``TransactionReceipt`` is processesd.
+
+    .. code-block:: python
+
+        >>> tx
+        <Transaction '0x8c166b66b356ad7f5c58337973b89950f03105cdae896ac66f16cdd4fc395d05'>
+        >>> tx.required_confs
+        4
 
 .. py:attribute:: TransactionReceipt.return_value
 
@@ -2223,6 +2245,21 @@ TransactionReceipt Methods
             }
             function mul(uint a, uint b) internal pure returns (uint c) {
                 c = a * b;
+
+
+.. py:classmethod:: TransactionReceipt.wait(n)
+
+    Will wait for ``n`` :attr:`confirmations<TransactionReceipt.confirmations>` of the transaction. This has no effect if ``n`` is less than the current amount of confirmations.
+
+.. code-block:: python
+
+        >>> tx
+        <Transaction '0x830b842e24efae712b67dddd97633356122c36e6cf2193fcf9f7dc635c4cbe2f'>
+        >>> tx.wait(2)
+        This transaction already has 3 confirmations.
+        >>> tx.wait(6)
+        Required confirmations: 6/6
+          Transaction confirmed - Block: 17   Gas used: 21000 (0.31%)
 
 ``brownie.network.web3``
 ========================

--- a/docs/deploy.rst
+++ b/docs/deploy.rst
@@ -53,7 +53,7 @@ The Deployment Map
 
 Brownie will maintain a ``map.json`` file in your ``build/deployment/`` folder that lists all deployed contracts on live networks, sorted by chain and contract name.
 
-::
+.. code-block:: json
 
     {
       "1": {
@@ -93,7 +93,7 @@ To restore a deleted :func:`ProjectContract <brownie.network.contract.ProjectCon
 Saving Deployments on Development Networks
 ==========================================
 
-If you need deployment artifacts on a development network, set :attr:`dev_deployment_artifacts` to true in the in the project's ``brownie-config.yaml`` file.
+If you need deployment artifacts on a development network, set :attr:`dev_deployment_artifacts` to ``true`` in the in the project's ``brownie-config.yaml`` file.
 
 These temporary deployment artifacts and the corresponding entries in :ref:`the deployment map<persistence>`  will be removed whenever you (re-) load a project or connect, disconnect, revert or reset your local network.
 

--- a/tests/network/transaction/test_confirmation.py
+++ b/tests/network/transaction/test_confirmation.py
@@ -29,3 +29,10 @@ def test_await_conf_failed_contract_deploy(accounts, BrownieTester, console_mode
     tx = BrownieTester.deploy(False, {"from": accounts[0]})
     assert tx.status == 0
     tx._await_confirmation(False)
+
+
+def test_transaction_confirmations(accounts, rpc):
+    tx = accounts[0].transfer(accounts[1], "1 ether")
+    assert tx.confirmations == 1
+    rpc.mine()
+    assert tx.confirmations == 2

--- a/tests/network/transaction/test_confirmation.py
+++ b/tests/network/transaction/test_confirmation.py
@@ -4,31 +4,31 @@
 def test_await_conf_simple_xfer(accounts):
     tx = accounts[0].transfer(accounts[1], "1 ether")
     assert tx.status == 1
-    tx._await_confirmation(False)
+    tx._await_transaction()
 
 
 def test_await_conf_successful_contract_call(accounts, tester):
     tx = tester.revertStrings(6, {"from": accounts[1]})
     assert tx.status == 1
-    tx._await_confirmation(False)
+    tx._await_transaction()
 
 
 def test_await_conf_failed_contract_call(accounts, tester, console_mode):
     tx = tester.revertStrings(1, {"from": accounts[1]})
     assert tx.status == 0
-    tx._await_confirmation(False)
+    tx._await_transaction()
 
 
 def test_await_conf_successful_contract_deploy(accounts, BrownieTester):
     tx = BrownieTester.deploy(True, {"from": accounts[0]}).tx
     assert tx.status == 1
-    tx._await_confirmation(False)
+    tx._await_transaction()
 
 
 def test_await_conf_failed_contract_deploy(accounts, BrownieTester, console_mode):
     tx = BrownieTester.deploy(False, {"from": accounts[0]})
     assert tx.status == 0
-    tx._await_confirmation(False)
+    tx._await_transaction()
 
 
 def test_transaction_confirmations(accounts, rpc):

--- a/tests/network/transaction/test_required_confirmations.py
+++ b/tests/network/transaction/test_required_confirmations.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 
 
@@ -32,3 +34,13 @@ def test_required_confirmations_transact(accounts, BrownieTester, block_time_net
     tx = brownieTester.doNothing({"from": accounts[0], "required_confs": 4})
     assert tx.confirmations >= 4
     assert web3.eth.blockNumber - block >= 4
+
+
+def test_required_confirmations_zero(accounts, block_time_network, web3):
+    block = web3.eth.blockNumber
+    tx = accounts[0].transfer(accounts[1], "1 ether", required_confs=0)
+    assert tx.status == -1
+    assert web3.eth.blockNumber - block == 0
+    time.sleep(1.5)
+    assert tx.status == 1
+    assert web3.eth.blockNumber - block >= 1

--- a/tests/network/transaction/test_required_confirmations.py
+++ b/tests/network/transaction/test_required_confirmations.py
@@ -44,3 +44,12 @@ def test_required_confirmations_zero(accounts, block_time_network, web3):
     time.sleep(1.5)
     assert tx.status == 1
     assert web3.eth.blockNumber - block >= 1
+
+
+def test_wait_for_confirmations(accounts, block_time_network):
+    tx = accounts[0].transfer(accounts[1], "1 ether", required_confs=1)
+    tx.wait(3)
+    assert tx.confirmations in [3, 4]
+    tx.wait(2)
+    tx.wait(5)
+    assert tx.confirmations >= 5

--- a/tests/network/transaction/test_required_confirmations.py
+++ b/tests/network/transaction/test_required_confirmations.py
@@ -1,16 +1,36 @@
 import time
+from copy import deepcopy
 
 import pytest
 
+import brownie
 
-@pytest.fixture
-def block_time_network(devnetwork, config):
+
+@pytest.fixture(scope="module")
+def block_time_config():
+    conf = brownie._config.CONFIG
+    argv = deepcopy(conf.argv)
+    networks = deepcopy(conf.networks)
+    settings = conf.settings._copy()
+    conf.networks["development"]["cmd_settings"]["block_time"] = 1
+    yield conf
+    conf.argv.clear()
+    conf.argv.update(argv)
+    conf.networks.clear()
+    conf.networks.update(networks)
+    conf.settings._unlock()
+    conf.settings.clear()
+    conf.settings.update(settings)
+    conf.settings._lock()
+
+
+@pytest.fixture(scope="module")
+def block_time_network(block_time_config):
     """Provide a network with fixed block mining time of 1 second."""
-    config.networks["development"]["cmd_settings"]["block_time"] = 1
-    devnetwork.disconnect()
-    devnetwork.connect("development")
-    yield devnetwork
-    devnetwork.disconnect()
+    if brownie.network.is_connected():
+        brownie.network.disconnect()
+    brownie.network.connect("development")
+    yield brownie.network
 
 
 def test_required_confirmations_deploy(accounts, BrownieTester, block_time_network, web3):
@@ -44,7 +64,7 @@ def test_required_confirmations_zero(accounts, block_time_network, web3):
     assert web3.eth.blockNumber - block == 0
     time.sleep(1.5)
     assert tx.status == 1
-    assert web3.eth.blockNumber - block >= 1
+    assert tx.confirmations >= 1
 
 
 def test_wait_for_confirmations(accounts, block_time_network):

--- a/tests/network/transaction/test_required_confirmations.py
+++ b/tests/network/transaction/test_required_confirmations.py
@@ -31,6 +31,7 @@ def block_time_network(block_time_config):
         brownie.network.disconnect()
     brownie.network.connect("development")
     yield brownie.network
+    brownie.network.disconnect()
 
 
 def test_required_confirmations_deploy(accounts, BrownieTester, block_time_network, web3):

--- a/tests/network/transaction/test_required_confirmations.py
+++ b/tests/network/transaction/test_required_confirmations.py
@@ -1,0 +1,34 @@
+import pytest
+
+
+@pytest.fixture
+def block_time_network(devnetwork, config):
+    """Provide a network with fixed block mining time of 1 second."""
+    config.networks["development"]["cmd_settings"]["block_time"] = 1
+    devnetwork.disconnect()
+    devnetwork.connect("development")
+    yield devnetwork
+
+
+def test_required_confirmations_deploy(accounts, BrownieTester, block_time_network, web3):
+    block = web3.eth.blockNumber
+    accounts[0].deploy(BrownieTester, True, required_confs=3)
+    assert web3.eth.blockNumber - block >= 3
+
+
+def test_required_confirmations_transfer(accounts, block_time_network, web3):
+    block = web3.eth.blockNumber
+    tx = accounts[0].transfer(accounts[1], "1 ether", required_confs=3)
+    assert tx.confirmations >= 3
+    assert web3.eth.blockNumber - block >= 3
+
+
+def test_required_confirmations_transact(accounts, BrownieTester, block_time_network, web3):
+    block = web3.eth.blockNumber
+    brownieTester = BrownieTester.deploy(True, {"from": accounts[0], "required_confs": 2})
+    assert web3.eth.blockNumber - block >= 2
+
+    block = web3.eth.blockNumber
+    tx = brownieTester.doNothing({"from": accounts[0], "required_confs": 4})
+    assert tx.confirmations >= 4
+    assert web3.eth.blockNumber - block >= 4

--- a/tests/network/transaction/test_required_confirmations.py
+++ b/tests/network/transaction/test_required_confirmations.py
@@ -2,33 +2,6 @@ import time
 
 import pytest
 
-# @pytest.fixture(scope="module")
-# def block_time_config():
-#     conf = brownie._config.CONFIG
-#     argv = deepcopy(conf.argv)
-#     networks = deepcopy(conf.networks)
-#     settings = conf.settings._copy()
-#     conf.networks["development"]["cmd_settings"]["block_time"] = 1
-#     yield conf
-#     conf.argv.clear()
-#     conf.argv.update(argv)
-#     conf.networks.clear()
-#     conf.networks.update(networks)
-#     conf.settings._unlock()
-#     conf.settings.clear()
-#     conf.settings.update(settings)
-#     conf.settings._lock()
-#
-#
-# @pytest.fixture(scope="module")
-# def block_time_network(block_time_config):
-#     """Provide a network with fixed block mining time of 1 second."""
-#     if brownie.network.is_connected():
-#         brownie.network.disconnect()
-#     brownie.network.connect("development")
-#     yield brownie.network
-#     brownie.network.disconnect()
-
 
 @pytest.fixture
 def block_time_network(devnetwork, config):

--- a/tests/network/transaction/test_required_confirmations.py
+++ b/tests/network/transaction/test_required_confirmations.py
@@ -10,6 +10,7 @@ def block_time_network(devnetwork, config):
     devnetwork.disconnect()
     devnetwork.connect("development")
     yield devnetwork
+    devnetwork.disconnect()
 
 
 def test_required_confirmations_deploy(accounts, BrownieTester, block_time_network, web3):

--- a/tests/network/transaction/test_required_confirmations.py
+++ b/tests/network/transaction/test_required_confirmations.py
@@ -1,37 +1,43 @@
 import time
-from copy import deepcopy
 
 import pytest
 
-import brownie
+# @pytest.fixture(scope="module")
+# def block_time_config():
+#     conf = brownie._config.CONFIG
+#     argv = deepcopy(conf.argv)
+#     networks = deepcopy(conf.networks)
+#     settings = conf.settings._copy()
+#     conf.networks["development"]["cmd_settings"]["block_time"] = 1
+#     yield conf
+#     conf.argv.clear()
+#     conf.argv.update(argv)
+#     conf.networks.clear()
+#     conf.networks.update(networks)
+#     conf.settings._unlock()
+#     conf.settings.clear()
+#     conf.settings.update(settings)
+#     conf.settings._lock()
+#
+#
+# @pytest.fixture(scope="module")
+# def block_time_network(block_time_config):
+#     """Provide a network with fixed block mining time of 1 second."""
+#     if brownie.network.is_connected():
+#         brownie.network.disconnect()
+#     brownie.network.connect("development")
+#     yield brownie.network
+#     brownie.network.disconnect()
 
 
-@pytest.fixture(scope="module")
-def block_time_config():
-    conf = brownie._config.CONFIG
-    argv = deepcopy(conf.argv)
-    networks = deepcopy(conf.networks)
-    settings = conf.settings._copy()
-    conf.networks["development"]["cmd_settings"]["block_time"] = 1
-    yield conf
-    conf.argv.clear()
-    conf.argv.update(argv)
-    conf.networks.clear()
-    conf.networks.update(networks)
-    conf.settings._unlock()
-    conf.settings.clear()
-    conf.settings.update(settings)
-    conf.settings._lock()
-
-
-@pytest.fixture(scope="module")
-def block_time_network(block_time_config):
+@pytest.fixture
+def block_time_network(devnetwork, config):
     """Provide a network with fixed block mining time of 1 second."""
-    if brownie.network.is_connected():
-        brownie.network.disconnect()
-    brownie.network.connect("development")
-    yield brownie.network
-    brownie.network.disconnect()
+    config.networks["development"]["cmd_settings"]["block_time"] = 1
+    devnetwork.disconnect()
+    devnetwork.connect("development")
+    yield devnetwork
+    devnetwork.disconnect()
 
 
 def test_required_confirmations_deploy(accounts, BrownieTester, block_time_network, web3):


### PR DESCRIPTION
### What I did

Add `required_confs` as an argument to transactions with a default value of 1 (same as current behaviour).

Setting `required_confs = n > 1` will wait for n blocks to be mined before the transaction receipt is processed.

If during the confirmation time the transaction is dropped (uncle block), the transaction will wait until it is picked up again and has the required amount of confirmations.

if `required_confs == 0` the transaction will immediately return a pending tx receipt and not wait for a confirmation.

Add `tx.wait(n)` to retroactively add required_confs and wait until they are confirmed.

TODO: Still needs more documentation

Closes #587

### How I did it
Added the argument to all deply, transfer and transact functions.

Refactored the confirmation logic


### How to verify it
I added tests for this.
or try `accounts[0].transfer(accounts[1], "1 ether", {'required_confs': 3})`

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [x] I have updated the documentation
- [x] I have added an entry to the changelog
