### PR TITLE
Basic line coverage xml and html reporting

### DIFF
--- a/brownie/test/cobertura.py
+++ b/brownie/test/cobertura.py
@@ -1,0 +1,174 @@
+import time
+from collections import defaultdict
+
+from lxml import etree
+
+
+def _make_cobertura_report(build, coverage_eval):
+    root = etree.Element("coverage")
+    root.set("complexity", "")
+    root.set("version", "1.9")
+    root.set("timestamp", str(int(time.time() * 1000)))
+    packages = etree.SubElement(root, "packages")
+
+    total_valid_lines = 0
+    total_lines_covered = 0
+
+    total_valid_branches = 0
+    total_branches_covered = 0
+
+    for contract_name in coverage_eval:
+        contract = build.get(contract_name)
+        coverage_map = contract["coverageMap"]
+
+        package = etree.SubElement(packages, "package")
+        package.set("name", contract_name)
+        package.set("complexity", "")
+
+        classes = etree.SubElement(package, "classes")
+
+        path_ids = set(
+            [k for k, v in coverage_map["statements"].items() if v]
+            + [k for k, v in coverage_map["branches"].items() if v]
+        )
+
+        package_valid_lines = 0
+        package_lines_covered = 0
+
+        package_valid_branches = 0
+        package_branches_covered = 0
+
+        for path_id in sorted(list(path_ids)):
+            filename = contract["allSourcePaths"][path_id]
+            if filename.startswith("/"):
+                continue
+
+            content = build._sources.get(filename).splitlines(True)
+            file_coverage = coverage_eval[contract_name].get(path_id, [set(), set(), set()])
+            line_coverage = _lines_to_coverage(coverage_map, path_id, file_coverage, content)
+
+            class_ = etree.SubElement(classes, "class")
+            class_.set("name", filename)
+            class_.set("filename", filename)
+            class_.set("complexity", "")
+
+            class_lines = etree.SubElement(class_, "lines")
+
+            class_valid_lines = 0
+            class_lines_covered = 0
+
+            class_valid_branches = 0
+            class_branches_covered = 0
+            for line_no in sorted(line_coverage):
+                line = etree.SubElement(class_lines, "line")
+                line.set("number", str(line_no))
+                class_valid_lines += 1
+                package_valid_lines += 1
+                total_valid_lines += 1
+                if line_coverage[line_no] is not None:
+                    line.set("hits", str(1))
+                    class_lines_covered += 1
+                    package_lines_covered += 1
+                    total_lines_covered += 1
+                    if line_coverage[line_no]:
+                        line.set("branch", "true")
+                        branches_covered = sum(line_coverage[line_no])
+                        valid_branches = len(line_coverage[line_no]) * 2
+                        class_valid_branches += valid_branches
+                        class_branches_covered += branches_covered
+                        package_valid_branches += valid_branches
+                        package_branches_covered += branches_covered
+                        total_valid_branches += valid_branches
+                        total_branches_covered += branches_covered
+                        pct = round((branches_covered / valid_branches) * 100)
+                        line.set(
+                            "condition-coverage", f"{pct}% ({branches_covered}/{valid_branches})"
+                        )
+                else:
+                    line.set("hits", str(0))
+
+            class_.set("line-rate", _rate(class_valid_lines, class_lines_covered))
+            class_.set("branch-rate", _rate(class_valid_branches, class_branches_covered))
+
+        package.set("line-rate", _rate(package_valid_lines, package_lines_covered))
+        package.set("branch-rate", _rate(package_valid_branches, package_branches_covered))
+
+    root.set("line-rate", _rate(total_valid_lines, total_lines_covered))
+    root.set("branch-rate", _rate(total_valid_branches, total_branches_covered))
+    root.set("lines-covered", str(total_lines_covered))
+    root.set("lines-valid", str(total_valid_lines))
+    root.set("branches-covered", str(total_branches_covered))
+    root.set("branches-valid", str(total_valid_branches))
+    return root
+
+
+def _rate(line_count, hit_count):
+    if line_count == 0:
+        return "1.0"
+    else:
+        return "{:.5}".format(hit_count / line_count)
+
+
+def _lines_to_coverage(coverage_map, path_id, file_coverage, content):
+    available_offsets = set()
+
+    for function in coverage_map["statements"][path_id].values():
+        for statement, [from_, to] in function.items():
+            available_offsets.update(range(from_, to))
+
+    for function in coverage_map["branches"][path_id].values():
+        for statement, [from_, to, _] in function.items():
+            available_offsets.update(range(from_, to))
+
+    statements = coverage_map["statements"][path_id]
+    branches = coverage_map["branches"][path_id]
+
+    flat_statements = {int(k): v for d in statements.values() for k, v in d.items()}
+    flat_branches = {int(k): [v[0], v[1]] for d in branches.values() for k, v in d.items()}
+    branch_coverage = defaultdict(int)
+
+    covered_offsets = set()
+    [covered_statements, covered_yes_branches, covered_no_branches] = file_coverage
+
+    for stmt in covered_statements:
+        covered_offsets.update(range(*flat_statements[stmt]))
+
+    for stmt in covered_yes_branches:
+        covered_offsets.update(range(*flat_branches[stmt]))
+        branch_coverage[stmt] += 1
+
+    for stmt in covered_no_branches:
+        covered_offsets.update(range(*flat_branches[stmt]))
+        branch_coverage[stmt] += 1
+
+    offset_branches = defaultdict(list)
+    for statements in branches.values():
+        for stmt, [from_, to, _] in statements.items():
+            offset_branches[from_].append(stmt)
+
+    branch_lines = {}
+    line_to_coverage = {}
+    from_ = 0
+    for n, line in enumerate(content):
+        to = from_ + len(line)
+        if set(range(from_, to)).intersection(available_offsets):
+            is_covered = bool(set(range(from_, to)).intersection(covered_offsets))
+            if is_covered:
+                line_to_coverage[n + 1] = []
+            else:
+                line_to_coverage[n + 1] = None
+        for offset, branches in list(offset_branches.items()):
+            if from_ <= offset < to:
+                for branch in branches:
+                    branch_lines[int(branch)] = n + 1
+                offset_branches.pop(offset)
+        from_ = to
+
+    for stmt, coverage in branch_coverage.items():
+        line = branch_lines[int(stmt)]
+        # nothing covers the line
+        if line_to_coverage[line] is None:
+            continue
+        line_to_coverage[line].append(coverage)
+
+    return line_to_coverage

