### PR TITLE
fix: decoding internal revert msg

### DIFF
--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -637,7 +637,7 @@ class TransactionReceipt:
                     subcall["selfdestruct"] = True
                 else:
                     if opcode == "REVERT":
-                        data = _get_memory(trace[i], -1)
+                        data = _get_memory(trace[i], -1)[4:]
                         if data:
                             subcall["revert_msg"] = decode_abi(["string"], data)[0]
                     if "revert_msg" not in subcall and "dev" in pc:


### PR DESCRIPTION
### What I did
Fix an issue when decoding an internal revert string.

Related to #679 

### How I did it
Ignore the first 4 bytes when decoding a revert string while expanding the trace.
