### PR TITLE
Filter fixtures from namespace during interactive debugging

### DIFF
--- a/brownie/test/managers/runner.py
+++ b/brownie/test/managers/runner.py
@@ -346,9 +346,12 @@ class PytestBrownieRunner(PytestBrownieBase):
             globals_dict = {k: v for k, v in globals_dict.items() if not k.startswith("__")}
             globals_dict = {k: v for k, v in globals_dict.items() if not k.startswith("@")}
 
-            # filter test functions
+            # filter test functions and fixtures
             test_names = self.node_map[location]
             globals_dict = {k: v for k, v in globals_dict.items() if k not in test_names}
+            globals_dict = {
+                k: v for k, v in globals_dict.items() if not hasattr(v, "_pytestfixturefunction")
+            }
 
             # get local namespace
             locals_dict = traceback.locals


### PR DESCRIPTION
### What I did
Filter fixtures from namespace when using `--interactive` flag with pytest.

### How I did it
When building namespace from globals, do not include objects that have a `_pytestfixturefunction` member.

### How to verify it
Debug something interactively.
