### PR TITLE
Feat unlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/iamdefinitelyahuman/brownie)
+### Added
+- Accounts can now be unlocked on development networks ([#633](https://github.com/eth-brownie/brownie/pull/633))
+
 
 ## [1.9.2](https://github.com/iamdefinitelyahuman/brownie/tree/v1.9.12) - 2020-06-08
 ### Added

--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -59,6 +59,19 @@ class Accounts(metaclass=_Singleton):
             self._accounts = [Account(i) for i in web3.eth.accounts]
         except Exception:
             pass
+
+        # Check if accounts were manually unlocked and add them
+        try:
+            unlocked_accounts = CONFIG.active_network["cmd_settings"]["unlock"]
+            if not isinstance(unlocked_accounts, list):
+                unlocked_accounts = [unlocked_accounts]
+            for address in unlocked_accounts:
+                if isinstance(address, int):
+                    address = HexBytes(address.to_bytes(20, "big")).hex()
+                self._accounts.append(Account(address))
+        except (ConnectionError, ValueError, KeyError):
+            pass
+
         if self.default not in self._accounts:
             self.default = None
 

--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -68,7 +68,9 @@ class Accounts(metaclass=_Singleton):
             for address in unlocked_accounts:
                 if isinstance(address, int):
                     address = HexBytes(address.to_bytes(20, "big")).hex()
-                self._accounts.append(Account(address))
+                account = Account(address)
+                if account not in self._accounts:
+                    self._accounts.append(account)
         except (ConnectionError, ValueError, KeyError):
             pass
 

--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -201,7 +201,7 @@ class Accounts(metaclass=_Singleton):
             )
         return self.add(priv_key)
 
-    def at(self, address: str) -> "LocalAccount":
+    def at(self, address: str, force: bool = False) -> "LocalAccount":
         """
         Retrieve an `Account` instance from the address string.
 
@@ -211,6 +211,8 @@ class Accounts(metaclass=_Singleton):
         ---------
         address: string
             Address of the account
+        force: bool
+            When True, will add the account even if it was not found in web3.eth.accounts
 
         Returns
         -------
@@ -219,7 +221,7 @@ class Accounts(metaclass=_Singleton):
         address = _resolve_address(address)
         acct = next((i for i in self._accounts if i == address), None)
 
-        if acct is None and address in web3.eth.accounts:
+        if acct is None and (address in web3.eth.accounts or force):
             acct = Account(address)
             self._accounts.append(acct)
 

--- a/brownie/network/rpc.py
+++ b/brownie/network/rpc.py
@@ -98,11 +98,11 @@ class Rpc(metaclass=_Singleton):
         for key, value in [(k, v) for k, v in kwargs.items() if v]:
             if key == "unlock":
                 if not isinstance(value, list):
-                    value: [value]  # type: ignore
+                    value = [value]  # type: ignore
                 for address in value:
                     if isinstance(address, int):
                         address = HexBytes(address.to_bytes(20, "big")).hex()
-                    cmd_list.extend([CLI_FLAGS[key], str(address)])
+                    cmd_list.extend([CLI_FLAGS[key], address])
             else:
                 try:
                     cmd_list.extend([CLI_FLAGS[key], str(value)])

--- a/brownie/network/rpc.py
+++ b/brownie/network/rpc.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import urlparse
 
 import psutil
+from hexbytes import HexBytes
 
 from brownie._config import EVM_EQUIVALENTS
 from brownie._singleton import _Singleton
@@ -37,6 +38,7 @@ CLI_FLAGS = {
     "block_time": "--blockTime",
     "default_balance": "--defaultBalanceEther",
     "time": "--time",
+    "unlock": "--unlock",
 }
 
 EVM_VERSIONS = ["byzantium", "constantinople", "petersburg", "istanbul"]
@@ -94,14 +96,22 @@ class Rpc(metaclass=_Singleton):
             kwargs["evm_version"] = EVM_EQUIVALENTS[kwargs["evm_version"]]  # type: ignore
         kwargs = _validate_cmd_settings(kwargs)
         for key, value in [(k, v) for k, v in kwargs.items() if v]:
-            try:
-                cmd_list.extend([CLI_FLAGS[key], str(value)])
-            except KeyError:
-                warnings.warn(
-                    f"Ignoring invalid commandline setting for ganache-cli: "
-                    f'"{key}" with value "{value}".',
-                    InvalidArgumentWarning,
-                )
+            if key == "unlock":
+                if not isinstance(value, list):
+                    value: [value]  # type: ignore
+                for address in value:
+                    if isinstance(address, int):
+                        address = HexBytes(address.to_bytes(20, "big")).hex()
+                    cmd_list.extend([CLI_FLAGS[key], str(address)])
+            else:
+                try:
+                    cmd_list.extend([CLI_FLAGS[key], str(value)])
+                except KeyError:
+                    warnings.warn(
+                        f"Ignoring invalid commandline setting for ganache-cli: "
+                        f'"{key}" with value "{value}".',
+                        InvalidArgumentWarning,
+                    )
         print(f"Launching '{' '.join(cmd_list)}'...")
         self._time_offset = 0
         self._snapshot_id = False

--- a/docs/account-management.rst
+++ b/docs/account-management.rst
@@ -75,3 +75,21 @@ In order to access a local account from a script or console, you must first unlo
     [<LocalAccount object '0xa9c2DD830DfFE8934fEb0A93BAbcb6e823e1FF05'>]
 
 Once the account is unlocked it will be available for use within the :func:`Accounts <brownie.network.account.Accounts>` container.
+
+Unlocking Accounts on Development Networks
+==========================================
+
+On a local or forked development network you can unlock and use any account, even if you don't have the corresponding private key.
+To do so, add the account to the ``unlock`` setting in a project's :ref:`configuration file<config>`:
+
+.. code-block:: yaml
+
+        networks:
+            development:
+                cmd_settings:
+                    unlock:
+                        - 0x7E1E3334130355799F833ffec2D731BCa3E68aF6
+                        - 0x0063046686E46Dc6F15918b61AE2B121458534a5
+
+The unlocked accounts are automatically added to the :func:`Accounts <brownie.network.account.Accounts>` container.
+Note that you might need to fund the unlocked accounts manually.

--- a/docs/api-network.rst
+++ b/docs/api-network.rst
@@ -153,9 +153,10 @@ Accounts Methods
         mnemonic: 'buffalo cinnamon glory chalk require inform strike ginger crop sell hidden cart'
         <LocalAccount '0xf293C5E0b22802Bf5DCef3FB8112EaA4cA54fcCF'>
 
-.. py:classmethod:: Accounts.at(address)
+.. py:classmethod:: Accounts.at(address, force=False)
 
     Given an address as a string, returns the corresponding :func:`Account <brownie.network.account.Account>` or :func:`LocalAccount <brownie.network.account.LocalAccount>` from the container.
+    If ``force=True``, returns and adds the account even if it is not found in the container. Use this if an account is unlocked by external means.
 
     .. code-block:: python
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -85,7 +85,7 @@ Networks
 
         Additional commandline parameters, which are passed into Ganache as commandline arguments. These settings will update the network specific settings defined in :ref:`network management<adding-network>` whenever the project with this configuration file is active.
 
-        The following example shows all commandline settings with their default value. ``fork`` has no default value and ``time`` will default to the current time. See :ref:`adding a development network<adding-network>` for more details on the arguments.
+        The following example shows all commandline settings with their default value. ``fork`` and ``unlock`` have no default values and ``time`` will default to the current time. See :ref:`adding a development network<adding-network>` for more details on the arguments.
 
     .. code-block:: yaml
 
@@ -100,11 +100,12 @@ Networks
                     gas_limit: 6721975
                     accounts: 10
                     evm_version: istanbul
-                    fork: None
+                    fork: null
                     mnemonic: brownie
                     block_time: 0
                     default_balance: 100
                     time: 2020-05-08T14:54:08+0000
+                    unlock: null
 
 .. py:attribute:: networks.live
 

--- a/docs/network-management.rst
+++ b/docs/network-management.rst
@@ -102,6 +102,7 @@ The following optional fields may be given for development networks, which are p
     * ``block_time``: The time waited between mining blocks. Defaults to instant mining.
     * ``default_balance``: The starting balance for all unlocked accounts. Can be given as unit string like "1000 ether" or "50 gwei" or as an number **in Ether**. Will default to 100 ether.
     * ``time``: Date (ISO 8601) that the first block should start. Use this feature, along with :func:`Rpc.sleep <Rpc.sleep>` to test time-dependent code. Defaults to the current time.
+    * ``unlock``: A single address or a list of addresses to unlock. These accounts are added to the :func:`Accounts <brownie.network.account.Accounts>` container and can be used as if the private key is known. Also works in combination with ``fork`` to send transactions from any account.
 
 .. note::
     These optional commandline fields can also be specified on a project level in the project's ``brownie-config.yaml`` file. See the :ref:`configuration files<config>`.

--- a/tests/project/test_brownie_config.py
+++ b/tests/project/test_brownie_config.py
@@ -28,6 +28,9 @@ def settings_proj(testproject):
                 accounts: 15
                 evm_version: byzantium
                 mnemonic: brownie2
+                unlock:
+                    - 0x16Fb96a5fa0427Af0C8F7cF1eB4870231c8154B6
+                    - "0x81431b69B1e0E334d4161A13C2955e0f3599381e"
     """
     with testproject._path.joinpath("brownie-config.yaml").open("w") as fp:
         yaml.dump(yaml.safe_load(test_brownie_config), fp)
@@ -72,11 +75,15 @@ def test_rpc_project_cmd_settings(devnetwork, testproject, config, settings_proj
     assert cmd_settings_proj["time"].timestamp() - devnetwork.rpc.time() < 60 * 60 * 25
 
     accounts = devnetwork.accounts
-    assert cmd_settings_proj["accounts"] == len(accounts)
+    assert cmd_settings_proj["accounts"] + len(cmd_settings_proj["unlock"]) == len(accounts)
     assert cmd_settings_proj["default_balance"] == accounts[0].balance()
 
     # Test if mnemonic was updated to "brownie2"
     assert "0x816200940a049ff1DEAB864d67a71ae6Dd1ebc3e" == accounts[0].address
+
+    # Test if unlocked accounts are added to the accounts object
+    assert "0x16Fb96a5fa0427Af0C8F7cF1eB4870231c8154B6" == accounts[-2].address
+    assert "0x81431b69B1e0E334d4161A13C2955e0f3599381e" == accounts[-1].address
 
     tx = accounts[0].transfer(accounts[1], 0)
     assert tx.gas_limit == settings_proj["gas_limit"]


### PR DESCRIPTION
### What I did

Added the `unlock` setting to the network config in development networks.
This will pass the unlocked accounts to `ganache-cli` and add them to the `accounts` object.

Closes #618

### How I did it
Added `unlock` field to the config file, accepts a single address or multiple addresses
When `Accounts._reset()` is called, add the unlocked accounts to the end of the list.

### How to verify it
I adjusted the tests

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [x] I have updated the documentation
- [x] I have added an entry to the changelog
