### PR TITLE
TransactionReceipt fixes

### DIFF
--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -351,6 +351,7 @@ class _PrivateKeyAccount(PublicKeyAccount):
         gas_price: Optional[int] = None,
         nonce: Optional[int] = None,
         required_confs: int = 1,
+        silent: bool = False,
     ) -> Any:
         """Deploys a contract.
 
@@ -399,10 +400,12 @@ class _PrivateKeyAccount(PublicKeyAccount):
             receipt = TransactionReceipt(
                 txid,
                 self,
+                silent=silent,
                 required_confs=required_confs,
                 name=contract._name + ".constructor",
                 revert_data=revert_data,
             )
+            history._add_tx(receipt)
         add_thread = threading.Thread(target=contract._add_from_tx, args=(receipt,), daemon=True)
         add_thread.start()
 
@@ -509,6 +512,7 @@ class _PrivateKeyAccount(PublicKeyAccount):
             receipt = TransactionReceipt(
                 txid, self, required_confs=required_confs, silent=silent, revert_data=revert_data
             )
+            history._add_tx(receipt)
         if rpc.is_active():
             undo_thread = threading.Thread(
                 target=rpc._add_to_undo_buffer,

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -449,7 +449,16 @@ class TransactionReceipt:
         self._raw_trace = trace = trace["result"]["structLogs"]
         if not trace:
             self._modified_state = False
-        elif self.status:
+            return
+
+        if isinstance(trace[0]["gas"], str):
+            # handle traces where numeric values are returned as nex (Nethermind)
+            for step in trace:
+                step["gas"] = int(step["gas"], 16)
+                step["gasCost"] = int.from_bytes(HexBytes(step["gasCost"]), "big", signed=True)
+                step["pc"] = int(step["pc"], 16)
+
+        if self.status:
             self._confirmed_trace(trace)
         else:
             self._reverted_trace(trace)

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -127,7 +127,7 @@ class TransactionReceipt:
         self,
         txid: Union[str, bytes],
         sender: Any = None,
-        silent: bool = False,
+        silent: bool = True,
         required_confs: int = 1,
         name: str = "",
         revert_data: Optional[Tuple] = None,
@@ -150,7 +150,6 @@ class TransactionReceipt:
             txid = txid.hex()
         if not self._silent:
             print(f"Transaction sent: {color('bright blue')}{txid}{color}")
-        history._add_tx(self)
 
         self._trace_origin = None
         self._raw_trace = None


### PR DESCRIPTION
### What I did
* only add `TransactionReceipt` objects to `history` when they are broadcasted from within brownie - closes #654 
* make `TransactionReceipt`'s `silent` kwarg `False` by default
* handle hexadecimal numeric values in traces (nethermind)

### How to verify it
Run tests.
