### PR TITLE
Fix warnings

### DIFF
--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -112,7 +112,7 @@ class Accounts(metaclass=_Singleton):
         if w3account.address in self._accounts:
             return self.at(w3account.address)
 
-        account = LocalAccount(w3account.address, w3account, w3account.privateKey)
+        account = LocalAccount(w3account.address, w3account, w3account.key)
         self._accounts.append(account)
 
         return account
@@ -139,7 +139,7 @@ class Accounts(metaclass=_Singleton):
                 mnemonic, account_path=f"m/44'/60'/0'/0/{i}"
             )
 
-            account = LocalAccount(w3account.address, w3account, w3account.privateKey)
+            account = LocalAccount(w3account.address, w3account, w3account.key)
             new_accounts.append(account)
             if account not in self._accounts:
                 self._accounts.append(account)

--- a/brownie/network/web3.py
+++ b/brownie/network/web3.py
@@ -50,7 +50,7 @@ class Web3(_Web3):
 
         if self.provider is None:
             if uri.startswith("ws"):
-                self.provider = WebsocketProvider(uri, {"timeout": timeout})
+                self.provider = WebsocketProvider(uri, {"close_timeout": timeout})
             elif uri.startswith("http"):
 
                 self.provider = HTTPProvider(uri, {"timeout": timeout})

