### PR TITLE
Bugfix: expanding trace with invalid internal function call

### DIFF
--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -589,7 +589,7 @@ class TransactionReceipt:
                 )
                 if step["op"] in ("CALL", "CALLCODE"):
                     self._subcalls[-1]["value"] = int(step["stack"][-3], 16)
-                if calldata and last_map[trace[i]["depth"]]["contract"]:
+                if calldata and last_map[trace[i]["depth"]].get("function"):
                     fn = last_map[trace[i]["depth"]]["function"]
                     zip_ = zip(fn.abi["inputs"], fn.decode_input(calldata))
                     self._subcalls[-1].update(

--- a/brownie/test/managers/runner.py
+++ b/brownie/test/managers/runner.py
@@ -61,10 +61,10 @@ class RevertContextManager:
         CONFIG.argv["always_transact"] = self.always_transact
 
         if exc_type is None:
-            raise AssertionError("Transaction did not revert") from None
+            raise AssertionError("Transaction did not revert")
 
         if exc_type is not VirtualMachineError:
-            raise exc_type(exc_value) from None
+            raise
 
         if self.revert_msg is None or self.revert_msg == exc_value.revert_msg:
             return True


### PR DESCRIPTION
### What I did
Fix a bug when expanding a trace where the contract is known, but the called function is not valid.

This was introduced in #679 - an attempt to decode the calldata for the unknown function raises an `AttributeError`.

### How I did it
During `_expand_trace`, check for `"function"` instead of `"contract"`

### How to verify it
Run tests.

