### PR TITLE
Fix repeated alerts by using type instead of instanceof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Geth Traces depth reduced ([#562](https://github.com/iamdefinitelyahuman/brownie/pull/562))
 - Ganache gasCost in traces (ganache bug) ([#562](https://github.com/iamdefinitelyahuman/brownie/pull/562))
 - Decoding error when contracts use the same event signature with different argument indexing ([#575](https://github.com/iamdefinitelyahuman/brownie/pull/575))
+- Repeated alerts will now run indefinitely, instead of twice
 
 ## [1.8.9](https://github.com/iamdefinitelyahuman/brownie/tree/v1.8.9) - 2020-05-26
 ### Changed

--- a/brownie/network/alert.py
+++ b/brownie/network/alert.py
@@ -90,7 +90,7 @@ class Alert:
                 start_value = value
                 if not repeat:
                     repeat = None
-                elif type(repeat) == int:
+                elif isinstance(repeat, int) and not isinstance(repeat, bool):
                     repeat -= 1
         finally:
             _instances.discard(self)

--- a/brownie/network/alert.py
+++ b/brownie/network/alert.py
@@ -25,6 +25,7 @@ class Alert:
         callback: Callable = None,
         repeat: bool = False,
     ) -> None:
+
         """Creates a new Alert.
 
         Args:
@@ -68,7 +69,7 @@ class Alert:
         delay: float,
         msg: str,
         callback: Callable,
-        repeat: Union[int, bool, None]=False,
+        repeat: Union[int, bool, None] = False,
     ) -> None:
         try:
             sleep = min(delay, 0.05)

--- a/brownie/network/alert.py
+++ b/brownie/network/alert.py
@@ -25,7 +25,6 @@ class Alert:
         callback: Callable = None,
         repeat: bool = False,
     ) -> None:
-
         """Creates a new Alert.
 
         Args:
@@ -69,7 +68,7 @@ class Alert:
         delay: float,
         msg: str,
         callback: Callable,
-        repeat: Union[int, bool, None] = False,
+        repeat: Union[int, bool, None]=False,
     ) -> None:
         try:
             sleep = min(delay, 0.05)
@@ -90,7 +89,7 @@ class Alert:
                 start_value = value
                 if not repeat:
                     repeat = None
-                elif isinstance(repeat, int):
+                elif type(repeat) == int:
                     repeat -= 1
         finally:
             _instances.discard(self)


### PR DESCRIPTION
### What I did

Fix repeated alerts

### How I did it

Used `type` instead of `instanceof`, because `bool` is a subclass of `int` in python. 

### How to verify it

It's a small change. Also automated tests should pickup if this is broken. 

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [✅] I have added an entry to the changelog
