### PR TITLE
Improvements to console auto-completion

### DIFF
--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -95,7 +95,7 @@ class Accounts(metaclass=_Singleton):
     def __iter__(self) -> Iterator:
         return iter(self._accounts)
 
-    def __getitem__(self, key: int) -> Any:
+    def __getitem__(self, key: int) -> "_PrivateKeyAccount":
         return self._accounts[key]
 
     def __delitem__(self, key: int) -> None:

--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -472,7 +472,7 @@ class _PrivateKeyAccount(PublicKeyAccount):
         nonce: Optional[int] = None,
         required_confs: int = 1,
         silent: bool = False,
-    ) -> "TransactionReceipt":
+    ) -> TransactionReceipt:
         """
         Broadcast a transaction from this account.
 

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -95,6 +95,18 @@ class TransactionReceipt:
         revert_msg: Error string from reverted contract all
         modified_state: Boolean, did this contract write to storage?"""
 
+    # these are defined as class attributes to expose them in console completion hints
+    block_number = None
+    contract_address: Optional[str] = None
+    contract_name = None
+    fn_name = None
+    gas_used = None
+    logs = None
+    nonce = None
+    sender = None
+    txid = None
+    txindex = None
+
     def __init__(
         self,
         txid: Union[str, bytes],
@@ -140,14 +152,6 @@ class TransactionReceipt:
         self._internal_transfers = None
         self._subcalls: Optional[List[Dict]] = None
         self._confirmed = threading.Event()
-
-        # attributes that cannot be set until the tx confirms
-        self.block_number = None
-        self.contract_address: Optional[str] = None
-        self.gas_used = None
-        self.logs = None
-        self.nonce = None
-        self.txindex = None
 
         # attributes that can be set immediately
         self.sender = sender


### PR DESCRIPTION
### What I did
* during multiline input, pressing tab at the start of a new line creates 4 spaces instead of opening the completion hints
* give correct hints for multiline input
* show completion hints for dict keys

Related issue: #558

### How I did it
Parse the input buffer using `tokenizer`.

### How to verify it
Use the console!
