### PR TITLE
Fix infinite loop when downloading implementation contract

### DIFF
--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -645,6 +645,9 @@ class Contract(_DeployedContractBase):
         if as_proxy_for is None and data["result"][0].get("Implementation"):
             as_proxy_for = _resolve_address(data["result"][0]["Implementation"])
 
+        if as_proxy_for == address:
+            as_proxy_for = None
+
         # if this is a proxy, fetch information for the implementation contract
         if as_proxy_for is not None:
             implementation_contract = Contract.from_explorer(as_proxy_for)


### PR DESCRIPTION
### What I did
Before downloading an implementation contract, check that it's address is `!=` the address of the proxy contract.

Fixes #669 

### How to verify it
In the console:

```python
>>> Contract.from_explorer('0x080bf510FCbF18b91105470639e9561022937712')
```
