### PR TITLE
fix: return actual call during call-as-tx

### DIFF
--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -1062,10 +1062,12 @@ class ContractCall(_ContractMethod):
         args, tx = _get_tx(self._owner, args)
         tx.update({"gas_price": 0, "from": self._owner or accounts[0]})
         try:
-            tx = self.transact(*args, tx)
-            return tx.return_value
-        finally:
-            rpc.undo()
+            self.transact(*args, tx)
+        except Exception:
+            pass
+
+        rpc.undo()
+        return self.call(*args)
 
 
 def _get_tx(owner: Optional[AccountsType], args: Tuple) -> Tuple:


### PR DESCRIPTION
### What I did
When coverage evaluation is active, return the actual result of `eth_call`, rather than `tx.return_value`

This fixes an edge case where if `rpc.sleep` was called after the last transaction, and the call relies on `block.timestamp`, the act of performing a transaction can alter the result.

### How to verify it
Run tests.
