### PR TITLE
Update .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,12 +2,12 @@ repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.3.0
     hooks:
-    -   id: check-yaml
+    -   id: check-yaml    
 -   repo: https://github.com/psf/black
-    rev: 19.3b0
+    rev: 19.10b0
     hooks:
       - id: black
-        name: fmt
+        name: fmt        
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.4.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     rev: 19.10b0
     hooks:
       - id: black
-        name: fmt        
+        name: black        
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.4.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,29 +1,35 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v3.1.0
     hooks:
-    -   id: check-yaml    
--   repo: https://github.com/psf/black
-    rev: 19.10b0
-    hooks:
-      - id: black
-        name: black        
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
-    hooks:
-    -   id: flake8
--   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.720
-    hooks:
-    -   id: mypy
+    -   id: check-yaml
+
 -   repo: https://github.com/asottile/seed-isort-config
-    rev: v1.9.2
+    rev: v2.2.0
     hooks:
     -   id: seed-isort-config
+
 -   repo: https://github.com/pre-commit/mirrors-isort
     rev: v4.3.21
     hooks:
       - id: isort
+
+-   repo: https://github.com/psf/black
+    rev: 19.10b0
+    hooks:
+      - id: black
+        name: black
+
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.3
+    hooks:
+    -   id: flake8
+
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.720
+    hooks:
+    -   id: mypy
+
 
 default_language_version:
     python: python3.7

--- a/brownie/__init__.py
+++ b/brownie/__init__.py
@@ -1,10 +1,14 @@
 #!/usr/bin/python3
 
+"""
+isort:skip_file
+"""
+from brownie.project import compile_source, run
 from brownie._config import CONFIG as _CONFIG
 from brownie.convert import Fixed, Wei
-from brownie.project import compile_source, run
 from brownie.network import accounts, alert, history, rpc, web3
 from brownie.network.contract import Contract  # NOQA: F401
+
 
 config = _CONFIG.settings
 

--- a/brownie/_cli/pm.py
+++ b/brownie/_cli/pm.py
@@ -74,7 +74,7 @@ def _clone(package_id, path_str="."):
     dest_path = Path(path_str)
     if dest_path.exists():
         if not dest_path.is_dir():
-            raise FileExistsError(f"Destination path already exists")
+            raise FileExistsError("Destination path already exists")
         dest_path = dest_path.joinpath(package_id)
     shutil.copytree(source_path, dest_path)
     notify("SUCCESS", f"Package '{_format_pkg(org, repo, version)}' was cloned at {dest_path}")

--- a/brownie/_cli/run.py
+++ b/brownie/_cli/run.py
@@ -59,7 +59,7 @@ def main():
 
                 shell = Console(active_project, {**globals_dict, **frame.f_locals})
                 shell.interact(
-                    banner=f"\nInteractive mode enabled. Use quit() to close.", exitmsg=""
+                    banner="\nInteractive mode enabled. Use quit() to close.", exitmsg=""
                 )
 
     if CONFIG.argv["gas"]:

--- a/brownie/_gui/opcodes.py
+++ b/brownie/_gui/opcodes.py
@@ -104,7 +104,7 @@ class OpcodeList(ttk.Treeview):
             if targets:
                 console.append(f"\nJumps: {', '.join(targets)}")
             else:
-                console.append(f"\nJumps: None")
+                console.append("\nJumps: None")
             for item in targets:
                 self.tag_configure(item, foreground="#00ff00")
                 self._last.add(item)

--- a/brownie/convert/datatypes.py
+++ b/brownie/convert/datatypes.py
@@ -175,7 +175,8 @@ class Fixed(Decimal):
 def _to_fixed(value: Any) -> Decimal:
     if isinstance(value, float):
         raise TypeError("Cannot convert float to decimal - use a string instead")
-    elif isinstance(value, (str, bytes)):
+
+    if isinstance(value, (str, bytes)):
         try:
             value = Wei(value)
         except TypeError:

--- a/brownie/network/state.py
+++ b/brownie/network/state.py
@@ -15,7 +15,7 @@ from .web3 import _resolve_address
 
 _contract_map: Dict = {}
 
-cur = Cursor(_get_data_folder().joinpath(f"deployments.db"))
+cur = Cursor(_get_data_folder().joinpath("deployments.db"))
 cur.execute("CREATE TABLE IF NOT EXISTS sources (hash PRIMARY KEY, source)")
 
 