--- a/brownie/test/output.py
+++ b/brownie/test/output.py
@@ -6,8 +6,6 @@ import time
 from collections import defaultdict
 from pathlib import Path
 from lxml import etree
-from pycobertura import Cobertura
-from pycobertura.reporters import HtmlReporter, TextReporter
 
 from brownie._config import CONFIG
 from brownie.exceptions import BrownieConfigWarning
@@ -118,17 +116,9 @@ def _save_coverage_report(build, coverage_eval, report_path):
         root.set("branches-valid", str(package_valid_branches))
 
         xml_path = report_path.parent.joinpath(f"{contract_name}-coverage.xml")
-        html_path = report_path.parent.joinpath(f"{contract_name}-coverage.html")
 
         with xml_path.open("wb") as fp:
             fp.write(etree.tostring(root, pretty_print=True))
-
-        cobertura = Cobertura(str(xml_path), source=".")
-
-        print(TextReporter(cobertura).generate())
-
-        with html_path.open("w") as fp:
-            fp.write(HtmlReporter(cobertura).generate())
 
     print(f"\nCoverage reports saved at {report_path} and {xml_path}")
     print("View the report using the Brownie GUI")

--- a/brownie/test/output.py
+++ b/brownie/test/output.py
@@ -17,21 +17,7 @@ from brownie.utils import color
 COVERAGE_COLORS = [(0.8, "bright red"), (0.9, "bright yellow"), (1, "bright green")]
 
 
