### PR TITLE
Filter reports by source path or contract name

### DIFF
--- a/brownie/data/default-config.yaml
+++ b/brownie/data/default-config.yaml
@@ -42,6 +42,10 @@ console:
     auto_suggest: true
     completions: true
 
+reports:
+    exclude_paths: null
+    exclude_contracts: null
+
 hypothesis:
     deadline: null
     max_examples: 50

--- a/brownie/exceptions.py
+++ b/brownie/exceptions.py
@@ -187,3 +187,7 @@ class InvalidArgumentWarning(BrownieEnvironmentWarning):
 
 class BrownieTestWarning(Warning):
     pass
+
+
+class BrownieConfigWarning(Warning):
+    pass

--- a/brownie/test/managers/base.py
+++ b/brownie/test/managers/base.py
@@ -237,7 +237,7 @@ class PytestBrownieBase:
 
             # output coverage report to console
             coverage_eval = coverage.get_merged_coverage_eval()
-            for line in output._build_coverage_output(self.project._build, coverage_eval):
+            for line in output._build_coverage_output(coverage_eval):
                 terminalreporter.write_line(line)
 
             # save coverage report as `reports/coverage.json`

--- a/brownie/test/output.py
+++ b/brownie/test/output.py
@@ -1,9 +1,11 @@
 #!/usr/bin/python3
 
 import json
+import warnings
 from pathlib import Path
 
 from brownie._config import CONFIG
+from brownie.exceptions import BrownieConfigWarning
 from brownie.network.state import TxHistory
 from brownie.project import get_loaded_projects
 from brownie.utils import color
@@ -43,8 +45,10 @@ def _load_report_exclude_data(settings):
             try:
                 exclude_paths.extend([i.as_posix() for i in base_path.glob(glob_str)])
             except Exception:
-                # TODO
-                pass
+                warnings.warn(
+                    "Invalid glob pattern in config exclude settings: '{glob_str}'",
+                    BrownieConfigWarning,
+                )
 
     exclude_contracts = []
     if settings["exclude_contracts"]:

--- a/brownie/test/output.py
+++ b/brownie/test/output.py
@@ -111,7 +111,7 @@ def _build_gas_profile_output():
     return lines + [""]
 
 
-def _build_coverage_output(build, coverage_eval):
+def _build_coverage_output(coverage_eval):
     # Formats a coverage evaluation report that may be printed to the console
 
     exclude_paths, exclude_contracts = _load_report_exclude_data(CONFIG.settings["reports"])

--- a/brownie/test/output.py
+++ b/brownie/test/output.py
@@ -118,10 +118,15 @@ def _build_coverage_output(build, coverage_eval):
                 f"\n  contract: {color('bright magenta')}{contract_name}{color}"
                 f" - {_cov_color(pct)}{pct:.1%}{color}"
             )
+
             cov = totals[contract_name]
-            for fn_name, count in cov["statements"].items():
-                branch = cov["branches"][fn_name] if fn_name in cov["branches"] else (0, 0, 0)
-                pct = _pct(count, branch)
+            results = []
+            for fn_name, statement_cov in cov["statements"].items():
+                branch_cov = cov["branches"][fn_name] if fn_name in cov["branches"] else (0, 0, 0)
+                pct = _pct(statement_cov, branch_cov)
+                results.append((fn_name, pct))
+
+            for fn_name, pct in sorted(results, key=lambda k: (-k[1], k[0])):
                 lines.append(f"    {fn_name} - {_cov_color(pct)}{pct:.1%}{color}")
 
     return lines

--- a/brownie/test/output.py
+++ b/brownie/test/output.py
@@ -77,8 +77,11 @@ def _build_gas_profile_output():
     for full_name, values in sorted_gas:
         contract, function = full_name.split(".", 1)
 
-        if project and project._sources.get_source_path(contract) in exclude_paths:
-            continue
+        try:
+            if project._sources.get_source_path(contract) in exclude_paths:
+                continue
+        except (AttributeError, KeyError):
+            pass
         if contract in exclude_contracts:
             continue
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -206,6 +206,39 @@ Console
 
     default value: ``true``
 
+.. _config-reports:
+
+Reports
+-------
+
+Settings related to reports such as coverage data and gas profiles.
+
+.. py:attribute:: exclude_paths
+
+    Paths or `glob patterns <https://en.wikipedia.org/wiki/Glob_%28programming%29>`_ of source files to be excluded from report data.
+
+    default value: ``null``
+
+    .. code-block:: yaml
+
+        reports:
+            exclude_sources:
+                - contracts/mocks/**/*.*
+                - contracts/SafeMath.sol
+
+.. py:attribute:: exclude_contracts
+
+    Contract names to be excluded from report data.
+
+    default value: ``null``
+
+    .. code-block:: yaml
+
+        reports:
+            exclude_contracts:
+                - SafeMath
+                - Owned
+
 .. _config-hypothesis:
 
 Hypothesis

