### PR TITLE
fix: copy hypothesis settings prior to mutation

### DIFF
--- a/brownie/_config.py
+++ b/brownie/_config.py
@@ -252,6 +252,7 @@ def _load_project_dependencies(project_path: Path) -> List:
 
 
 def _modify_hypothesis_settings(settings, name, parent=None):
+    settings = settings.copy()
     if parent is None:
         parent = hp_settings._current_profile
 


### PR DESCRIPTION
### What I did
Do not allow mutation of hypothesis settings.

Fixes #701 

### How I did it
In `brownie._config`, copy `settings` prior to mutation.

