### PR TITLE
Pytest reports

### DIFF
--- a/brownie/_cli/run.py
+++ b/brownie/_cli/run.py
@@ -8,7 +8,7 @@ from brownie._cli.console import Console
 from brownie._config import CONFIG, _update_argv_from_docopt
 from brownie.exceptions import ProjectNotFound
 from brownie.project.scripts import _get_path, run
-from brownie.test.output import _print_gas_profile
+from brownie.test.output import _build_gas_profile_output
 from brownie.utils import color
 from brownie.utils.docopt import docopt
 
@@ -63,4 +63,6 @@ def main():
                 )
 
     if CONFIG.argv["gas"]:
-        _print_gas_profile()
+        print("\n======= Gas profile =======")
+        for line in _build_gas_profile_output():
+            print(line)

--- a/tests/test/plugin/test_output.py
+++ b/tests/test/plugin/test_output.py
@@ -16,23 +16,23 @@ def test_stuff(BrownieTester, EVMTester, accounts):
 
 
 def test_print_gas(plugintester, mocker):
-    mocker.spy(output, "_print_gas_profile")
+    mocker.spy(output, "_build_gas_profile_output")
     plugintester.runpytest("--gas")
-    assert output._print_gas_profile.call_count == 1
+    assert output._build_gas_profile_output.call_count == 1
     plugintester.runpytest()
-    assert output._print_gas_profile.call_count == 1
+    assert output._build_gas_profile_output.call_count == 1
     plugintester.runpytest("-G")
-    assert output._print_gas_profile.call_count == 2
+    assert output._build_gas_profile_output.call_count == 2
 
 
 def test_print_coverage(plugintester, mocker):
-    mocker.spy(output, "_print_coverage_totals")
+    mocker.spy(output, "_build_coverage_output")
     plugintester.runpytest("--coverage")
-    assert output._print_coverage_totals.call_count == 1
+    assert output._build_coverage_output.call_count == 1
     plugintester.runpytest()
-    assert output._print_coverage_totals.call_count == 1
+    assert output._build_coverage_output.call_count == 1
     plugintester.runpytest("-C")
-    assert output._print_coverage_totals.call_count == 2
+    assert output._build_coverage_output.call_count == 2
 
 
 def test_coverage_save_report(plugintester):


### PR DESCRIPTION
### What I did
Adjust how coverage and gas reports are handled in `pytest`.

This fixes an issue where windows systems don't properly display the ANSI escape sequences, and generally improves the formatting of the output.

### How to verify it
Run the tests.