-def _save_coverage_report(build, coverage_eval, report_path):
-    # Saves a test coverage report for viewing in the GUI
-    report = {
-        "highlights": _get_highlights(build, coverage_eval),
-        "coverage": _get_totals(build, coverage_eval),
-        "sha1": {},  # TODO
-    }
-    report = json.loads(json.dumps(report, default=sorted))
-    report_path = Path(report_path).absolute()
-    if report_path.is_dir():
-        report_path = report_path.joinpath("coverage.json")
-
-    with report_path.open("w") as fp:
-        json.dump(report, fp, sort_keys=True, indent=2)
-
+def _make_cobertura_report(build, coverage_eval):
     root = etree.Element("coverage")
     root.set("complexity", "")
     root.set("version", "1.9")
@@ -126,13 +112,30 @@ def _save_coverage_report(build, coverage_eval, report_path):
     root.set("lines-valid", str(total_valid_lines))
     root.set("branches-covered", str(total_branches_covered))
     root.set("branches-valid", str(total_valid_branches))
+    return root
 
-    xml_path = report_path.parent.joinpath("coverage.xml")
 
+def _save_coverage_report(build, coverage_eval, report_path):
+    report_dir = Path(report_path).absolute()
+
+    # Saves a test coverage report for viewing in the GUI
+    json_report = {
+        "highlights": _get_highlights(build, coverage_eval),
+        "coverage": _get_totals(build, coverage_eval),
+        "sha1": {},  # TODO
+    }
+    json_report = json.loads(json.dumps(json_report, default=sorted))
+    json_path = report_dir.joinpath("coverage.json")
+    with json_path.open("w") as fp:
+        json.dump(json_report, fp, sort_keys=True, indent=2)
+
+    # Saves a test coverage report for codecov.io
+    cobertura_report = _make_cobertura_report(build, coverage_eval)
+    xml_path = report_dir.joinpath("coverage.xml")
     with xml_path.open("wb") as fp:
-        fp.write(etree.tostring(root, pretty_print=True))
+        fp.write(etree.tostring(cobertura_report, pretty_print=True))
 
-    print(f"\nCoverage reports saved at {report_path} and {xml_path}")
+    print(f"\nCoverage reports saved at {json_path} and {xml_path}")
     print("View the report using the Brownie GUI")
     return report_path
 

--- a/brownie/test/output.py
+++ b/brownie/test/output.py
@@ -1,9 +1,7 @@
 #!/usr/bin/python3
 
 import json
-import time
 import warnings
-from collections import defaultdict
 from pathlib import Path
 
 from lxml import etree
@@ -12,107 +10,10 @@ from brownie._config import CONFIG
 from brownie.exceptions import BrownieConfigWarning
 from brownie.network.state import TxHistory
 from brownie.project import get_loaded_projects
+from brownie.test.cobertura import _make_cobertura_report
 from brownie.utils import color
 
 COVERAGE_COLORS = [(0.8, "bright red"), (0.9, "bright yellow"), (1, "bright green")]
