### PR TITLE
Rpc.undo/redo fix

### DIFF
--- a/brownie/network/rpc.py
+++ b/brownie/network/rpc.py
@@ -319,6 +319,10 @@ class Rpc(metaclass=_Singleton):
             raise TypeError("seconds must be an integer value")
         self._time_offset = self._request("evm_increaseTime", [seconds])
 
+        if seconds:
+            self._redo_buffer.clear()
+            self._current_id = self._snap()
+
     def mine(self, blocks: int = 1) -> str:
         """Increases the block height within the test RPC.
 
@@ -328,6 +332,9 @@ class Rpc(metaclass=_Singleton):
             raise TypeError("blocks must be an integer value")
         for i in range(blocks):
             self._request("evm_mine", [])
+
+        self._redo_buffer.clear()
+        self._current_id = self._snap()
         return f"Block height at {web3.eth.blockNumber}"
 
     def snapshot(self) -> str:

--- a/tests/network/rpc/test_redo.py
+++ b/tests/network/rpc/test_redo.py
@@ -63,11 +63,29 @@ def test_snapshot_clears_redo_buffer(accounts, rpc):
         rpc.redo()
 
 
-def test_revert_clears_undo_buffer(accounts, rpc):
+def test_revert_clears_redo_buffer(accounts, rpc):
     rpc.snapshot()
     accounts[0].transfer(accounts[1], 100)
     accounts[0].transfer(accounts[1], 100)
     rpc.undo()
     rpc.revert()
+    with pytest.raises(ValueError):
+        rpc.redo()
+
+
+def test_sleep_clears_redo_buffer(accounts, rpc):
+    accounts[0].transfer(accounts[1], 100)
+    accounts[0].transfer(accounts[1], 100)
+    rpc.undo()
+    rpc.sleep(100)
+    with pytest.raises(ValueError):
+        rpc.redo()
+
+
+def test_mine_clears_redo_buffer(accounts, rpc):
+    accounts[0].transfer(accounts[1], 100)
+    accounts[0].transfer(accounts[1], 100)
+    rpc.undo()
+    rpc.mine()
     with pytest.raises(ValueError):
         rpc.redo()

--- a/tests/network/rpc/test_undo.py
+++ b/tests/network/rpc/test_undo.py
@@ -50,3 +50,21 @@ def test_revert_clears_undo_buffer(accounts, rpc):
     rpc.revert()
     with pytest.raises(ValueError):
         rpc.undo()
+
+
+def test_does_not_undo_sleep(accounts, rpc):
+    accounts[0].transfer(accounts[1], 100)
+    time = rpc.time()
+    rpc.sleep(100000)
+    accounts[0].transfer(accounts[1], 100)
+    rpc.undo()
+    assert rpc.time() >= time + 100000
+
+
+def test_does_not_undo_mining(accounts, rpc, web3):
+    accounts[0].transfer(accounts[1], 100)
+    rpc.mine()
+    height = web3.eth.blockNumber
+    accounts[0].transfer(accounts[1], 100)
+    rpc.undo()
+    assert web3.eth.blockNumber == height


### PR DESCRIPTION
### What I did
Ensure `rpc.undo` and `rpc.redo` revert to immediately before a transaction is made.

### How I did it
Update the current snapshot after calls to `rpc.sleep` or `rpc.mine`.

### How to verify it
Run tests. I added some new cases.
