### PR TITLE
Minor tweaks to `brownie run`

### DIFF
--- a/brownie/_cli/__main__.py
+++ b/brownie/_cli/__main__.py
@@ -44,6 +44,10 @@ def main():
         # this call triggers a SystemExit
         docopt(__doc__, ["brownie", "-h"])
 
+    if "-i" in sys.argv:
+        # a small kindness to ipython users
+        sys.argv[sys.argv.index("-i")] = "-I"
+
     cmd = sys.argv[1]
     cmd_list = [i.stem for i in Path(__file__).parent.glob("[!_]*.py")]
     if cmd not in cmd_list:

--- a/brownie/_cli/console.py
+++ b/brownie/_cli/console.py
@@ -184,6 +184,15 @@ class Console(code.InteractiveConsole):
             text = color.highlight(text)
         self.write(text)
 
+    def interact(self, *args, **kwargs):
+        # temporarily modify mode so that container repr's display correctly for console
+        cli_mode = CONFIG.argv["cli"]
+        CONFIG.argv["cli"] = "console"
+        try:
+            super().interact(*args, **kwargs)
+        finally:
+            CONFIG.argv["cli"] = cli_mode
+
     def raw_input(self, prompt=""):
         return self.prompt_session.prompt(prompt)
 

--- a/brownie/_cli/run.py
+++ b/brownie/_cli/run.py
@@ -21,7 +21,7 @@ Arguments:
 Options:
   --network [name]        Use a specific network (default {CONFIG.settings['networks']['default']})
   --silent                Suppress console output for transactions
-  --interactive -I        Open an interactive console if the script fails
+  --interactive -I        Open an interactive console when the script completes or raises
   --gas -g                Display gas profile for function calls
   --tb -t                 Show entire python traceback on exceptions
   --help -h               Display this message
@@ -34,6 +34,7 @@ def main():
     args = docopt(__doc__)
     _update_argv_from_docopt(args)
 
+    active_project = None
     if project.check_for_project():
         active_project = project.load()
         active_project.load_config()
@@ -45,25 +46,33 @@ def main():
     path_str = path.absolute().as_posix()
 
     try:
-        run(args["<filename>"], method_name=args["<function>"] or "main")
+        return_value = run(args["<filename>"], method_name=args["<function>"] or "main")
+        exit_code = 0
+        extra_locals = {"_": return_value}
     except Exception as e:
         print(color.format_tb(e))
+        frame = next(
+            (i.frame for i in inspect.trace()[::-1] if Path(i.filename).as_posix() == path_str),
+            None,
+        )
+        if frame is None:
+            # exception was an internal brownie issue - do not open the console
+            sys.exit(1)
 
+        # when exception occurs in the script, open console with the namespace of the failing frame
+        exit_code = 1
+        globals_dict = {k: v for k, v in frame.f_globals.items() if not k.startswith("__")}
+        extra_locals = {**globals_dict, **frame.f_locals}
+
+    try:
         if args["--interactive"]:
-            frame = next(
-                (i.frame for i in inspect.trace()[::-1] if Path(i.filename).as_posix() == path_str),
-                None,
-            )
-            if frame is not None:
-                globals_dict = {k: v for k, v in frame.f_globals.items() if not k.startswith("__")}
+            shell = Console(active_project, extra_locals)
+            shell.interact(banner="\nInteractive mode enabled. Use quit() to close.", exitmsg="")
+    finally:
+        # the console terminates from a SystemExit - make sure we still deliver the final gas report
+        if CONFIG.argv["gas"]:
+            print("\n======= Gas profile =======")
+            for line in _build_gas_profile_output():
+                print(line)
 
-                shell = Console(active_project, {**globals_dict, **frame.f_locals})
-                shell.interact(
-                    banner="\nInteractive mode enabled. Use quit() to close.", exitmsg=""
-                )
-        sys.exit(1)
-
-    if CONFIG.argv["gas"]:
-        print("\n======= Gas profile =======")
-        for line in _build_gas_profile_output():
-            print(line)
+        sys.exit(exit_code)

--- a/brownie/project/scripts.py
+++ b/brownie/project/scripts.py
@@ -52,10 +52,15 @@ def run(
         module = _import_from_path(script)
 
         name = module.__name__
+
         if not hasattr(module, method_name):
             raise AttributeError(f"Module '{name}' has no method '{method_name}'")
+        try:
+            module_path = Path(module.__file__).relative_to(Path(".").absolute())
+        except ValueError:
+            module_path = Path(module.__file__)
         print(
-            f"\nRunning '{color('bright blue')}{name}{color}."
+            f"\nRunning '{color('bright blue')}{module_path}{color}::"
             f"{color('bright cyan')}{method_name}{color}'..."
         )
         return getattr(module, method_name)(*args, **kwargs)


### PR DESCRIPTION
### What I did
* reduce length of path output when running scripts
* always enter console when using `brownie run -I` (even when script does not raise)
* correctly show container `__repr__` when loading console from `brownie run` or `brownie test`
