### PR TITLE
check for getitem/call before showing open paren hints

### DIFF
--- a/brownie/_cli/console.py
+++ b/brownie/_cli/console.py
@@ -501,6 +501,8 @@ def _parse_document(local_dict, text):
 
                 active_objects[-1] = obj
                 last_token = None
+                if not hasattr(active_objects[-1], "__call__"):
+                    raise SyntaxError
 
             paren_count += 1
             comma_data.append((0, token.end))
@@ -519,6 +521,8 @@ def _parse_document(local_dict, text):
             if last_token:
                 active_objects[-1] = _obj_from_token(active_objects[-1], last_token)
                 last_token = None
+                if not hasattr(active_objects[-1], "__getitem__"):
+                    raise SyntaxError
 
             is_open_sqb = True
             comma_data.append((0, token.end))


### PR DESCRIPTION
### What I did
Check validity of open bracket when finding type hints / completions.

### How I did it
* For `(` check that the object has a `__call__` method
* For `[` check that the object has a `__getitem__` method

### How to verify it
Try it in the console.
