### PR TITLE
Fix transaction verbosity

### DIFF
--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -351,7 +351,7 @@ class _PrivateKeyAccount(PublicKeyAccount):
         gas_price: Optional[int] = None,
         nonce: Optional[int] = None,
         required_confs: int = 1,
-        silent: bool = False,
+        silent: bool = None,
     ) -> Any:
         """Deploys a contract.
 
@@ -377,6 +377,8 @@ class _PrivateKeyAccount(PublicKeyAccount):
                 f"Local RPC using '{rpc.evm_version()}' but contract was compiled for '{evm}'"
             )
         data = contract.deploy.encode_input(*args)
+        if silent is None:
+            silent = bool(CONFIG.mode == "test" or CONFIG.argv["silent"])
         with self._lock:
             try:
                 txid = self._transact(  # type: ignore
@@ -471,7 +473,7 @@ class _PrivateKeyAccount(PublicKeyAccount):
         data: str = None,
         nonce: Optional[int] = None,
         required_confs: int = 1,
-        silent: bool = False,
+        silent: bool = None,
     ) -> TransactionReceipt:
         """
         Broadcast a transaction from this account.
@@ -488,6 +490,8 @@ class _PrivateKeyAccount(PublicKeyAccount):
         Returns:
             TransactionReceipt object
         """
+        if silent is None:
+            silent = bool(CONFIG.mode == "test" or CONFIG.argv["silent"])
         with self._lock:
             tx = {
                 "from": self.address,

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -111,7 +111,7 @@ class TransactionReceipt:
         self,
         txid: Union[str, bytes],
         sender: Any = None,
-        silent: bool = None,
+        silent: bool = True,
         required_confs: int = 1,
         name: str = "",
         revert_data: Optional[Tuple] = None,
@@ -126,12 +126,7 @@ class TransactionReceipt:
             name: contract function being called
             revert_data: (revert string, program counter, revert type)
         """
-        if silent is None and (CONFIG.mode == "test" or CONFIG.argv["silent"]):
-            self._silent = True
-        else:
-            if silent is None:
-                silent = True
-            self._silent = silent
+        self._silent = silent
 
         if isinstance(txid, bytes):
             txid = HexBytes(txid).hex()


### PR DESCRIPTION
### What I did
Fix transaction verbosity so it is correctly silenced when tests are running.

### How I did it
Move the `CONFIG.mode == "test" or CONFIG.argv["silent"]` check out of `TransactionReceipt` and into `Accounts`
