### PR TITLE
Reduce vyper traceback

### DIFF
--- a/brownie/project/compiler/vyper.py
+++ b/brownie/project/compiler/vyper.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Optional, Tuple
 import vyper
 from semantic_version import Version
 from vyper.cli import vyper_json
+from vyper.exceptions import VyperException
 
 from brownie.project.compiler.utils import expand_source_map
 from brownie.project.sources import is_inside_offset
@@ -50,7 +51,10 @@ def compile_from_input_json(
     if not silent:
         print("Compiling contracts...")
         print(f"  Vyper version: {get_version()}")
-    return vyper_json.compile_json(input_json, root_path=allow_paths)
+    try:
+        return vyper_json.compile_json(input_json, root_path=allow_paths)
+    except VyperException as exc:
+        raise exc.with_traceback(None)
 
 
 def _get_unique_build_json(

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,5 +19,5 @@ pyyaml>=5.3.0,<6.0.0
 requests>=2.23.0,<3.0.0
 semantic-version==2.8.5
 tqdm==4.46.1
-vyper==0.2.1
+vyper>=0.2.0,<0.3.0
 web3==5.11.1


### PR DESCRIPTION
### What I did
* Reduce the length of the traceback on a failed vyper compile.  Fixes #658 

### How I did it
Catch `VyperException` and re-raise without a traceback

### How to verify it
Run tests