### PR TITLE
fix: chain fixture

### DIFF
--- a/brownie/test/fixtures.py
+++ b/brownie/test/fixtures.py
@@ -64,7 +64,7 @@ class PytestBrownieFixtures:
     @pytest.fixture(scope="session")
     def chain(self):
         """Yields a Chain object, used for interacting with the blockchain."""
-        yield brownie.rpc
+        yield brownie.chain
 
     @pytest.fixture(scope="session")
     def Contract(self):


### PR DESCRIPTION
### What I did
Fix a bug in the `chain` fixture, it was returning `rpc` instead of `chain` :fearful: 
