### PR TITLE
pytest exit status

### DIFF
--- a/brownie/_cli/test.py
+++ b/brownie/_cli/test.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python3
 
+import sys
+
 import pytest
 
 from brownie import project
@@ -58,4 +60,8 @@ def main():
         elif isinstance(value, str):
             pytest_args.extend([opt, value])
 
-    pytest.main(pytest_args, ["pytest-brownie"])
+    return_code = pytest.main(pytest_args, ["pytest-brownie"])
+
+    if return_code:
+        # only exit with non-zero status to make testing easier
+        sys.exit(return_code)

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -23,7 +23,7 @@ class CliTester:
         self.mocker = mocker
 
     def mock_subroutines(self, *args, **kwargs):
-        return True
+        return
 
     def run_and_test_parameters(self, argv=None, parameters={}):
         sys.argv = ["brownie"]


### PR DESCRIPTION
### What I did
Fix a bug where `brownie test` always exitted with a zero status, even when tests failed :astonished: 

### How I did it
Catch the return code from `pytest.main` and exit with it.

### How to verify it
failing - https://github.com/iamdefinitelyahuman/token-mix/runs/747035738?check_suite_focus=true
passing - https://github.com/iamdefinitelyahuman/token-mix/runs/747061341?check_suite_focus=true