### PR TITLE
Project installation fixes

### DIFF
--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -764,28 +764,29 @@ def _install_from_github(package_id: str) -> str:
     shutil.move(installed, install_path)
 
     try:
-        brownie_config: Dict = {"project_structure": {}}
+        if not install_path.joinpath("brownie-config.yaml").exists():
+            brownie_config: Dict = {"project_structure": {}}
 
-        contract_paths = set(
-            i.relative_to(install_path).parts[0] for i in install_path.glob("**/*.sol")
-        )
-        contract_paths.update(
-            i.relative_to(install_path).parts[0] for i in install_path.glob("**/*.vy")
-        )
-        if not contract_paths:
-            raise InvalidPackage(f"{package_id} does not contain any .sol or .vy files")
-        if install_path.joinpath("contracts").is_dir():
-            brownie_config["project_structure"]["contracts"] = "contracts"
-        elif len(contract_paths) == 1:
-            brownie_config["project_structure"]["contracts"] = contract_paths.pop()
-        else:
-            raise InvalidPackage(
-                f"{package_id} has no `contracts/` subdirectory, and "
-                "multiple directories containing source files"
+            contract_paths = set(
+                i.relative_to(install_path).parts[0] for i in install_path.glob("**/*.sol")
             )
+            contract_paths.update(
+                i.relative_to(install_path).parts[0] for i in install_path.glob("**/*.vy")
+            )
+            if not contract_paths:
+                raise InvalidPackage(f"{package_id} does not contain any .sol or .vy files")
+            if install_path.joinpath("contracts").is_dir():
+                brownie_config["project_structure"]["contracts"] = "contracts"
+            elif len(contract_paths) == 1:
+                brownie_config["project_structure"]["contracts"] = contract_paths.pop()
+            else:
+                raise InvalidPackage(
+                    f"{package_id} has no `contracts/` subdirectory, and "
+                    "multiple directories containing source files"
+                )
 
-        with install_path.joinpath("brownie-config.yaml").open("w") as fp:
-            yaml.dump(brownie_config, fp)
+            with install_path.joinpath("brownie-config.yaml").open("w") as fp:
+                yaml.dump(brownie_config, fp)
 
         project = load(install_path)
         project.close()

--- a/tests/project/packages/test_install.py
+++ b/tests/project/packages/test_install.py
@@ -84,3 +84,8 @@ def test_install_from_config_dependencies(dependentproject):
 def test_dependency_already_installed(dependentproject):
     install_package("brownie-mix/token-mix@1.0.0")
     dependentproject.load()
+
+
+def test_wont_compile():
+    # can't compile due to a NamespaceCollision, should still install
+    install_package("makerdao/dss@1.0.6")


### PR DESCRIPTION
### What I did
* Allow installing packages with a non-standard contracts folder - closes #497 
* Allow installing packages that won't compile

### How I did it
* If the project has no `contracts` folder, but there is another folder that contains contract files, create a configuration file with a `project_structure` field to point at the other folder
* If a project cannot compile, raise a warning but do not prevent it from installing. Users can still import individual contracts even if Brownie cannot load the project as a whole.

### How to verify it
Run tests.
