### PR TITLE
Fix requests header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/iamdefinitelyahuman/brownie)
 
+### Fixed
+- Http Requests now send a custom User-Agent (Fixes Kovan api requests) ([#643](https://github.com/eth-brownie/brownie/pull/643))
+
 ## [1.9.3](https://github.com/iamdefinitelyahuman/brownie/tree/v1.9.3) - 2020-06-19
 ### Added
 - Accounts can now be unlocked on development networks ([#633](https://github.com/eth-brownie/brownie/pull/633))

--- a/brownie/_cli/__main__.py
+++ b/brownie/_cli/__main__.py
@@ -5,12 +5,10 @@ import sys
 from pathlib import Path
 
 from brownie import network
-from brownie._config import CONFIG
+from brownie._config import CONFIG, __version__
 from brownie.exceptions import ProjectNotFound
 from brownie.utils import color, notify
 from brownie.utils.docopt import docopt, levenshtein_norm
-
-__version__ = "1.9.3"
 
 __doc__ = """Usage:  brownie <command> [<args>...] [options <args>]
 

--- a/brownie/_cli/analyze.py
+++ b/brownie/_cli/analyze.py
@@ -13,8 +13,12 @@ from pythx import Client, ValidationError
 from pythx.middleware import ClientToolNameMiddleware, GroupDataMiddleware
 
 from brownie import project
-from brownie._cli.__main__ import __version__
-from brownie._config import CONFIG, _load_project_structure_config, _update_argv_from_docopt
+from brownie._config import (
+    CONFIG,
+    __version__,
+    _load_project_structure_config,
+    _update_argv_from_docopt,
+)
 from brownie.exceptions import ProjectNotFound
 from brownie.utils import color, notify
 from brownie.utils.docopt import docopt

--- a/brownie/_config.py
+++ b/brownie/_config.py
@@ -4,6 +4,7 @@ import json
 import os
 import re
 import shutil
+import sys
 import warnings
 from collections import defaultdict
 from pathlib import Path
@@ -13,6 +14,7 @@ import yaml
 from hypothesis import settings as hp_settings
 from hypothesis.database import DirectoryBasedExampleDatabase
 
+from brownie._cli.__main__ import __version__
 from brownie._singleton import _Singleton
 
 BROWNIE_FOLDER = Path(__file__).parent
@@ -21,6 +23,12 @@ DATA_FOLDER = Path.home().joinpath(".brownie")
 DATA_SUBFOLDERS = ("accounts", "ethpm", "packages")
 
 EVM_EQUIVALENTS = {"atlantis": "byzantium", "agharta": "petersburg"}
+
+python_version = (
+    f"{sys.version_info.major}.{sys.version_info.minor}"
+    f".{sys.version_info.micro} {sys.version_info.releaselevel}"
+)
+REQUEST_HEADERS = {"User-Agent": f"Brownie/{__version__} (Python/{python_version})"}
 
 
 class ConfigContainer:

--- a/brownie/_config.py
+++ b/brownie/_config.py
@@ -14,8 +14,9 @@ import yaml
 from hypothesis import settings as hp_settings
 from hypothesis.database import DirectoryBasedExampleDatabase
 
-from brownie._cli.__main__ import __version__
 from brownie._singleton import _Singleton
+
+__version__ = "1.9.3"
 
 BROWNIE_FOLDER = Path(__file__).parent
 DATA_FOLDER = Path.home().joinpath(".brownie")

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -17,7 +17,7 @@ from eth_utils import remove_0x_prefix
 from hexbytes import HexBytes
 from semantic_version import Version
 
-from brownie._config import CONFIG
+from brownie._config import CONFIG, REQUEST_HEADERS
 from brownie.convert.datatypes import Wei
 from brownie.convert.normalize import format_input, format_output
 from brownie.convert.utils import (
@@ -1228,8 +1228,8 @@ def _fetch_from_explorer(address: str, action: str, silent: bool) -> Dict:
             f"Fetching source of {color('bright blue')}{address}{color} "
             f"from {color('bright blue')}{urlparse(url).netloc}{color}..."
         )
-    response = requests.get(url, params=params)
 
+    response = requests.get(url, params=params, headers=REQUEST_HEADERS)
     if response.status_code != 200:
         raise ConnectionError(f"Status {response.status_code} when querying {url}: {response.text}")
     data = response.json()

--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -726,12 +726,13 @@ def _install_from_github(package_id: str) -> str:
     if install_path.exists():
         raise FileExistsError("Package is aleady installed")
 
+    headers = REQUEST_HEADERS.copy()
     if os.getenv("GITHUB_TOKEN"):
         auth = b64encode(os.environ["GITHUB_TOKEN"].encode()).decode()
-        REQUEST_HEADERS.update({"Authorization": "Basic {}".format(auth)})
+        headers.update({"Authorization": "Basic {}".format(auth)})
 
     response = requests.get(
-        f"https://api.github.com/repos/{org}/{repo}/tags?per_page=100", headers=REQUEST_HEADERS
+        f"https://api.github.com/repos/{org}/{repo}/tags?per_page=100", headers=headers
     )
     if response.status_code != 200:
         msg = "Status {} when getting package versions from Github: '{}'".format(

--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -22,6 +22,7 @@ from tqdm import tqdm
 
 from brownie._config import (
     CONFIG,
+    REQUEST_HEADERS,
     _get_data_folder,
     _load_project_compiler_config,
     _load_project_config,
@@ -725,13 +726,12 @@ def _install_from_github(package_id: str) -> str:
     if install_path.exists():
         raise FileExistsError("Package is aleady installed")
 
-    headers: Dict = {}
     if os.getenv("GITHUB_TOKEN"):
         auth = b64encode(os.environ["GITHUB_TOKEN"].encode()).decode()
-        headers = {"Authorization": "Basic {}".format(auth)}
+        REQUEST_HEADERS.update({"Authorization": "Basic {}".format(auth)})
 
     response = requests.get(
-        f"https://api.github.com/repos/{org}/{repo}/tags?per_page=100", headers=headers
+        f"https://api.github.com/repos/{org}/{repo}/tags?per_page=100", headers=REQUEST_HEADERS
     )
     if response.status_code != 200:
         msg = "Status {} when getting package versions from Github: '{}'".format(
@@ -865,7 +865,7 @@ def _load_sources(project_path: Path, subfolder: str, allow_json: bool) -> Dict:
 
 
 def _stream_download(download_url: str, target_path: str) -> None:
-    response = requests.get(download_url, stream=True)
+    response = requests.get(download_url, stream=True, headers=REQUEST_HEADERS)
     total_size = int(response.headers.get("content-length", 0))
     progress_bar = tqdm(total=total_size, unit="iB", unit_scale=True)
     content = bytes()

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ current_version = 1.9.3
 
 [bumpversion:file:setup.py]
 
-[bumpversion:file:brownie/_cli/__main__.py]
+[bumpversion:file:brownie/_config.py]
 
 [flake8]
 exclude = tests/data/*


### PR DESCRIPTION
### What I did

Added a custom user agent to send with requests.
`{"User-Agent": f"Brownie/{__version__} (Python/{python_version})"}`
Example: `Brownie/1.9.3 (Python/3.6.8 final)"`

Related issue: #642 

### How I did it

Updated all `requests.get`  statements to include the user agent header.

### How to verify it
Try and load a contract on Kovan.

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [x] I have added an entry to the changelog
