### PR TITLE
Feat pending nonce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - `tx.call_trace()` now displays internal and total gas usage ([#564](https://github.com/iamdefinitelyahuman/brownie/pull/564))
+- Default nonce for transactions now takes pending transactions into account. ([#597](https://github.com/iamdefinitelyahuman/brownie/pull/597))
 
 ### Fixed
 - Geth Traces depth reduced ([#562](https://github.com/iamdefinitelyahuman/brownie/pull/562))

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -131,7 +131,8 @@ class ContractContainer(_ContractBase):
         reverted = [
             i
             for i in self._contracts
-            if (i.tx and i.tx.block_number > height) or len(web3.eth.getCode(i.address).hex()) <= 4
+            if (i.tx and i.tx.block_number is not None and i.tx.block_number > height)
+            or len(web3.eth.getCode(i.address).hex()) <= 4
         ]
         for contract in reverted:
             self.remove(contract)

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -331,7 +331,7 @@ class TransactionReceipt:
         # await first confirmation
         receipt = web3.eth.waitForTransactionReceipt(self.txid, timeout=None, poll_latency=0.5)
 
-        self.block_number: int = receipt["blockNumber"]
+        self.block_number: Optional[int] = receipt["blockNumber"]
         # wait for more confirmations if required and handle uncle blocks
         remaining_confs = required_confs
         while remaining_confs > 0 and required_confs > 1:
@@ -342,7 +342,10 @@ class TransactionReceipt:
                 if not self._silent:
                     sys.stdout.write(f"\r{color('red')}Transaction was lost...{color}{' ' * 8}")
                     sys.stdout.flush()
-                continue
+                # check if tx is still in mempool, this will raise otherwise
+                tx = web3.eth.getTransaction(self.txid)
+                self.block_number = None
+                return self._await_confirmation(tx, required_confs)
             if required_confs - self.confirmations != remaining_confs:
                 remaining_confs = required_confs - self.confirmations
                 if not self._silent:

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -329,7 +329,7 @@ class TransactionReceipt:
                 sys.stdout.flush()
 
         # await first confirmation
-        receipt = web3.eth.waitForTransactionReceipt(self.txid, None)
+        receipt = web3.eth.waitForTransactionReceipt(self.txid, timeout=None, poll_latency=0.5)
 
         self.block_number: int = receipt["blockNumber"]
         # wait for more confirmations if required and handle uncle blocks

--- a/docs/api-network.rst
+++ b/docs/api-network.rst
@@ -289,7 +289,7 @@ Account Methods
     * ``gas_limit``: Gas limit for the transaction. The given value is converted to :func:`Wei <brownie.convert.datatypes.Wei>`. If none is given, the price is set using ``eth_estimateGas``.
     * ``gas_price``: Gas price for the transaction. The given value is converted to :func:`Wei <brownie.convert.datatypes.Wei>`. If none is given, the price is set using ``eth_gasPrice``.
     * ``nonce``: Nonce for the transaction. If none is given, the nonce is set using ``eth_getTransactionCount`` while also considering any pending transactions of the Account.
-    * ``required_confs``: The required :attr:`confirmations<TransactionReceipt.confirmations>` before the :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>` is processed. If none is given, defaults to 1 confirmation.  If 0 is given, will immediately return a pending :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>` instead of a :func:`Contract <brownie.network.contract.Contract>` instance, while waiting for a confirmation in a separate thread.
+    * ``required_confs``: The required :attr:`confirmations<TransactionReceipt.confirmations>` before the :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>` is processed. If none is given, defaults to 1 confirmation.  If 0 is given, immediately returns a pending :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>` instead of a :func:`Contract <brownie.network.contract.Contract>` instance, while waiting for a confirmation in a separate thread.
 
     Returns a :func:`Contract <brownie.network.contract.Contract>` instance upon success. If the transaction reverts or you do not wait for a confirmation, a :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>` is returned instead.
 
@@ -336,7 +336,7 @@ Account Methods
     * ``gas_price``: Gas price for the transaction. The given value is converted to :func:`Wei <brownie.convert.datatypes.Wei>`. If none is given, the price is set using ``eth_gasPrice``.
     * ``data``: Transaction data hexstring.
     * ``nonce``: Nonce for the transaction. If none is given, the nonce is set using ``eth_getTransactionCount`` while also considering any pending transactions of the Account..
-    * ``required_confs``: The required :attr:`confirmations<TransactionReceipt.confirmations>` before the :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>` is processed. If none is given, defaults to 1 confirmation.  If 0 is given, will immediately return a pending :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>`, while waiting for a confirmation in a separate thread.
+    * ``required_confs``: The required :attr:`confirmations<TransactionReceipt.confirmations>` before the :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>` is processed. If none is given, defaults to 1 confirmation.  If 0 is given, immediately returns a pending :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>`, while waiting for a confirmation in a separate thread.
     * ``silent``: Toggles console verbosity. If ``True`` is given, suppresses all console output for this transaction.
 
     Returns a :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>` instance.

--- a/docs/api-network.rst
+++ b/docs/api-network.rst
@@ -279,7 +279,7 @@ Account Methods
         >>> accounts[0].balance() == "100 ether"
         True
 
-.. py:classmethod:: Account.deploy(contract, *args, amount=None, gas_limit=None, gas_price=None, nonce=None)
+.. py:classmethod:: Account.deploy(contract, *args, amount=None, gas_limit=None, gas_price=None, nonce=None, required_confs=1)
 
     Deploys a contract.
 
@@ -288,7 +288,8 @@ Account Methods
     * ``amount``: Amount of ether to send with the transaction. The given value is converted to :func:`Wei <brownie.convert.datatypes.Wei>`.
     * ``gas_limit``: Gas limit for the transaction. The given value is converted to :func:`Wei <brownie.convert.datatypes.Wei>`. If none is given, the price is set using ``eth_estimateGas``.
     * ``gas_price``: Gas price for the transaction. The given value is converted to :func:`Wei <brownie.convert.datatypes.Wei>`. If none is given, the price is set using ``eth_gasPrice``.
-    * ``nonce``: Nonce for the transaction. If none is given, the nonce is set using ``eth_getTransactionCount``.
+    * ``nonce``: Nonce for the transaction. If none is given, the nonce is set using ``eth_getTransactionCount`` while also considering any pending transactions of the Account.
+    * ``required_confs``: The required :attr:`confirmations<TransactionReceipt.confirmations>` before the :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>` is processed. If none is given, defaults to 1 confirmation.  If 0 is given, will immediately return a pending :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>` instead of a :func:`Contract <brownie.network.contract.Contract>` instance, while waiting for a confirmation in a separate thread.
 
     Returns a :func:`Contract <brownie.network.contract.Contract>` instance upon success. If the transaction reverts or you do not wait for a confirmation, a :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>` is returned instead.
 
@@ -325,7 +326,7 @@ Account Methods
         >>> accounts[0].estimate_gas(accounts[1], "1 ether")
         21000
 
-.. py:classmethod:: Account.transfer(self, to=None, amount=0, gas_limit=None, gas_price=None, data=None, nonce=None, silent=False)
+.. py:classmethod:: Account.transfer(self, to=None, amount=0, gas_limit=None, gas_price=None, data=None, nonce=None, required_confs=1, silent=False)
 
     Broadcasts a transaction from this account.
 
@@ -334,7 +335,8 @@ Account Methods
     * ``gas_limit``: Gas limit for the transaction. The given value is converted to :func:`Wei <brownie.convert.datatypes.Wei>`. If none is given, the price is set using ``eth_estimateGas``.
     * ``gas_price``: Gas price for the transaction. The given value is converted to :func:`Wei <brownie.convert.datatypes.Wei>`. If none is given, the price is set using ``eth_gasPrice``.
     * ``data``: Transaction data hexstring.
-    * ``nonce``: Nonce for the transaction. If none is given, the nonce is set using ``eth_getTransactionCount``.
+    * ``nonce``: Nonce for the transaction. If none is given, the nonce is set using ``eth_getTransactionCount`` while also considering any pending transactions of the Account..
+    * ``required_confs``: The required :attr:`confirmations<TransactionReceipt.confirmations>` before the :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>` is processed. If none is given, defaults to 1 confirmation.  If 0 is given, will immediately return a pending :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>`, while waiting for a confirmation in a separate thread.
     * ``silent``: Toggles console verbosity. If ``True`` is given, suppresses all console output for this transaction.
 
     Returns a :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>` instance.

--- a/docs/core-accounts.rst
+++ b/docs/core-accounts.rst
@@ -41,15 +41,15 @@ The :func:`Account.transfer <Account.transfer>` method is used to send ether bet
     >>> accounts[1].balance()
     110000000000000000000
 
-=========================
-Running Many Transactions
-=========================
 
-Running any transaction will by default wait until that transaction is completed before continuing. There are two ways to run many transactions at the same time without waiting:
+Broadcasting Multiple Transactions
+==================================
 
-1. Set the required confirmations of the transaction to ``0``.
+Broadcasting a transaction is normally a *blocking action* - Brownie waits until the transaction has confirmed before continuing.
+One way to broadcast transactions without blocking is to set ``required_confs = 0``.
+This immediately returns a pending :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>` and continues without waiting for a confirmation.
+Additionally, setting ``silent = True`` suppresses the console output.
 
-This will immediately return a pending :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>` and continue without waiting for a confirmation. Additionally, setting ``silent=True`` will suppress the console output.
 
 .. code-block:: python
 
@@ -60,38 +60,4 @@ This will immediately return a pending :func:`TransactionReceipt <brownie.networ
     >>> [tx.status for tx in transactions]
     [1, -1, -1]
 
-These transactions will initially be pending (``status = -1``) and confirm in a seperate thread in the background.
-
-2. Run the transactions in individual threads.
-
-A more advanced usage is to create a thread for each transaction. Brownie will automatically set the correct nonces and ensure thread safety.
-
-.. code-block:: python
-
-    import threading
-
-    def send_confirmed_ether(recipient):
-        accounts[0].transfer(recipient, "1 ether", required_confs=4, silent=True)
-        print(f"Confirmed tx to send ether to {recipient}.")
-
-    threads = [
-        threading.Thread(target=send_confirmed_ether, args=(accounts[i],), daemon=True)
-        for i in range(1, 4)
-    ]
-
-    for t in threads:
-        t.start()
-    print("Transactions queued.")
-
-    # ... code while you wait for confirmations ...
-
-    for t in threads:
-        t.join()
-    print("All transactions confirmed.")
-
-    # Output
-    Transactions queued.
-    Confirmed tx to send ether to 0x33A4622B82D4c04a53e170c638B944ce27cffce3.
-    Confirmed tx to send ether to 0x0063046686E46Dc6F15918b61AE2B121458534a5.
-    Confirmed tx to send ether to 0x21b42413bA931038f35e7A5224FaDb065d297Ba3.
-    Transactions confirmed.
+These transactions are initially pending (``status == -1``) and appear yellow in the console.

--- a/docs/core-contracts.rst
+++ b/docs/core-contracts.rst
@@ -143,7 +143,8 @@ When executing a transaction to a contract, you can optionally include a :py:cla
     * ``gas_limit``: The amount of gas provided for transaction execution, in wei. If not given, the gas limit is determined using :meth:`web3.eth.estimateGas <web3.eth.Eth.estimateGas>`.
     * ``gas_price``: The gas price for the transaction, in wei. If not given, the gas price is set according to :attr:`web3.eth.gasPrice <web3.eth.Eth.gasPrice>`.
     * ``amount``: The amount of Ether to include with the transaction, in wei.
-    * ``nonce``: The nonce for the transaction. If not given, the nonce is set according to :meth:`web3.eth.getTransactionCount <web3.eth.Eth.getTransactionCount>`.
+    * ``nonce``: The nonce for the transaction. If not given, the nonce is set according to :meth:`web3.eth.getTransactionCount <web3.eth.Eth.getTransactionCount>` while taking pending transactions from the sender into account.
+    * ``required_confs``: The required :attr:`confirmations<TransactionReceipt.confirmations>` before the :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>` is processed. If none is given, defaults to 1 confirmation.  If 0 is given, will immediately return a pending :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>`, while waiting for a confirmation in a separate thread.
 
 All currency integer values can also be given as strings that will be converted by :func:`Wei <brownie.convert.datatypes.Wei>`.
 

--- a/docs/core-contracts.rst
+++ b/docs/core-contracts.rst
@@ -144,7 +144,7 @@ When executing a transaction to a contract, you can optionally include a :py:cla
     * ``gas_price``: The gas price for the transaction, in wei. If not given, the gas price is set according to :attr:`web3.eth.gasPrice <web3.eth.Eth.gasPrice>`.
     * ``amount``: The amount of Ether to include with the transaction, in wei.
     * ``nonce``: The nonce for the transaction. If not given, the nonce is set according to :meth:`web3.eth.getTransactionCount <web3.eth.Eth.getTransactionCount>` while taking pending transactions from the sender into account.
-    * ``required_confs``: The required :attr:`confirmations<TransactionReceipt.confirmations>` before the :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>` is processed. If none is given, defaults to 1 confirmation.  If 0 is given, will immediately return a pending :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>`, while waiting for a confirmation in a separate thread.
+    * ``required_confs``: The required :attr:`confirmations<TransactionReceipt.confirmations>` before the :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>` is processed. If none is given, defaults to 1 confirmation.  If 0 is given, immediately returns a pending :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>`, while waiting for a confirmation in a separate thread.
 
 All currency integer values can also be given as strings that will be converted by :func:`Wei <brownie.convert.datatypes.Wei>`.
 

--- a/docs/core-transactions.rst
+++ b/docs/core-transactions.rst
@@ -284,9 +284,3 @@ The :func:`TxHistory <brownie.network.state.TxHistory>` container, available as 
     >>> history
     [<Transaction object '0xe803698b0ade1598c594b2c73ad6a656560a4a4292cc7211b53ffda4a1dbfbe8'>, <Transaction object '0xa7616a96ef571f1791586f570017b37f4db9decb1a5f7888299a035653e8b44b'>]
 
-Unconfirmed Transactions
-========================
-
-After broadcasting a transaction, Brownie will pause and wait for it to confirm. If you are using the console you can press ``Ctrl-C`` stop waiting and immediately receive the :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>` object. It will be marked as pending, and many attributes and methods will not yet be available. A notification will be displayed when the transaction confirms.
-
-If you send another transaction from the same account before the previous one has confirmed, it is still broadcast with the next sequential nonce.


### PR DESCRIPTION
### What I did

* Add multithreading lock to send transactions from an account
* Add support for pending nonces and set pending nonce as the default nonce to use

Closes #588 

### How I did it
If the last transaction from an account is still pending, the pending nonce is the nonce of this transaction plus 1

### How to verify it
I added two tests.

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [x] I have updated the documentation
- [x] I have added an entry to the changelog
