### PR TITLE
Fix etherscan json

### DIFF
--- a/tests/network/contract/test_contract.py
+++ b/tests/network/contract/test_contract.py
@@ -287,9 +287,9 @@ def test_as_proxy_for(network):
     original = Contract.from_explorer("0x3d9819210a31b4961b30ef54be2aed79b9c9cd3b")
     proxy = Contract.from_explorer(
         "0x3d9819210a31b4961b30ef54be2aed79b9c9cd3b",
-        as_proxy_for="0x97BD4Cc841FC999194174cd1803C543247a014fe",
+        as_proxy_for="0x9d0a0443ff4bb04391655b8cd205683d9fa75550",
     )
-    implementation = Contract("0x97BD4Cc841FC999194174cd1803C543247a014fe")
+    implementation = Contract("0x9d0a0443ff4bb04391655b8cd205683d9fa75550")
 
     assert original.abi == proxy.abi
     assert original.address == proxy.address


### PR DESCRIPTION
### What I did
Add support for compiler JSON outputs when query source code from Etherscan.

Closes #494 

### How to verify it
Run tests.  I updated a test that queries a source using JSON for source verification.
