### PR TITLE
Add address to EventItem

### DIFF
--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -473,7 +473,7 @@ class TransactionReceipt:
     def _reverted_trace(self, trace: Sequence) -> None:
         self._modified_state = False
         # get events from trace
-        self._events = _decode_trace(trace)
+        self._events = _decode_trace(trace, str(self.receiver or self.contract_address))
         if self.contract_address:
             step = next((i for i in trace if i["op"] == "CODECOPY"), None)
             if step is not None and int(step["stack"][-3], 16) > 24577:

--- a/docs/api-network.rst
+++ b/docs/api-network.rst
@@ -1338,6 +1338,14 @@ _EventItem
         >>> tx.events[2].name
         CountryModified
 
+.. py:attribute:: _EventItem.address
+
+    The address where the event was fired. If the object contains multiple events, this value is set to ``None``.
+
+    .. code-block:: python
+
+        >>> tx.events[2].address
+        "0x2d72c1598537bcf4a4af97668b3a24e68b7d0cc5"
 
 .. py:attribute:: _EventItem.pos
 

--- a/docs/core-transactions.rst
+++ b/docs/core-transactions.rst
@@ -57,13 +57,13 @@ Data about events is available as :func:`TransactionReceipt.events <TransactionR
         'CountryModified': [
             {
                 'country': 1,
-                'limits': (0,0,0,0,0,0,0,0),
+                'limits': (0, 0, 0, 0, 0, 0, 0, 0),
                 'minrating': 1,
                 'permitted': True
             },
             {
                 'country': 2,
-                'limits': (0,0,0,0,0,0,0,0),
+                'limits': (0, 0, 0, 0, 0, 0, 0, 0),
                 'minrating': 1,
                 'permitted': True
             }
@@ -100,12 +100,18 @@ Or as a list when the sequence is important, or more than one event of the same 
 
 .. code-block:: python
 
+    # name of the address
     >>> tx.events[1].name
     'CountryModified'
+
+    # address where the event fired
+    >>> tx.events[1].address
+    "0xDd18d6475A7C71Ee33CEBE730a905DbBd89945a1"
+
     >>> tx.events[1]
     {
         'country': 1,
-        'limits': (0,0,0,0,0,0,0,0),
+        'limits': (0, 0, 0, 0, 0, 0, 0, 0),
         'minrating': 1,
         'permitted': True
     }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ black==19.10b0
 colorama>=0.4.1;platform_system=='Windows'
 eth-abi==2.1.1
 eth-account==0.5.2
-eth-event>=1.1.0,<2.0.0
+eth-event>=1.2.0,<2.0.0
 eth-hash[pycryptodome]==0.2.0
 eth-utils==1.9.0
 hexbytes==0.2.1

--- a/tests/network/test_event.py
+++ b/tests/network/test_event.py
@@ -27,6 +27,11 @@ def test_types(event):
     assert type(event["IndexedEvent"]) is _EventItem
 
 
+def test_address(event, tester):
+    assert event["Debug"].address is None
+    assert event["Debug"][0].address == tester
+
+
 def test_count(event):
     assert len(event) == 3
     assert event.count("IndexedEvent") == len(event["IndexedEvent"]) == 1


### PR DESCRIPTION
### What I did
Add an `address` member to decoded event logs.

Closes #670 

### How I did it
Most of the work happened upstream in https://github.com/iamdefinitelyahuman/eth-event/pull/13. In brownie, the address is exposed as a member of `_EventItem`.

### How to verify it
Run tests.
