### PR TITLE
Hypothesis settings

### DIFF
--- a/brownie/_cli/test.py
+++ b/brownie/_cli/test.py
@@ -19,6 +19,7 @@ Brownie Options:
   --coverage -C            Evaluate contract test coverage
   --interactive -I         Open an interactive console each time a test fails
   --stateful [true,false]  Only run stateful tests, or skip them
+  --failfast               Fail hypothesis tests quickly (no shrinking)
   --revert-tb -R           Show detailed traceback on unhandled transaction reverts
   --gas -G                 Display gas profile for function calls
   --network [name]         Use a specific network (default {CONFIG.settings['networks']['default']})

--- a/brownie/_config.py
+++ b/brownie/_config.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import yaml
+from hypothesis import Phase
 from hypothesis import settings as hp_settings
 from hypothesis.database import DirectoryBasedExampleDatabase
 
@@ -253,6 +254,13 @@ def _load_project_dependencies(project_path: Path) -> List:
 def _modify_hypothesis_settings(settings, name, parent=None):
     if parent is None:
         parent = hp_settings._current_profile
+
+    if "phases" in settings:
+        try:
+            settings["phases"] = [getattr(Phase, k) for k, v in settings["phases"].items() if v]
+        except AttributeError as exc:
+            raise ValueError(f"'{exc.args[0]}' is not a valid hypothesis phase setting")
+
     hp_settings.register_profile(
         name,
         parent=hp_settings.get_profile(parent),

--- a/brownie/data/default-config.yaml
+++ b/brownie/data/default-config.yaml
@@ -51,6 +51,12 @@ hypothesis:
     max_examples: 50
     report_multiple_bugs: False
     stateful_step_count: 10
+    phases:
+        explicit: true
+        reuse: true
+        generate: true
+        target: true
+        shrink: true
 
 autofetch_sources: false
 dependencies: null

--- a/brownie/test/plugin.py
+++ b/brownie/test/plugin.py
@@ -40,6 +40,9 @@ def pytest_addoption(parser):
             help="Only run or skip stateful tests (default: run all tests)",
         )
         parser.addoption(
+            "--failfast", action="store_true", help="Fail hypothesis tests quickly (no shrinking)",
+        )
+        parser.addoption(
             "--network",
             "-N",
             default=False,
@@ -86,6 +89,14 @@ def pytest_configure(config):
             Plugin = PytestBrownieXdistRunner
         else:
             Plugin = PytestBrownieRunner
+
+        if config.getoption("interactive"):
+            config.option.failfast = True
+
+        if config.getoption("failfast"):
+            _modify_hypothesis_settings(
+                {"phases": {"explicit": True, "generate": True, "target": True}}, "brownie-failfast"
+            )
 
         session = Plugin(config, active_project)
         config.pluginmanager.register(session, "brownie-core")

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -254,6 +254,13 @@ Default settings for :ref:`property-based<hypothesis>` and :ref:`stateful<hypoth
         max_examples: 50
         report_multiple_bugs: False
         stateful_step_count: 10
+        deadline: null
+        phases:
+            explicit: true
+            reuse: true
+            generate: true
+            target: true
+            shrink: true
 
 Other Settings
 --------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ eth-event>=1.1.0,<2.0.0
 eth-hash[pycryptodome]==0.2.0
 eth-utils==1.9.0
 hexbytes==0.2.1
-hypothesis==5.16.2
+hypothesis==5.19.0
 prompt-toolkit==3.0.5
 psutil>=5.7.0,<6.0.0
 py>=1.5.0


### PR DESCRIPTION
### What I did
* Expose `hypothesis` phase settings
* add a `--failfast` flag to `brownie test` that causes `hypothesis` tests to fail sooner. This flag is automatically enabled when using `--interactive` mode
* bump hypothesis dep version

Closes #629 

### How to verify it
Run tests.

