### PR TITLE
Update default gas limit to 12 million

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/eth-brownie/brownie)
 ### Fixed
 - Less restrictive `default_langauge_version` in pre-commit hooks
+- Updated network configs to match mainnet's latest gas limits
 
 ## [1.9.4](https://github.com/eth-brownie/brownie/tree/v1.9.4) - 2020-06-21
 ### Fixed

--- a/brownie/data/default-config.yaml
+++ b/brownie/data/default-config.yaml
@@ -16,9 +16,9 @@ project_structure:
 networks:
     default: development
     development:
-        gas_limit: 6721975
+        gas_limit: 12000000
         gas_price: 0
-        reverting_tx_gas_limit: 6721975
+        reverting_tx_gas_limit: 12000000
         default_contract_owner: true
         cmd_settings: null
     live:

--- a/brownie/data/network-config.yaml
+++ b/brownie/data/network-config.yaml
@@ -46,7 +46,7 @@ development:
     host: http://127.0.0.1
     cmd_settings:
       port: 8545
-      gas_limit: 6721975
+      gas_limit: 12000000
       accounts: 10
       evm_version: istanbul
       mnemonic: brownie
@@ -57,7 +57,7 @@ development:
     timeout: 120
     cmd_settings:
       port: 8545
-      gas_limit: 10000000
+      gas_limit: 12000000
       accounts: 10
       evm_version: istanbul
       mnemonic: brownie


### PR DESCRIPTION
### What I did

Updated default gas to match what mainnet is at.

I'm not sure what people with existing installs should do. I'm guessing deleting `~/.browie/network-config.yaml` would work.

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [ ] ~~I have included test cases~~
- [ ] ~~I have updated the documentation~~
- [x] I have added an entry to the changelog
