### PR TITLE
Syntax highlighting for Vyper exceptions

### DIFF
--- a/brownie/_cli/console.py
+++ b/brownie/_cli/console.py
@@ -14,8 +14,6 @@ from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.keys import Keys
 from prompt_toolkit.lexers import PygmentsLexer
 from prompt_toolkit.styles.pygments import style_from_pygments_cls
-from pygments import highlight
-from pygments.formatters import get_formatter_by_name
 from pygments.lexers import PythonLexer
 from pygments.styles import get_style_by_name
 
@@ -109,20 +107,6 @@ class Console(code.InteractiveConsole):
         if extra_locals:
             locals_dict.update(extra_locals)
 
-        # prepare lexer and formatter
-        self.lexer = PythonLexer()
-        fmt_name = "terminal"
-        try:
-            import curses
-
-            curses.setupterm()
-            if curses.tigetnum("colors") == 256:
-                fmt_name = "terminal256"
-        except Exception:
-            # if curses won't import we are probably using Windows
-            pass
-        self.formatter = get_formatter_by_name(fmt_name, style=console_settings["color_style"])
-
         # create prompt session object
         history_file = str(_get_data_folder().joinpath(".history").absolute())
         kwargs = {}
@@ -184,7 +168,7 @@ class Console(code.InteractiveConsole):
         except (SyntaxError, NameError):
             pass
         if CONFIG.settings["console"]["show_colors"]:
-            text = highlight(text, self.lexer, self.formatter)
+            text = color.highlight(text)
         self.write(text)
 
     def raw_input(self, prompt=""):

--- a/brownie/utils/color.py
+++ b/brownie/utils/color.py
@@ -124,6 +124,7 @@ class Color:
     ) -> str:
         if isinstance(exc, SyntaxError) and exc.text is not None:
             return self.format_syntaxerror(exc)
+
         tb = [i.replace("./", "") for i in traceback.format_tb(exc.__traceback__)]
         if filename and not CONFIG.argv["tb"]:
             try:
@@ -131,6 +132,7 @@ class Color:
                 stop = tb.index(next(i for i in tb[::-1] if filename in i)) + 1
             except Exception:
                 pass
+
         tb = tb[start:stop]
         for i in range(len(tb)):
             info, code = tb[i].split("\n")[:2]
@@ -148,8 +150,10 @@ class Color:
 
         msg = str(exc)
         if isinstance(exc, VyperException):
-            # apply syntax highlights to vyper exceptions
+            # apply syntax highlight and remove traceback on vyper exceptions
             msg = self.highlight(msg)
+            if not CONFIG.argv["tb"]:
+                tb.clear()
 
         tb.append(f"{self('bright red')}{type(exc).__name__}{self}: {msg}")
         return "\n".join(tb)

--- a/brownie/utils/color.py
+++ b/brownie/utils/color.py
@@ -8,6 +8,7 @@ from typing import Dict, Optional, Sequence
 import pygments
 from pygments.formatters import get_formatter_by_name
 from pygments.lexers import PythonLexer
+from vyper.exceptions import VyperException
 
 from brownie._config import CONFIG
 
@@ -144,7 +145,13 @@ class Color:
             )
             if code:
                 tb[i] += f"\n{code}"
-        tb.append(f"{self('bright red')}{type(exc).__name__}{self}: {exc}")
+
+        msg = str(exc)
+        if isinstance(exc, VyperException):
+            # apply syntax highlights to vyper exceptions
+            msg = self.highlight(msg)
+
+        tb.append(f"{self('bright red')}{type(exc).__name__}{self}: {msg}")
         return "\n".join(tb)
 
     def format_syntaxerror(self, exc: SyntaxError) -> str:


### PR DESCRIPTION
### What I did
Apply syntax highlights to Vyper exceptions.

### How I did it
Move `pygments` logic from `_cli/console.py` to `utils/color.py` - this is also a first step toward #407

### How to verify it
Try to compile a vyper contract that contains an error.