### PR TITLE
less restrictive default_language_version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,4 +32,4 @@ repos:
 
 
 default_language_version:
-    python: python3.7
+    python: python3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/eth-brownie/brownie)
+### Fixed
+- Less restrictive default_langauge_version in pre-commit hooks
 
 ## [1.9.4](https://github.com/eth-brownie/brownie/tree/v1.9.4) - 2020-06-21
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/eth-brownie/brownie)
 ### Fixed
-- Less restrictive default_langauge_version in pre-commit hooks
+- Less restrictive `default_langauge_version` in pre-commit hooks
 
 ## [1.9.4](https://github.com/eth-brownie/brownie/tree/v1.9.4) - 2020-06-21
 ### Fixed


### PR DESCRIPTION
my system has python3.8 instead of 3.7

### What I did

Simple config change

### How to verify it

I have the hooks installed and I was able to create this commit.

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [ ] ~~I have included test cases~~
- [ ] ~~I have updated the documentation~~
- [x] I have added an entry to the changelog
