### PR TITLE
Handle incomplete solc source map

### DIFF
--- a/brownie/project/compiler/solidity.py
+++ b/brownie/project/compiler/solidity.py
@@ -402,6 +402,14 @@ def _generate_coverage_data(
             key = (pc_list[-1]["path"], pc_list[-1]["offset"])
             revert_map.setdefault(key, []).append(len(pc_list))
 
+    while opcodes and opcodes[0] not in ("INVALID", "STOP"):
+        # necessary because sometimes solidity returns an incomplete source map
+        pc_list.append({"op": opcodes.popleft(), "pc": pc})
+        pc += 1
+        if opcodes and opcodes[0][:2] == "0x":
+            pc_list[-1]["value"] = opcodes.popleft()
+            pc += int(pc_list[-1]["op"][4:])
+
     # compare revert and require statements against the map of revert jumps
     for (contract_id, fn_offset), values in revert_map.items():
         fn_node = source_nodes[contract_id].children(


### PR DESCRIPTION
### What I did
During compilation, extend `pcMap` if solidity does not provide a long enough `sourceMap`.

I'm still investigating the cause, but I've managed to produce the following minimal example that produces a `sourceMap` that is 7 instructions too short: https://gist.github.com/iamdefinitelyahuman/a6c658acb7e83371ecf730ebf6f8814d

### How to verify it
Run tests.
