### PR TITLE
Dynamically apply __tracebackhide__

### DIFF
--- a/brownie/exceptions.py
+++ b/brownie/exceptions.py
@@ -8,8 +8,6 @@ import yaml
 
 import brownie
 
-__tracebackhide__ = True
-
 # network
 
 

--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -26,8 +26,6 @@ from .state import TxHistory
 from .transaction import TransactionReceipt
 from .web3 import _resolve_address, web3
 
-__tracebackhide__ = True
-
 history = TxHistory()
 rpc = Rpc()
 

--- a/brownie/network/alert.py
+++ b/brownie/network/alert.py
@@ -7,8 +7,6 @@ from typing import Callable, Dict, List, Tuple, Union
 from brownie.utils import color
 
 __console_dir__ = ["Alert", "new", "show", "stop_all"]
-__tracebackhide__ = True
-
 _instances = set()
 
 

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -44,8 +44,6 @@ from .rpc import _revert_register
 from .state import _add_contract, _add_deployment, _find_contract, _get_deployment, _remove_contract
 from .web3 import _resolve_address, web3
 
-__tracebackhide__ = True
-
 _unverified_addresses: Set = set()
 
 

--- a/brownie/network/event.py
+++ b/brownie/network/event.py
@@ -11,8 +11,6 @@ from brownie._config import _get_data_folder
 from brownie.convert.normalize import format_event
 from brownie.exceptions import EventLookupError
 
-__tracebackhide__ = True
-
 
 class EventDict:
     """Dict/list hybrid container, base class for all events fired in a transaction."""

--- a/brownie/network/rpc.py
+++ b/brownie/network/rpc.py
@@ -42,7 +42,6 @@ CLI_FLAGS = {
 EVM_VERSIONS = ["byzantium", "constantinople", "petersburg", "istanbul"]
 EVM_DEFAULT = "istanbul"
 
-__tracebackhide__ = True
 _revert_refs: List = []
 
 

--- a/brownie/network/state.py
+++ b/brownie/network/state.py
@@ -13,7 +13,6 @@ from brownie.utils.sql import Cursor
 from .rpc import _revert_register
 from .web3 import _resolve_address
 
-__tracebackhide__ = True
 _contract_map: Dict = {}
 
 cur = Cursor(_get_data_folder().joinpath(f"deployments.db"))

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -24,7 +24,6 @@ from .event import _decode_logs, _decode_trace
 from .state import TxHistory, _find_contract
 from .web3 import web3
 
-__tracebackhide__ = True
 history = TxHistory()
 
 

--- a/brownie/network/web3.py
+++ b/brownie/network/web3.py
@@ -16,7 +16,6 @@ from brownie._config import CONFIG, _get_data_folder
 from brownie.convert import to_address
 from brownie.exceptions import MainnetUndefined, UnsetENSName
 
-__tracebackhide__ = True
 _chain_uri_cache: Dict = {}
 
 

--- a/brownie/test/managers/runner.py
+++ b/brownie/test/managers/runner.py
@@ -53,8 +53,6 @@ class RevertContextManager:
         pass
 
     def __exit__(self, exc_type, exc_value, traceback):
-        __tracebackhide__ = True
-
         if exc_type is None:
             raise AssertionError("Transaction did not revert") from None
 

--- a/brownie/test/plugin.py
+++ b/brownie/test/plugin.py
@@ -1,5 +1,8 @@
 #!/usr/bin/python3
 
+import sys
+from pathlib import Path
+
 import pytest
 
 from brownie import project
@@ -56,6 +59,15 @@ def pytest_configure(config):
             # prevent pytest INTERNALERROR traceback when project fails to compile
             print(f"{color.format_tb(e)}\n")
             raise pytest.UsageError("Unable to load project")
+
+        # apply __tracebackhide__ so brownie internals aren't included in tracebacks
+        base_path = Path(sys.modules["brownie"].__file__).parent.as_posix()
+        for module in [
+            v
+            for v in sys.modules.values()
+            if getattr(v, "__file__", None) and v.__file__.startswith(base_path)
+        ]:
+            module.__tracebackhide__ = True
 
         # enable verbose output if stdout capture is disabled
         if config.getoption("capture") == "no":

--- a/brownie/test/stateful.py
+++ b/brownie/test/stateful.py
@@ -13,7 +13,6 @@ from hypothesis.strategies import SearchStrategy
 import brownie
 from brownie.utils import color
 
-__tracebackhide__ = True
 sf.__tracebackhide__ = True
 
 marker = deque("-/|\\-/|\\")

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,5 @@ addopts =
 	--cov-report term
 	--cov-report xml
 	--ignore tests/data/
-	--full-trace
 	-n auto
 


### PR DESCRIPTION
### What I did
Only apply [`__tracebackhide__`](https://docs.pytest.org/en/latest/example/simple.html#writing-well-integrated-assertion-helpers) when the brownie plugin is loaded.

Closes #580 

### How I did it
During Brownie's `pytest_configure` hook, iterate over `sys.modules` and add `__tracebackhide__` to all Brownie modules.

This way, when running internal Brownie tests we can see the full tracebak without having to use `--full-trace` and also view pytest internals.

### How to verify it
Make a test fail and look at the traceback.