--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -453,7 +453,7 @@ class Project(_ProjectBase):
             pass
 
     def _clear_dev_deployments(self, height: int) -> None:
-        path = self._build_path.joinpath(f"deployments/dev")
+        path = self._build_path.joinpath("deployments/dev")
         if path.exists():
             deployment_map = self._load_deployment_map()
             for deployment in path.glob("*.json"):
@@ -718,7 +718,7 @@ def _install_from_github(package_id: str) -> str:
             "\ne.g. 'OpenZeppelin/openzeppelin-contracts@v2.5.0'"
         ) from None
 
-    base_install_path = _get_data_folder().joinpath(f"packages")
+    base_install_path = _get_data_folder().joinpath("packages")
     install_path = base_install_path.joinpath(f"{org}")
     install_path.mkdir(exist_ok=True)
     install_path = install_path.joinpath(f"{repo}@{version}")

--- a/brownie/project/sources.py
+++ b/brownie/project/sources.py
@@ -49,7 +49,7 @@ class Sources:
 
         if collisions:
             raise NamespaceCollision(
-                f"Multiple contracts or interfaces with the same name\n  "
+                "Multiple contracts or interfaces with the same name\n  "
                 + "\n  ".join(f"{k}: {', '.join(sorted(v))}" for k, v in collisions.items())
             )
 
@@ -202,4 +202,4 @@ def get_pragma_spec(source: str, path: Optional[str] = None) -> NpmSpec:
         return NpmSpec(pragma_string)
     if path:
         raise PragmaError(f"No version pragma in '{path}'")
-    raise PragmaError(f"String does not contain a version pragma")
+    raise PragmaError("String does not contain a version pragma")

--- a/brownie/test/managers/runner.py
+++ b/brownie/test/managers/runner.py
@@ -363,7 +363,7 @@ class PytestBrownieRunner(PytestBrownieBase):
                 CONFIG.argv["cli"] = "console"
                 shell = Console(self.project, extra_locals=namespace)
                 shell.interact(
-                    banner=f"\nInteractive mode enabled. Use quit() to continue running tests.",
+                    banner="\nInteractive mode enabled. Use quit() to continue running tests.",
                     exitmsg="",
                 )
             except SystemExit:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 black==19.10b0
 bumpversion==0.6.0
 coverage==5.1
-flake8==3.7.9
+flake8==3.8.3
 isort==4.3.21
 mypy==0.720
 pytest-cov==2.9.0

--- a/tests/convert/test_return_value.py
+++ b/tests/convert/test_return_value.py
@@ -12,13 +12,13 @@ def return_value(accounts, tester):
 
 
 def test_type(return_value):
-    assert type(return_value) is ReturnValue
-    assert type(return_value["_addr"]) is EthAddress
-    assert type(return_value["_bool"]) is ReturnValue
-    assert type(return_value["_bool"][0]) is bool
-    assert type(return_value["_num"]) is Wei
-    assert type(return_value["_bytes"]) is ReturnValue
-    assert type(return_value["_bytes"][0][0]) is HexString
+    assert isinstance(return_value, ReturnValue)
+    assert isinstance(return_value["_addr"], EthAddress)
+    assert isinstance(return_value["_bool"], ReturnValue)
+    assert isinstance(return_value["_bool"][0], bool)
+    assert isinstance(return_value["_num"], Wei)
+    assert isinstance(return_value["_bytes"], ReturnValue)
+    assert isinstance(return_value["_bytes"][0][0], HexString)
 
 
 def test_len(return_value):
@@ -63,7 +63,7 @@ def test_eq_conversions(accounts, return_value):
 
 def test_dict(accounts, return_value):
     d = return_value.dict()
-    assert type(d) is dict
+    assert isinstance(d, dict)
     assert len(d) == 4
     assert len(d["_bool"]) == 3
     assert sorted(d) == ["_addr", "_bool", "_bytes", "_num"]
@@ -86,7 +86,7 @@ def test_getitem(accounts, return_value):
 def test_getitem_slice(accounts, return_value):
     s = return_value[1:3]
     assert s == [[False, False, False], accounts[2]]
-    assert type(s) is ReturnValue
+    assert isinstance(s, ReturnValue)
     assert s[0] == s["_bool"]
     assert "_num" not in s
 

