### PR TITLE
delete `required_confs` prior to making a call

### DIFF
--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -919,7 +919,9 @@ class _ContractMethod:
         args, tx = _get_tx(self._owner, args)
         if tx["from"]:
             tx["from"] = str(tx["from"])
+        del tx["required_confs"]
         tx.update({"to": self._address, "data": self.encode_input(*args)})
+
         try:
             data = web3.eth.call({k: v for k, v in tx.items() if v}, block_identifier)
         except ValueError as e:


### PR DESCRIPTION
### What I did
Delete `required_confs` prior to making a call. This fixes an issue when making calls  with Parity (and i'm confused why Geth doesn't raise on this, frankly).

### How to verify it
Run tests. Connect to kovan and see that you can make a call.