--- a/docs/tests-pytest-intro.rst
+++ b/docs/tests-pytest-intro.rst
@@ -379,8 +379,6 @@ Once you are finished, type ``quit()`` to continue with the next test.
 
 See :ref:`Inspecting and Debugging Transactions <core-transactions>` for more information on Brownie's debugging functionality.
 
-
-
 Evaluating Gas Usage
 --------------------
 
@@ -403,9 +401,6 @@ When the tests complete, a report will display:
            ├─ constructor   -  avg:  211445  low:  211445  high:  211445
            └─ set           -  avg:   21658  low:   21658  high:   21658
 
-
-
-
 Evaluating Coverage
 -------------------
 
@@ -419,25 +414,21 @@ When the tests complete, a report will display:
 
 ::
 
-    Coverage analysis:
-
-      contract: Token - 82.3%
-        SafeMath.add - 66.7%
-        SafeMath.sub - 100.0%
-        Token.<fallback> - 0.0%
-        Token.allowance - 100.0%
-        Token.approve - 100.0%
-        Token.balanceOf - 100.0%
-        Token.decimals - 0.0%
-        Token.name - 100.0%
-        Token.symbol - 0.0%
-        Token.totalSupply - 100.0%
-        Token.transfer - 85.7%
-        Token.transferFrom - 100.0%
+    contract: Token - 80.8%
+      Token.allowance - 100.0%
+      Token.approve - 100.0%
+      Token.balanceOf - 100.0%
+      Token.transfer - 100.0%
+      Token.transferFrom - 100.0%
+      SafeMath.add - 75.0%
+      SafeMath.sub - 75.0%
+      Token.<fallback> - 0.0%
 
     Coverage report saved at reports/coverage.json
 
 Brownie outputs a % score for each contract method that you can use to quickly gauge your overall coverage level. A detailed coverage report is also saved in the project's ``reports`` folder, that can be viewed via the Brownie GUI. See :ref:`coverage-gui` for more information.
+
+You can exclude specific contracts or source files from this report by modifying your project's :ref:`configuration file <config-reports>`.
 
 .. _xdist:
 

--- a/tests/test/test_report_output.py
+++ b/tests/test/test_report_output.py
@@ -1,0 +1,67 @@
+import pytest
+
+from brownie.exceptions import BrownieConfigWarning
+from brownie.test import coverage
+from brownie.test.output import _build_coverage_output, _build_gas_profile_output
+
+
+def test_exclude_gas(tester, ext_tester, config):
+    tester.useSafeMath(5, 10)
+    ext_tester.makeExternalCall(tester, 5)
+
+    report = _build_gas_profile_output()
+
+    config.settings["reports"]["exclude_contracts"] = "ExternalCallTester"
+    assert _build_gas_profile_output() != report
+
+
+def test_exclude_gas_as_list(tester, ext_tester, config):
+    tester.useSafeMath(5, 10)
+    ext_tester.makeExternalCall(tester, 5)
+
+    report = _build_gas_profile_output()
+
+    config.settings["reports"]["exclude_contracts"] = ["ExternalCallTester"]
+    assert _build_gas_profile_output() != report
+
+
+def test_exclude_gas_internal_calls_no_effect(tester, ext_tester, config):
+    tester.useSafeMath(5, 10)
+    ext_tester.makeExternalCall(tester, 5)
+
+    report = _build_gas_profile_output()
+
+    config.settings["reports"]["exclude_contracts"] = "SafeMath"
+    assert _build_gas_profile_output() == report
+
+
+def test_exclude_coverage(coverage_mode, tester, config):
+    tester.useSafeMath(5, 10)
+
+    coverage_eval = coverage.get_merged_coverage_eval()
+    report = _build_coverage_output(coverage_eval)
+    assert _build_coverage_output(coverage_eval) == report
+
+    config.settings["reports"]["exclude_contracts"] = "SafeMath"
+    assert _build_coverage_output(coverage_eval) != report
+
+
+def test_exclude_coverage_by_glob(coverage_mode, tester, vypertester, config):
+    tester.useSafeMath(5, 10)
+    vypertester.overflow(1, 2)
+
+    coverage_eval = coverage.get_merged_coverage_eval()
+    report = _build_coverage_output(coverage_eval)
+    assert _build_coverage_output(coverage_eval) == report
+
+    config.settings["reports"]["exclude_paths"] = "contracts/*.vy"
+    assert _build_coverage_output(coverage_eval) != report
+
+
+def test_invalid_glob_warns(tester, ext_tester, config):
+    tester.useSafeMath(5, 10)
+    ext_tester.makeExternalCall(tester, 5)
+
+    config.settings["reports"]["exclude_paths"] = "/contracts"
+    with pytest.warns(BrownieConfigWarning):
+        _build_gas_profile_output()


### PR DESCRIPTION
### What I did
Allow filtering of report data based on source path or contract name.

Closes #195 

### How I did it
Add a `reports` section to the config. See the updates to the documentation in the diff for an explanation of how it works.

### How to verify it
Run tests. I added some new test cases to verify the behavior.
