### PR TITLE
Load project before conftest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/eth-brownie/brownie)
+### Fixed
+- Allow using contract types in conftest ([#719](https://github.com/eth-brownie/brownie/pull/719))
+
 ## [1.10.5](https://github.com/eth-brownie/brownie/tree/v1.10.5) - 2020-08-07
 ### Changed
 - Container repr outside of console ([#707](https://github.com/eth-brownie/brownie/pull/707))

--- a/brownie/test/plugin.py
+++ b/brownie/test/plugin.py
@@ -56,7 +56,7 @@ def pytest_addoption(parser):
         )
 
 
-def pytest_load_initial_conftests(early_config, parser, args):
+def pytest_load_initial_conftests():
     if project.check_for_project("."):
         try:
             active_project = project.load()
@@ -107,7 +107,7 @@ def pytest_configure(config):
                 {"phases": {"explicit": True, "generate": True, "target": True}}, "brownie-failfast"
             )
 
-        active_project = project.get_loaded_projects()[-1]
+        active_project = project.get_loaded_projects()[0]
         session = Plugin(config, active_project)
         config.pluginmanager.register(session, "brownie-core")
 

--- a/brownie/test/plugin.py
+++ b/brownie/test/plugin.py
@@ -56,9 +56,8 @@ def pytest_addoption(parser):
         )
 
 
-def pytest_configure(config):
+def pytest_load_initial_conftests(early_config, parser, args):
     if project.check_for_project("."):
-
         try:
             active_project = project.load()
             active_project.load_config()
@@ -67,6 +66,10 @@ def pytest_configure(config):
             # prevent pytest INTERNALERROR traceback when project fails to compile
             print(f"{color.format_tb(e)}\n")
             raise pytest.UsageError("Unable to load project")
+
+
+def pytest_configure(config):
+    if project.check_for_project("."):
 
         if not config.getoption("showinternal"):
             # do not include brownie internals in tracebacks

--- a/brownie/test/plugin.py
+++ b/brownie/test/plugin.py
@@ -107,6 +107,7 @@ def pytest_configure(config):
                 {"phases": {"explicit": True, "generate": True, "target": True}}, "brownie-failfast"
             )
 
+        active_project = project.get_loaded_projects()[-1]
         session = Plugin(config, active_project)
         config.pluginmanager.register(session, "brownie-core")
 

--- a/tests/test/plugin/test_conftest.py
+++ b/tests/test/plugin/test_conftest.py
@@ -1,0 +1,26 @@
+#!/usr/bin/python3
+
+
+def test_load_contract_type(plugintester):
+    plugintester.makeconftest(
+        """
+import pytest
+from brownie import BrownieTester
+
+@pytest.fixture(params=[BrownieTester, BrownieTester])
+def brownie_tester(request):
+    yield request.param"""
+    )
+
+    plugintester.makepyfile(
+        """
+def test_call_and_transact(brownie_tester, accounts, web3, fn_isolation):
+    c = accounts[0].deploy(brownie_tester, True)
+    c.setNum(12, {'from': accounts[0]})
+    assert web3.eth.blockNumber == 2
+    c.getTuple(accounts[0])
+    assert web3.eth.blockNumber == 2"""
+    )
+
+    result = plugintester.runpytest("-n 2")
+    result.assert_outcomes(passed=2)


### PR DESCRIPTION
### What I did
Fixes: #719

### How I did it
Load the project config during the discovery phase of conftest.py files

### How to verify it
Everything should still work, and loading contract types in conftest.py should be possible

### Checklist
- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [x] I have updated the documentation
- [x] I have added an entry to the changelog