--- a/tests/project/ethpm/test_create_manifest.py
+++ b/tests/project/ethpm/test_create_manifest.py
@@ -117,7 +117,7 @@ def test_contract_types(tp_path):
     assert "EVMTester" in manifest["contract_types"]
     assert manifest["contract_types"]["EVMTester"] == {
         "contract_name": "EVMTester",
-        "source_path": f"./EVMTester.sol",
+        "source_path": "./EVMTester.sol",
         "deployment_bytecode": {"bytecode": f"0x{build['bytecode']}"},
         "runtime_bytecode": {"bytecode": f"0x{build['deployedBytecode']}"},
         "abi": build["abi"],
@@ -280,7 +280,7 @@ def test_pin_and_get(dep_project):
     get = ethpm.get_manifest(uri)
 
     for key in list(process) + list(get):
-        if type(process[key]) is str:
+        if isinstance(process[key], str):
             assert process[key] == get[key]
             continue
         for k in list(process[key]) + list(get[key]):

--- a/tests/test/strategies/test_array.py
+++ b/tests/test/strategies/test_array.py
@@ -33,56 +33,56 @@ def test_size_wrong_length():
 
 @given(value=strategy("uint8[2][5]"))
 def test_given(value):
-    assert type(value) is list
+    assert isinstance(value, list)
     assert len(value) == 5
     for item in value:
-        assert type(item) is list
+        assert isinstance(item, list)
         assert len(item) == 2
-        assert type(item[0]) is int
+        assert isinstance(item[0], int)
         assert 0 <= item[0] <= 255
 
 
 @given(value=strategy("uint8[][]", min_length=2))
 def test_min_int(value):
-    assert type(value) is list
+    assert isinstance(value, list)
     assert 2 <= len(value) <= 8
     for item in value:
-        assert type(item) is list
+        assert isinstance(item, list)
         assert 2 <= len(item) <= 8
-        assert type(item[0]) is int
+        assert isinstance(item[0], int)
         assert 0 <= item[0] <= 255
 
 
 @given(value=strategy("uint8[][]", min_length=[4, 3]))
 def test_min_list(value):
-    assert type(value) is list
+    assert isinstance(value, list)
     assert 3 <= len(value) <= 8
     for item in value:
-        assert type(item) is list
+        assert isinstance(item, list)
         assert 4 <= len(item) <= 8
-        assert type(item[0]) is int
+        assert isinstance(item[0], int)
         assert 0 <= item[0] <= 255
 
 
 @given(value=strategy("uint8[][]", max_length=4))
 def test_max_int(value):
-    assert type(value) is list
+    assert isinstance(value, list)
     assert 1 <= len(value) <= 4
     for item in value:
-        assert type(item) is list
+        assert isinstance(item, list)
         assert 1 <= len(item) <= 4
-        assert type(item[0]) is int
+        assert isinstance(item[0], int)
         assert 0 <= item[0] <= 255
 
 
 @given(value=strategy("uint8[][]", max_length=[2, 4]))
 def test_max_list(value):
-    assert type(value) is list
+    assert isinstance(value, list)
     assert 1 <= len(value) <= 4
     for item in value:
-        assert type(item) is list
+        assert isinstance(item, list)
         assert 1 <= len(item) <= 2
-        assert type(item[0]) is int
+        assert isinstance(item[0], int)
         assert 0 <= item[0] <= 255
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ commands =
 [testenv:lint]
 deps =
     black==19.10b0
-    flake8==3.7.9
+    flake8==3.8.3
     isort==4.3.21
     mypy==0.720
 basepython=python3


### PR DESCRIPTION
### What I did

- Repo of `flake8` (https://gitlab.com/pycqa/flake8) is updated with most recent one, warning messages when I run `pre-commit run --all-files` told me to use `repo: https://gitlab.com/pycqa/flake8`.

- Name of `black`: is changed from `ftm` to `black`

- Based on this [docs](https://medium.com/staqu-dev-logs/keeping-python-code-clean-with-pre-commit-hooks-black-flake8-and-isort-cac8b01e0ea1) following pre-commit hooks pipeline is recommended:   
`isort => black => flake8` 
I didn't change it on the file but if you want you have to change the `- repo` orders as for the pipeline order.

- Fix unnecessary `f""` Using an f-string that does not have any interpolated
  variables [f-string-without-interpolation]

- Fix `type()` instead of isinstance() for a typecheck 

- Add new line before each repo for readibility on `.pre-commit-config.yaml`
  file