### PR TITLE
Handle global structs and enums

### DIFF
--- a/brownie/project/compiler/solidity.py
+++ b/brownie/project/compiler/solidity.py
@@ -256,7 +256,9 @@ def _get_unique_build_json(
         "bytecode": bytecode,
         "bytecodeSha1": sha1(_remove_metadata(bytecode).encode()).hexdigest(),
         "coverageMap": {"statements": statement_map, "branches": branch_map},
-        "dependencies": [i.name for i in contract_node.dependencies],
+        "dependencies": [
+            i.name for i in contract_node.dependencies if i.nodeType == "ContractDefinition"
+        ],
         "offset": contract_node.offset,
         "pcMap": pc_map,
         "type": contract_node.contractKind,

--- a/brownie/project/sources.py
+++ b/brownie/project/sources.py
@@ -169,7 +169,7 @@ def get_contract_names(full_source: str) -> List:
     comment_regex = r"(?:\s*\/\/[^\n]*)|(?:\/\*[\s\S]*?\*\/)"
     uncommented_source = re.sub(comment_regex, "", full_source)
     contracts = re.findall(
-        r"((?:abstract contract|contract|library|interface)\s[^;{]*{[\s\S]*?})\s*(?=(?:abstract contract|contract|library|interface|pragma)\s|$)",  # NOQA: E501
+        r"((?:abstract contract|contract|library|interface)\s[^;{]*{[\s\S]*?})\s*(?=(?:abstract contract|contract|library|interface|pragma|struct|enum)\s|$)",  # NOQA: E501
         uncommented_source,
     )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ hypothesis==5.23.7
 prompt-toolkit==3.0.5
 psutil>=5.7.0,<6.0.0
 py>=1.5.0
-py-solc-ast>=1.2.4,<2.0.0
+py-solc-ast>=1.2.5,<2.0.0
 py-solc-x>=0.10.1,<1.0.0
 pygments==2.6.1
 pygments_lexer_solidity==0.5.1

--- a/tests/project/test_sources.py
+++ b/tests/project/test_sources.py
@@ -3,13 +3,17 @@
 import pytest
 from semantic_version import NpmSpec
 
+from brownie import compile_source
 from brownie.exceptions import NamespaceCollision
 from brownie.project import sources
 
 MESSY_SOURCE = """
-  pragma  solidity>=0.4.22    <0.7.0  ;contract Foo{} interface Bar {}
-abstract contract Baz is Foo {}
- library   Potato{}"""
+  pragma  solidity>=0.4.22   <0.7.0  ;contract Foo{} interface Bar
+    {} enum Struct { Contract }
+abstract contract Baz is Foo {} struct  Interface  { uint256 Abstract;
+}    library   Potato{} pragma     solidity    ^0.6.0;  contract Foo2 is
+Foo{ enum E {a, b}  struct S {bool b;
+}}  library Bar2{}"""
 
 
 @pytest.fixture(scope="module")
@@ -57,7 +61,12 @@ def test_get_source_path(sourceobj):
 
 def test_get_contract_names():
     names = sources.get_contract_names(MESSY_SOURCE)
-    assert names == ["Foo", "Bar", "Baz", "Potato"]
+    assert names == ["Foo", "Bar", "Baz", "Potato", "Foo2", "Bar2"]
+
+
+def test_load_messy_project():
+    project = compile_source(MESSY_SOURCE)
+    assert list(project.keys()) == ["Bar2", "Foo", "Foo2", "Potato"]
 
 
 def test_get_pragma_spec():


### PR DESCRIPTION
### What I did
Correctly handle structs and enums that are declared outside of a contract.

Closes #712 

### How I did it
* Fix the issue upstream in https://github.com/iamdefinitelyahuman/py-solc-ast/pull/12
* When compiling, ignore dependencies that are not contracts.
* Expand regex logic for finding contracts, to also handle structs and enums

### How to verify it
Run the tests.  I expanded an existing case to look at this functionality.