-
-
-def _make_cobertura_report(build, coverage_eval):
-    root = etree.Element("coverage")
-    root.set("complexity", "")
-    root.set("version", "1.9")
-    root.set("timestamp", str(int(time.time() * 1000)))
-    packages = etree.SubElement(root, "packages")
-
-    total_valid_lines = 0
-    total_lines_covered = 0
-
-    total_valid_branches = 0
-    total_branches_covered = 0
-
-    for contract_name in coverage_eval:
-        contract = build.get(contract_name)
-        coverage_map = contract["coverageMap"]
-
-        package = etree.SubElement(packages, "package")
-        package.set("name", contract_name)
-        package.set("complexity", "")
-
-        classes = etree.SubElement(package, "classes")
-
-        path_ids = set(
-            [k for k, v in coverage_map["statements"].items() if v]
-            + [k for k, v in coverage_map["branches"].items() if v]
-        )
-
-        package_valid_lines = 0
-        package_lines_covered = 0
-
-        package_valid_branches = 0
-        package_branches_covered = 0
-
-        for path_id in sorted(list(path_ids)):
-            filename = contract["allSourcePaths"][path_id]
-            if filename.startswith("/"):
-                continue
-
-            content = open(filename).readlines()
-            file_coverage = coverage_eval[contract_name].get(path_id, [set(), set(), set()])
-            line_coverage = _lines_to_coverage(coverage_map, path_id, file_coverage, content)
-
-            class_ = etree.SubElement(classes, "class")
-            class_.set("name", filename)
-            class_.set("filename", filename)
-            class_.set("complexity", "")
-
-            class_lines = etree.SubElement(class_, "lines")
-
-            class_valid_lines = 0
-            class_lines_covered = 0
-
-            class_valid_branches = 0
-            class_branches_covered = 0
-            for line_no in sorted(line_coverage):
-                line = etree.SubElement(class_lines, "line")
-                line.set("number", str(line_no))
-                class_valid_lines += 1
-                package_valid_lines += 1
-                total_valid_lines += 1
-                if line_coverage[line_no] is not None:
-                    line.set("hits", str(1))
-                    class_lines_covered += 1
-                    package_lines_covered += 1
-                    total_lines_covered += 1
-                    if line_coverage[line_no]:
-                        line.set("branch", "true")
-                        branches_covered = sum(line_coverage[line_no])
-                        valid_branches = len(line_coverage[line_no]) * 2
-                        class_valid_branches += valid_branches
-                        class_branches_covered += branches_covered
-                        package_valid_branches += valid_branches
-                        package_branches_covered += branches_covered
-                        total_valid_branches += valid_branches
-                        total_branches_covered += branches_covered
-                        pct = round((branches_covered / valid_branches) * 100)
-                        line.set(
-                            "condition-coverage", f"{pct}% ({branches_covered}/{valid_branches})"
-                        )
-                else:
-                    line.set("hits", str(0))
-
-            class_.set("line-rate", _rate(class_valid_lines, class_lines_covered))
-            class_.set("branch-rate", _rate(class_valid_branches, class_branches_covered))
-
-        package.set("line-rate", _rate(package_valid_lines, package_lines_covered))
-        package.set("branch-rate", _rate(package_valid_branches, package_branches_covered))
-
-    root.set("line-rate", _rate(total_valid_lines, total_lines_covered))
-    root.set("branch-rate", _rate(total_valid_branches, total_branches_covered))
-    root.set("lines-covered", str(total_lines_covered))
-    root.set("lines-valid", str(total_valid_lines))
-    root.set("branches-covered", str(total_branches_covered))
-    root.set("branches-valid", str(total_valid_branches))
-    return root
 
 
 def _save_coverage_report(build, coverage_eval, report_path):
@@ -138,78 +39,6 @@ def _save_coverage_report(build, coverage_eval, report_path):
     print(f"\nCoverage reports saved at {json_path} and {xml_path}")
     print("View the report using the Brownie GUI")
     return report_path
