### PR TITLE
Add POA middleware

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,4 +20,4 @@ requests>=2.23.0,<3.0.0
 semantic-version==2.8.5
 tqdm==4.46.0
 vyper==0.1.0b17
-web3==5.10.0
+web3==5.11.0

--- a/tests/network/test_web3.py
+++ b/tests/network/test_web3.py
@@ -93,3 +93,10 @@ def test_chain_uri_disconnected(web3):
     web3.disconnect()
     with pytest.raises(ConnectionError):
         web3.chain_uri
+
+
+def test_rinkeby(web3, network):
+    network.connect("rinkeby")
+
+    # this should work because we automatically add the POA middleware
+    web3.eth.getBlock("latest")


### PR DESCRIPTION
### What I did
Add `geth_poa_middleware` when connecting to a POA network

Closes #583 

### How I did it
After connecting, call `web3.eth.getBlock('latest')` and catch `ExtraDataLengthError`. If this exception is raised, add the required middleware.

### How to verify it
Run the tests. I added a test case to confirm connection to rinkeby works.
