### PR TITLE
fix: add "max" gas limit setting

### DIFF
--- a/brownie/data/default-config.yaml
+++ b/brownie/data/default-config.yaml
@@ -16,9 +16,9 @@ project_structure:
 networks:
     default: development
     development:
-        gas_limit: 12000000
+        gas_limit: max
         gas_price: 0
-        reverting_tx_gas_limit: 12000000
+        reverting_tx_gas_limit: max
         default_contract_owner: true
         cmd_settings: null
     live:

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -121,9 +121,9 @@ Networks
 
     .. py:attribute:: gas_limit
 
-        The default gas limit for all transactions. If set to ``auto`` the gas limit is determined using ``web3.eth.estimateGas``.
+        The default gas limit for all transactions. If set to ``auto`` the gas limit is determined using ``web3.eth.estimateGas``. If set to ``max``, the block gas limit is used.
 
-        development default: ``6721975``
+        development default: ``max``
 
         live default: ``auto``
 
@@ -135,7 +135,7 @@ Networks
 
         The gas limit to use when a transaction would revert. If set to ``false``, transactions that would revert will instead raise a :func:`VirtualMachineError <brownie.exceptions.VirtualMachineError>`.
 
-        development default: ``6721975``
+        development default: ``max``
 
         live default: ``false``
 


### PR DESCRIPTION
### What I did
Add "max" as an allowable setting for `gas_limit` in config.

Fixes an issue related to #650, where a development network can be launched with a lower block gas limit than specified in the config for transactions.

### How to verify it
Run tests.
