### PR TITLE
Allow `brownie run` outside of a project

### DIFF
--- a/brownie/_cli/run.py
+++ b/brownie/_cli/run.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from brownie import network, project
 from brownie._cli.console import Console
 from brownie._config import CONFIG, _update_argv_from_docopt
-from brownie.exceptions import ProjectNotFound
 from brownie.project.scripts import _get_path, run
 from brownie.test.output import _build_gas_profile_output
 from brownie.utils import color
@@ -39,8 +38,6 @@ def main():
         active_project = project.load()
         active_project.load_config()
         print(f"{active_project._name} is the active project.")
-    else:
-        raise ProjectNotFound
 
     network.connect(CONFIG.argv["network"])
 

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -94,7 +94,7 @@ def test_cli_compile_and_analyze_projectnotfound_exception(cli_tester):
     assert cli_tester.mock_subroutines.call_count == 0
 
 
-def test_cli_run_with_projectnotfound_exception(cli_tester):
+def test_cli_run_with_missing_file(cli_tester):
     cli_tester.monkeypatch.setattr("brownie.run", cli_tester.mock_subroutines)
 
     subtargets = ("brownie.network.connect",)
@@ -104,8 +104,8 @@ def test_cli_run_with_projectnotfound_exception(cli_tester):
     with pytest.raises(SystemExit):
         cli_tester.run_and_test_parameters("run testfile", parameters=None)
 
-    assert cli_tester.mock_subroutines.called is False
-    assert cli_tester.mock_subroutines.call_count == 0
+    assert cli_tester.mock_subroutines.called is True
+    assert cli_tester.mock_subroutines.call_count == 1
 
 
 def test_cli_ethpm(cli_tester, testproject):

--- a/tests/project/test_scripts.py
+++ b/tests/project/test_scripts.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-from brownie.exceptions import ProjectNotFound
 from brownie.project.scripts import run
 
 
@@ -41,11 +40,6 @@ def test_multiple_projects(testproject, otherproject):
     otherproject.close()
     with pytest.raises(FileNotFoundError):
         run("other")
-
-
-def test_no_project():
-    with pytest.raises(ProjectNotFound):
-        run("foo")
 
 
 def test_no_script(testproject):


### PR DESCRIPTION
### What I did
Allow use of `brownie run` outside of a project.

### How I did it
* Remove the requirement for a loaded project in `brownie._cli.run`
* Modify the import logic when loading scripts. The root folder is temporarily added to `sys.path` to ensure a script may be imported from anywhere.

### How to verify it
Try it out.

