### PR TITLE
Fix undo call as tx

### DIFF
--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -1123,12 +1123,13 @@ class ContractCall(_ContractMethod):
 
         try:
             self.transact(*args, tx)
+            chain.undo()
         except VirtualMachineError as exc:
             pc, revert_msg = exc.pc, exc.revert_msg
+            chain.undo()
         except Exception:
             pass
 
-        chain.undo()
         try:
             return self.call(*args)
         except VirtualMachineError as exc:

--- a/tests/network/contract/test_contract.py
+++ b/tests/network/contract/test_contract.py
@@ -287,9 +287,9 @@ def test_as_proxy_for(network):
     original = Contract.from_explorer("0x3d9819210a31b4961b30ef54be2aed79b9c9cd3b")
     proxy = Contract.from_explorer(
         "0x3d9819210a31b4961b30ef54be2aed79b9c9cd3b",
-        as_proxy_for="0x9d0a0443ff4bb04391655b8cd205683d9fa75550",
+        as_proxy_for="0xAf601CbFF871d0BE62D18F79C31e387c76fa0374",
     )
-    implementation = Contract("0x9d0a0443ff4bb04391655b8cd205683d9fa75550")
+    implementation = Contract("0xAf601CbFF871d0BE62D18F79C31e387c76fa0374")
 
     assert original.abi == proxy.abi
     assert original.address == proxy.address


### PR DESCRIPTION
### What I did
* when handling a call-as-tx, do not call `chain.undo` if a transaction did not occur