### PR TITLE
Block identifier

### DIFF
--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -7,7 +7,7 @@ import sys
 import warnings
 from pathlib import Path
 from textwrap import TextWrapper
-from typing import Any, Callable, Dict, Iterator, List, Optional, Set, Tuple, Union
+from typing import Any, Dict, Iterator, List, Optional, Set, Tuple, Union
 from urllib.parse import urlparse
 
 import eth_abi
@@ -1038,7 +1038,7 @@ class ContractCall(_ContractMethod):
         Bytes4 method signature.
     """
 
-    def __call__(self, *args: Tuple, block_identifier: Union[int, str, bytes] = None) -> Callable:
+    def __call__(self, *args: Tuple, block_identifier: Union[int, str, bytes] = None) -> Any:
         """
         Call the contract method without broadcasting a transaction.
 

--- a/docs/api-network.rst
+++ b/docs/api-network.rst
@@ -930,11 +930,12 @@ Contract Internal Attributes
 ContractCall
 ------------
 
-.. py:class:: brownie.network.contract.ContractCall(*args)
+.. py:class:: brownie.network.contract.ContractCall(*args, block_identifier=None)
 
     Calls a non state-changing contract method without broadcasting a transaction, and returns the result. ``args`` must match the required inputs for the method.
 
-    The expected inputs are shown in the method's ``__repr__`` value.
+    * ``args``: Input arguments for the call. The expected inputs are shown in the method's ``__repr__`` value.
+    * ``block_identifier``: A block number or hash that the call is executed at. If ``None``, the latest block is used. Raises `ValueError` if this value is too far in the past and you are not using an archival node.
 
     Inputs and return values are formatted via methods in the :ref:`convert<api-convert>` module. Multiple values are returned inside a :func:`ReturnValue <brownie.convert.datatypes.ReturnValue>`.
 
@@ -1061,9 +1062,12 @@ ContractTx Attributes
 ContractTx Methods
 ******************
 
-.. py:classmethod:: ContractTx.call(*args)
+.. py:classmethod:: ContractTx.call(*args, block_identifier=None)
 
     Calls the contract method without broadcasting a transaction, and returns the result.
+
+    * ``args``: Input arguments for the call. The expected inputs are shown in the method's ``__repr__`` value.
+    * ``block_identifier``: A block number or hash that the call is executed at. If ``None``, the latest block is used. Raises `ValueError` if this value is too far in the past and you are not using an archival node.
 
     Inputs and return values are formatted via methods in the :ref:`convert<api-convert>` module. Multiple values are returned inside a :func:`ReturnValue <brownie.convert.datatypes.ReturnValue>`.
 


### PR DESCRIPTION
### What I did
Expose `block_identifier` when making contract calls

Closes #586 

### How I did it
Added the `block_identifier` kwarg where it made sense. This is the same syntax that `web3.py` uses.

The only non-trivial thing I encountered was the case where calls are always handled as transactions (when evaluating coverage, for example). In this case, if the kwarg is provided I've opted to forgo running it as a transaction - since we can't very effectively perform a tx against historic state.

### How to verify it
Run tests. I added some new test cases.
