### PR TITLE
fix: avoids development network to revert when `atexit` is being called

### DIFF
--- a/brownie/network/rpc.py
+++ b/brownie/network/rpc.py
@@ -75,8 +75,6 @@ class Rpc(metaclass=_Singleton):
             if getattr(self._rpc, "stderr", None) is not None:
                 self._rpc.stderr.close()
             self.kill(False)
-        else:
-            self._request("evm_revert", [self._reset_id])
 
     def launch(self, cmd: str, **kwargs: Dict) -> None:
         """Launches the RPC client.


### PR DESCRIPTION
### What I did

When running a script using `development` network, even using a `ganache` instance I launch, after finishing the execution the evm changes are reverted.

### How I did it

As pointed out by @iamdefinitelyahuman I removed the lines where invoked when exiting.

### How to verify it

I haven't tried myself to automatically test the `atexit` hook, I can try to do so if required (I'm not a python dev so it might take me a while but a quick googling told me that hook is only executed then the process ends, in this case, pytest) . Manual test is required I'm afraid.

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