-
-
-def _rate(line_count, hit_count):
-    if line_count == 0:
-        return "1.0"
-    else:
-        return "{:.5}".format(hit_count / line_count)
-
-
-def _lines_to_coverage(coverage_map, path_id, file_coverage, content):
-    available_offsets = set()
-
-    for function in coverage_map["statements"][path_id].values():
-        for statement, [from_, to] in function.items():
-            available_offsets.update(range(from_, to))
-
-    for function in coverage_map["branches"][path_id].values():
-        for statement, [from_, to, _] in function.items():
-            available_offsets.update(range(from_, to))
-
-    statements = coverage_map["statements"][path_id]
-    branches = coverage_map["branches"][path_id]
-
-    flat_statements = {int(k): v for d in statements.values() for k, v in d.items()}
-    flat_branches = {int(k): [v[0], v[1]] for d in branches.values() for k, v in d.items()}
-    branch_coverage = defaultdict(int)
-
-    covered_offsets = set()
-    [covered_statements, covered_yes_branches, covered_no_branches] = file_coverage
-
-    for stmt in covered_statements:
-        covered_offsets.update(range(*flat_statements[stmt]))
-
-    for stmt in covered_yes_branches:
-        covered_offsets.update(range(*flat_branches[stmt]))
-        branch_coverage[stmt] += 1
-
-    for stmt in covered_no_branches:
-        covered_offsets.update(range(*flat_branches[stmt]))
-        branch_coverage[stmt] += 1
-
-    offset_branches = defaultdict(list)
-    for statements in branches.values():
-        for stmt, [from_, to, _] in statements.items():
-            offset_branches[from_].append(stmt)
-
-    branch_lines = {}
-    line_to_coverage = {}
-    from_ = 0
-    for n, line in enumerate(content):
-        to = from_ + len(line)
-        if set(range(from_, to)).intersection(available_offsets):
-            is_covered = bool(set(range(from_, to)).intersection(covered_offsets))
-            if is_covered:
-                line_to_coverage[n + 1] = []
-            else:
-                line_to_coverage[n + 1] = None
-        for offset, branches in list(offset_branches.items()):
-            if from_ <= offset < to:
-                for branch in branches:
-                    branch_lines[int(branch)] = n + 1
-                offset_branches.pop(offset)
-        from_ = to
-
-    for stmt, coverage in branch_coverage.items():
-        line = branch_lines[int(stmt)]
-        # nothing covers the line
-        if line_to_coverage[line] is None:
-            continue
-        line_to_coverage[line].append(coverage)
-
-    return line_to_coverage
 
 
 def _load_report_exclude_data(settings):

--- a/brownie/test/output.py
+++ b/brownie/test/output.py
@@ -68,7 +68,10 @@ def _save_coverage_report(build, coverage_eval, report_path):
             filename = contract["allSourcePaths"][path_id]
             if filename.startswith("/"):
                 continue
+
             content = open(filename).readlines()
+            file_coverage = coverage_eval[contract_name].get(path_id, [set(), set(), set()])
+            line_coverage = _lines_to_coverage(coverage_map, path_id, file_coverage, content)
 
             class_ = etree.SubElement(classes, "class")
             class_.set("name", filename)
@@ -76,10 +79,6 @@ def _save_coverage_report(build, coverage_eval, report_path):
             class_.set("complexity", "")
 
             class_lines = etree.SubElement(class_, "lines")
-
-            file_coverage = coverage_eval[contract_name][path_id]
-
-            line_coverage = _lines_to_coverage(coverage_map, path_id, file_coverage, content)
 
             class_valid_lines = 0
             class_lines_covered = 0
@@ -195,12 +194,12 @@ def _lines_to_coverage(coverage_map, path_id, file_coverage, content):
         for offset, branches in list(offset_branches.items()):
             if from_ <= offset < to:
                 for branch in branches:
-                    branch_lines[branch] = n + 1
+                    branch_lines[int(branch)] = n + 1
                 offset_branches.pop(offset)
         from_ = to
 
     for stmt, coverage in branch_coverage.items():
-        line = branch_lines[str(stmt)]
+        line = branch_lines[int(stmt)]
         # nothing covers the line
         if line_to_coverage[line] is None:
             continue

--- a/brownie/test/output.py
+++ b/brownie/test/output.py
@@ -36,6 +36,8 @@ def _save_coverage_report(build, coverage_eval, report_path):
     root.set("complexity", "")
     root.set("version", "1.9")
     root.set("timestamp", str(int(time.time() * 1000)))
+    packages = etree.SubElement(root, "packages")
+
     total_valid_lines = 0
     total_lines_covered = 0
 
@@ -46,7 +48,6 @@ def _save_coverage_report(build, coverage_eval, report_path):
         contract = build.get(contract_name)
         coverage_map = contract["coverageMap"]
 
-        packages = etree.SubElement(root, "packages")
         package = etree.SubElement(packages, "package")
         package.set("name", contract_name)
         package.set("complexity", "")

