### PR TITLE
Use solcx v1.0.0

### DIFF
--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -3,7 +3,6 @@
 import json
 import os
 import re
-import sys
 import warnings
 from pathlib import Path
 from textwrap import TextWrapper
@@ -682,21 +681,18 @@ class Contract(_DeployedContractBase):
         else:
             try:
                 version = Version(compiler_str.lstrip("v")).truncate()
-                if sys.platform == "darwin":
-                    is_compilable = (
-                        version >= Version("0.5.0")
-                        or f"v{version}" in solcx.get_installed_solc_versions()
-                    )
-                else:
-                    is_compilable = f"v{version}" in solcx.get_available_solc_versions()
+                is_compilable = (
+                    version
+                    in solcx.get_installable_solc_versions() + solcx.get_installed_solc_versions()
+                )
             except Exception:
                 is_compilable = False
 
         if not is_compilable:
             if not silent:
                 warnings.warn(
-                    f"{address}: target compiler '{compiler_str}' is "
-                    "unsupported by Brownie. Some functionality will not be available.",
+                    f"{address}: target compiler '{compiler_str}' cannot be installed or is not "
+                    "supported by Brownie. Some debugging functionality will not be available.",
                     BrownieCompilerWarning,
                 )
             return cls.from_abi(name, address, abi, owner)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ prompt-toolkit==3.0.5
 psutil>=5.7.0,<6.0.0
 py>=1.5.0
 py-solc-ast>=1.2.5,<2.0.0
-py-solc-x>=0.10.1,<1.0.0
+py-solc-x>=1.0.0,<2.0.0
 pygments==2.6.1
 pygments_lexer_solidity==0.5.1
 pytest==5.4.3

--- a/tests/network/contract/test_contract.py
+++ b/tests/network/contract/test_contract.py
@@ -153,18 +153,6 @@ def test_from_explorer_pre_422(network):
     assert "pcMap" not in contract._build
 
 
-def test_from_explorer_osx_pre_050(network, monkeypatch):
-    network.connect("mainnet")
-    monkeypatch.setattr("sys.platform", "darwin")
-    installed = ["v0.5.8", "v0.5.7"]
-    monkeypatch.setattr("solcx.get_installed_solc_versions", lambda: installed)
-
-    # chainlink, compiler version 0.4.24
-    with pytest.warns(BrownieCompilerWarning):
-        contract = Contract.from_explorer("0xf79d6afbb6da890132f9d7c355e3015f15f3406f")
-    assert "pcMap" not in contract._build
-
-
 def test_from_explorer_vyper_supported_020(network):
     network.connect("mainnet")
 


### PR DESCRIPTION
### What I did
Update to use `solcx` v1.0.0

### How I did it
A few API changes, nothing too major.  This could be done much more effectively to take advantage of the new API, but I think that's more in the scope of brownie v2

### How to verify it
Run tests.
