### PR TITLE
Fix redo

### DIFF
--- a/brownie/network/state.py
+++ b/brownie/network/state.py
@@ -335,7 +335,7 @@ class Chain(metaclass=_Singleton):
             if num > len(self._undo_buffer):
                 raise ValueError(f"Undo buffer contains {len(self._undo_buffer)} items")
 
-            for i in range(num, 0, -1):
+            for i in range(num):
                 id_, fn, args, kwargs = self._undo_buffer.pop()
                 self._redo_buffer.append((fn, args, kwargs))
 
@@ -364,8 +364,8 @@ class Chain(metaclass=_Singleton):
             if num > len(self._redo_buffer):
                 raise ValueError(f"Redo buffer contains {len(self._redo_buffer)} items")
 
-            for i in range(num, 0, -1):
-                fn, args, kwargs = self._redo_buffer[-1]
+            for i in range(num):
+                fn, args, kwargs = self._redo_buffer.pop()
                 fn(*args, **kwargs)
 
             return web3.eth.blockNumber

--- a/tests/network/state/test_redo.py
+++ b/tests/network/state/test_redo.py
@@ -15,7 +15,7 @@ def test_redo(accounts, chain, web3):
 
 def test_redo_multiple(accounts, chain, web3):
     for i in range(1, 6):
-        accounts[0].transfer(accounts[i], "1 ether")
+        accounts[0].transfer(accounts[i], f"{i} ether")
     result = accounts[0].balance()
     chain.undo(5)
     chain.redo(5)

--- a/tests/network/state/test_undo.py
+++ b/tests/network/state/test_undo.py
@@ -14,7 +14,7 @@ def test_undo(accounts, chain, web3):
 def test_undo_multiple(accounts, chain, web3):
     initial = accounts[0].balance()
     for i in range(1, 6):
-        accounts[0].transfer(accounts[i], "1 ether")
+        accounts[0].transfer(accounts[i], f"{i} ether")
     chain.undo(5)
     assert accounts[0].balance() == initial
 


### PR DESCRIPTION
### What I did
Fix a bug in the `chain.redo` logic preventing redo of multiple transactions.


### How I did it
Correctly pop the tx from the redo buffer, instead of always referencing `[-1]`.

### How to verify it
Run tests. I updated the test case around this - it was passing because it was poorly designed.