--- a/brownie/test/output.py
+++ b/brownie/test/output.py
@@ -100,24 +100,18 @@ def _save_coverage_report(build, coverage_eval, report_path):
                         package_branches_covered += branches_covered
                         pct = round((branches_covered / valid_branches) * 100)
                         line.set(
-                            "condition-coverage",
-                            f"{pct}% ({branches_covered}/{valid_branches})")
+                            "condition-coverage", f"{pct}% ({branches_covered}/{valid_branches})"
+                        )
                 else:
                     line.set("hits", str(0))
 
-            class_.set(
-                "line-rate", _rate(class_valid_lines, class_lines_covered))
-            class_.set(
-                "branch-rate", _rate(class_valid_branches, class_branches_covered))
+            class_.set("line-rate", _rate(class_valid_lines, class_lines_covered))
+            class_.set("branch-rate", _rate(class_valid_branches, class_branches_covered))
 
-        package.set(
-            "line-rate", _rate(package_valid_lines, package_lines_covered))
-        package.set(
-            "branch-rate", _rate(package_valid_branches, package_branches_covered))
-        root.set(
-            "line-rate", _rate(package_valid_lines, package_lines_covered))
-        root.set(
-            "branch-rate", _rate(package_valid_branches, package_branches_covered))
+        package.set("line-rate", _rate(package_valid_lines, package_lines_covered))
+        package.set("branch-rate", _rate(package_valid_branches, package_branches_covered))
+        root.set("line-rate", _rate(package_valid_lines, package_lines_covered))
+        root.set("branch-rate", _rate(package_valid_branches, package_branches_covered))
         root.set("lines-covered", str(package_lines_covered))
         root.set("lines-valid", str(package_valid_lines))
         root.set("branches-covered", str(package_branches_covered))

--- a/brownie/test/output.py
+++ b/brownie/test/output.py
@@ -138,27 +138,19 @@ def _lines_to_coverage(coverage_map, path_id, file_coverage, content):
     branches = coverage_map["branches"][path_id]
 
     flat_statements = {k: v for d in statements.values() for k, v in d.items()}
-
-    flat_yes_branches = {k: [v[0], v[1]] for d in branches.values() for k, v in d.items() if v[2]}
-
-    flat_no_branches = {
-        k: [v[0], v[1]] for d in branches.values() for k, v in d.items() if not v[2]
-    }
+    flat_branches = {k: [v[0], v[1]] for d in branches.values() for k, v in d.items()}
 
     covered_offsets = set()
     [covered_statements, covered_yes_branches, covered_no_branches] = file_coverage
 
     for stmt in covered_statements:
-        if str(stmt) in flat_statements:
-            covered_offsets.update(range(*flat_statements[str(stmt)]))
+        covered_offsets.update(range(*flat_statements[str(stmt)]))
 
     for stmt in covered_yes_branches:
-        if str(stmt) in flat_yes_branches:
-            covered_offsets.update(range(*flat_yes_branches[str(stmt)]))
+        covered_offsets.update(range(*flat_branches[str(stmt)]))
 
-    for stmt in covered_yes_branches:
-        if str(stmt) in flat_no_branches:
-            covered_offsets.update(range(*flat_no_branches[str(stmt)]))
+    for stmt in covered_no_branches:
+        covered_offsets.update(range(*flat_branches[str(stmt)]))
 
     line_to_coverage = {}
     from_ = 0

--- a/brownie/test/output.py
+++ b/brownie/test/output.py
@@ -119,12 +119,12 @@ def _save_coverage_report(build, coverage_eval, report_path):
         package.set("line-rate", _rate(package_valid_lines, package_lines_covered))
         package.set("branch-rate", _rate(package_valid_branches, package_branches_covered))
 
