### PR TITLE
Enter correct frame with run --interactive

### DIFF
--- a/brownie/_cli/run.py
+++ b/brownie/_cli/run.py
@@ -52,7 +52,8 @@ def main():
 
         if args["--interactive"]:
             frame = next(
-                (i.frame for i in inspect.trace() if Path(i.filename).as_posix() == path_str), None
+                (i.frame for i in inspect.trace()[::-1] if Path(i.filename).as_posix() == path_str),
+                None,
             )
             if frame is not None:
                 globals_dict = {k: v for k, v in frame.f_globals.items() if not k.startswith("__")}


### PR DESCRIPTION
### What I did
When using the `-I` flag with `brownie run`, ensure the local namespace uses the correct frame.

### How I did it
Reverse `inspect.trace` when finding the correct frame.

### How to verify it
Try it in the CLI
