### PR TITLE
Meaningful error on failed trace

### DIFF
--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -184,7 +184,7 @@ class ContractContainer(_ContractBase):
 
     def _add_from_tx(self, tx: TransactionReceiptType) -> None:
         tx._confirmed.wait()
-        if tx.status:
+        if tx.status and tx.contract_address is not None:
             try:
                 self.at(tx.contract_address, tx.sender, tx)
             except ContractNotFound:

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -136,7 +136,7 @@ class TransactionReceipt:
 
         # attributes that cannot be set until the tx confirms
         self.block_number = None
-        self.contract_address = None
+        self.contract_address: Optional[str] = None
         self.gas_used = None
         self.logs = None
         self.nonce = None


### PR DESCRIPTION
### What I did
Raise a meaningful error when a call to `debug_traceTransaction` fails.  Fixes #636.

### How I did it
* Remove `__slots__` and `__getattr__` logic from `TransactionReceipt`.  This was unnecessarily complex and the root of the issue.
* When an exception is raised while querying the trace, save it as `_trace_exc` and re-raise any time a trace attribute is accessed.

### How to verify it
Run tests.
