### PR TITLE
Console output

### DIFF
--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -90,7 +90,9 @@ class Accounts(metaclass=_Singleton):
             return False
 
     def __repr__(self) -> str:
-        return str(self._accounts)
+        if CONFIG.argv["cli"] == "console":
+            return str(self._accounts)
+        return super().__repr__()
 
     def __iter__(self) -> Iterator:
         return iter(self._accounts)

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -122,7 +122,9 @@ class ContractContainer(_ContractBase):
         return len(self._contracts)
 
     def __repr__(self) -> str:
-        return str(self._contracts)
+        if CONFIG.argv["cli"] == "console":
+            return str(self._contracts)
+        return super().__repr__()
 
     def _reset(self) -> None:
         for contract in self._contracts:

--- a/brownie/network/rpc.py
+++ b/brownie/network/rpc.py
@@ -113,7 +113,7 @@ class Rpc(metaclass=_Singleton):
                         f'"{key}" with value "{value}".',
                         InvalidArgumentWarning,
                     )
-        print(f"Launching '{' '.join(cmd_list)}'...")
+        print(f"\nLaunching '{' '.join(cmd_list)}'...")
         out = DEVNULL if sys.platform == "win32" else PIPE
         self._rpc = psutil.Popen(cmd_list, stdin=DEVNULL, stdout=out, stderr=out)
         # check that web3 can connect

--- a/brownie/network/state.py
+++ b/brownie/network/state.py
@@ -40,7 +40,9 @@ class TxHistory(metaclass=_Singleton):
         _revert_register(self)
 
     def __repr__(self) -> str:
-        return str(self._list)
+        if CONFIG.argv["cli"] == "console":
+            return str(self._list)
+        return super().__repr__()
 
     def __bool__(self) -> bool:
         return bool(self._list)


### PR DESCRIPTION
### What I did
Minor improvements to console output:

* add a newline before showing RPC launch info
* only show contents of `ContractContainer` and `Accounts` in the console (makes pytest exception output easier to read)