--- a/brownie/project/ethpm.py
+++ b/brownie/project/ethpm.py
@@ -619,7 +619,7 @@ def release_package(
         uri: IPFS uri of the package
     """
 
-    registry = network.contract.Contract(
+    registry = network.contract.Contract.from_abi(
         "ERC1319Registry", registry_address, REGISTRY_ABI, owner=account
     )
     verify_manifest(package_name, version, uri)

--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -322,7 +322,7 @@ class Project(_ProjectBase):
             if "pcMap" in build:
                 contract = ProjectContract(self, build, build_json.stem)
             else:
-                contract = Contract(  # type: ignore
+                contract = Contract.from_abi(  # type: ignore
                     contract_name, build_json.stem, build["abi"]
                 )
                 contract._project = self

--- a/tests/network/contract/test_contract.py
+++ b/tests/network/contract/test_contract.py
@@ -6,7 +6,7 @@ import pytest
 import requests
 
 from brownie import Wei
-from brownie.exceptions import ContractNotFound
+from brownie.exceptions import BrownieCompilerWarning, ContractNotFound
 from brownie.network.contract import (
     Contract,
     ContractCall,
@@ -109,13 +109,17 @@ def test_contract_from_ethpm_no_deployments(ipfs_mock, network):
 
 
 def test_deprecated_init_abi(tester):
-    old = Contract("BrownieTester", tester.address, tester.abi)
+    with pytest.warns(DeprecationWarning):
+        old = Contract("BrownieTester", tester.address, tester.abi)
+
     assert old == Contract.from_abi("BrownieTester", tester.address, tester.abi)
 
 
 def test_deprecated_init_ethpm(ipfs_mock, network):
     network.connect("ropsten")
-    old = Contract("ComplexNothing", manifest_uri="ipfs://testipfs-complex")
+
+    with pytest.warns(DeprecationWarning):
+        old = Contract("ComplexNothing", manifest_uri="ipfs://testipfs-complex")
 
     assert old == Contract.from_ethpm("ComplexNothing", manifest_uri="ipfs://testipfs-complex")
 
@@ -132,7 +136,9 @@ def test_from_explorer(network):
 def test_from_explorer_only_abi(network):
     network.connect("mainnet")
     # uniswap DAI market - ABI is available but source is not
-    contract = Contract.from_explorer("0x2a1530C4C41db0B0b2bB646CB5Eb1A67b7158667")
+    with pytest.warns(BrownieCompilerWarning):
+        contract = Contract.from_explorer("0x2a1530C4C41db0B0b2bB646CB5Eb1A67b7158667")
+
     assert contract._name == "UnknownContractName"
     assert "pcMap" not in contract._build
 
@@ -141,7 +147,8 @@ def test_from_explorer_pre_422(network):
     network.connect("mainnet")
 
     # MKR, compiler version 0.4.18
-    contract = Contract.from_explorer("0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2")
+    with pytest.warns(BrownieCompilerWarning):
+        contract = Contract.from_explorer("0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2")
     assert contract._name == "DSToken"
     assert "pcMap" not in contract._build
 
@@ -153,13 +160,15 @@ def test_from_explorer_osx_pre_050(network, monkeypatch):
     monkeypatch.setattr("solcx.get_installed_solc_versions", lambda: installed)
 
     # chainlink, compiler version 0.4.24
-    contract = Contract.from_explorer("0xf79d6afbb6da890132f9d7c355e3015f15f3406f")
+    with pytest.warns(BrownieCompilerWarning):
+        contract = Contract.from_explorer("0xf79d6afbb6da890132f9d7c355e3015f15f3406f")
     assert "pcMap" not in contract._build
 
 
 def test_from_explorer_vyper(network):
     network.connect("mainnet")
-    contract = Contract.from_explorer("0x2157a7894439191e520825fe9399ab8655e0f708")
+    with pytest.warns(BrownieCompilerWarning):
+        contract = Contract.from_explorer("0x2157a7894439191e520825fe9399ab8655e0f708")
 
     assert contract._name == "Vyper_contract"
     assert "pcMap" not in contract._build
@@ -173,14 +182,16 @@ def test_from_explorer_unverified(network):
 
 def test_from_explorer_etc(network):
     network.connect("etc")
-    contract = Contract.from_explorer("0x085b0fdf115aa9e16ae1bddd396ce1f993c52220")
+    with pytest.warns(BrownieCompilerWarning):
+        contract = Contract.from_explorer("0x085b0fdf115aa9e16ae1bddd396ce1f993c52220")
 
     assert contract._name == "ONEX"
 
 
 def test_retrieve_existing(network):
     network.connect("mainnet")
-    new = Contract.from_explorer("0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2")
+    with pytest.warns(BrownieCompilerWarning):
+        new = Contract.from_explorer("0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2")
 
     existing = Contract("0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2")
     assert new == existing
@@ -189,7 +200,8 @@ def test_retrieve_existing(network):
 @pytest.mark.xfail(reason="Infura rate limiting - the test suite needs a refactor", strict=False)
 def test_existing_different_chains(network):
     network.connect("mainnet")
-    Contract.from_explorer("0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2")
+    with pytest.warns(BrownieCompilerWarning):
+        Contract.from_explorer("0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2")
 
     network.disconnect()
     network.connect("ropsten")
@@ -199,7 +211,8 @@ def test_existing_different_chains(network):
 
 def test_alias(network):
     network.connect("mainnet")
-    contract = Contract.from_explorer("0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2")
+    with pytest.warns(BrownieCompilerWarning):
+        contract = Contract.from_explorer("0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2")
 
     contract.set_alias("testalias")
 
@@ -222,8 +235,10 @@ def test_alias_not_exists(network):
 
 def test_duplicate_alias(network):
     network.connect("mainnet")
+
     foo = Contract.from_explorer("0x2af5d2ad76741191d15dfe7bf6ac92d4bd912ca3")
-    bar = Contract.from_explorer("0x2157a7894439191e520825fe9399ab8655e0f708")
+    with pytest.warns(BrownieCompilerWarning):
+        bar = Contract.from_explorer("0x2157a7894439191e520825fe9399ab8655e0f708")
 
     foo.set_alias("foo")
     with pytest.raises(ValueError):


### PR DESCRIPTION
### What I did
* use `pytest.warns` to handle expected warnings within the test suite
* update deprecated API references to `eth_account` and `websockets`

### How to verify it
Check that the CI shows no warnings.