-    root.set("line-rate", _rate(package_valid_lines, package_lines_covered))
-    root.set("branch-rate", _rate(package_valid_branches, package_branches_covered))
-    root.set("lines-covered", str(package_lines_covered))
-    root.set("lines-valid", str(package_valid_lines))
-    root.set("branches-covered", str(package_branches_covered))
-    root.set("branches-valid", str(package_valid_branches))
+    root.set("line-rate", _rate(total_valid_lines, total_lines_covered))
+    root.set("branch-rate", _rate(total_valid_branches, total_branches_covered))
+    root.set("lines-covered", str(total_lines_covered))
+    root.set("lines-valid", str(total_valid_lines))
+    root.set("branches-covered", str(total_branches_covered))
+    root.set("branches-valid", str(total_valid_branches))
 
     xml_path = report_path.parent.joinpath("coverage.xml")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,11 +6,13 @@ eth-hash[pycryptodome]==0.2.0
 eth-utils==1.9.0
 hexbytes==0.2.1
 hypothesis==5.16.2
+lxml==4.5.1
 prompt-toolkit==3.0.5
 psutil>=5.7.0,<6.0.0
 py>=1.5.0
 py-solc-ast>=1.2.4,<2.0.0
 py-solc-x>=0.10.0,<1.0.0
+pycobertura==0.10.5
 pygments==2.6.1
 pytest==5.4.3
 pytest-xdist==1.32.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ psutil>=5.7.0,<6.0.0
 py>=1.5.0
 py-solc-ast>=1.2.4,<2.0.0
 py-solc-x>=0.10.0,<1.0.0
-pycobertura==0.10.5
 pygments==2.6.1
 pytest==5.4.3
 pytest-xdist==1.32.0

--- a/tests/test/plugin/test_output.py
+++ b/tests/test/plugin/test_output.py
@@ -35,17 +35,22 @@ def test_print_coverage(plugintester, mocker):
     assert output._build_coverage_output.call_count == 2
 
 
+def list_files(path):
+    return sorted([i.name for i in path.glob("*")])
+
+
 def test_coverage_save_report(plugintester):
     path = Path(plugintester.tmpdir).joinpath("reports")
     plugintester.runpytest()
     assert not len(list(path.glob("*")))
     plugintester.runpytest("-C")
-    assert [i.name for i in path.glob("*")] == ["coverage.json"]
+    assert list_files(path) == ["coverage.json", "coverage.xml"]
     plugintester.runpytest("-C")
-    assert [i.name for i in path.glob("*")] == ["coverage.json"]
-    next(path.glob("*")).open("w").write("this isn't json, is it?")
+    assert list_files(path) == ["coverage.json", "coverage.xml"]
+    next(path.glob("*.json")).open("w").write("this isn't json, is it?")
+    next(path.glob("*.xml")).open("w").write("this isn't xml, is it?")
     plugintester.runpytest("-C")
-    assert [i.name for i in path.glob("*")] == ["coverage.json"]
+    assert list_files(path) == ["coverage.json", "coverage.xml"]
 
 
 def test_stdout_capture(plugintester):


### PR DESCRIPTION
### What I did

Added very simple line coverage based cobertura xml generation

Related issue: #568

### How I did it

Analyze coverage_map and aggregate all the offsets that contain executable code.
Analyze coverage_eval and aggregate all the offsets that were covered.
For each line check if it overlaps available offsets and if it overlaps covered offsets, produce xml report using lxml.

### How to verify it

Running tests produces separate xml and html report files for each contract.

### Known issues

- Most code is inline and not refactored into functions
- There are no tests
- Sometimes coverage_eval has True or False branches present that do not exist in coverage_map
```
file_coverage_map = {'LGTRelayer.forward': {'13': [2085, 2103, True]}, 'LGTRelayer.forwardAuto': {'14': [2809, 2827, True], '15': [2955, 2972, False], '16': [3059, 3116, False]}, 'LGTRelayer.forwardMax': {'17': [1015, 1033, True]}}
file_coverage_eval = [{0, 1, 2, 3, 4, 5, 6, 8, 10, 11, 12}, {15}, {16, 17, 13, 14}]
```
- pycobertura does not handle methods or packages, so I have no way to validate and thus implement method based coverage
- it might be possible to get all coverage xml files into a single xml by using package to denote a contract, but without being able to run actual html generation it's hard to test

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
