### PR TITLE
Allow namespace collision between interfaces

### DIFF
--- a/tests/project/test_sources.py
+++ b/tests/project/test_sources.py
@@ -27,17 +27,18 @@ def test_namespace_collisions(solc5source):
     # contract collision
     with pytest.raises(NamespaceCollision):
         sources.Sources({"foo.sol": solc5source, "bar.sol": solc5source}, {})
-    # contract / interface collision
-    with pytest.raises(NamespaceCollision):
-        sources.Sources({"foo.sol": solc5source}, {"bar.sol": solc5source})
     # interface collision
     with pytest.raises(NamespaceCollision):
         sources.Sources({}, {"foo.sol": solc5source, "bar.sol": solc5source})
     # solc / vyper collision
     with pytest.raises(NamespaceCollision):
         sources.Sources({"foo.sol": solc5source, "Foo.vy": "@external\ndef bar(): pass"}, {})
-    with pytest.raises(NamespaceCollision):
-        sources.Sources({"foo.sol": solc5source}, {"Foo.vy": "@external\ndef bar(): pass"})
+
+
+def test_contract_interface_collisions(solc5source):
+    # contract / interface collision
+    sources.Sources({"foo.sol": solc5source}, {"bar.sol": solc5source})
+    sources.Sources({"foo.sol": solc5source}, {"Foo.vy": "@external\ndef bar(): pass"})
 
 
 def test_get_path_list(sourceobj):
@@ -61,7 +62,14 @@ def test_get_source_path(sourceobj):
 
 def test_get_contract_names():
     names = sources.get_contract_names(MESSY_SOURCE)
-    assert names == ["Foo", "Bar", "Baz", "Potato", "Foo2", "Bar2"]
+    assert names == [
+        ("Foo", "contract"),
+        ("Bar", "interface"),
+        ("Baz", "abstract contract"),
+        ("Potato", "library"),
+        ("Foo2", "contract"),
+        ("Bar2", "library"),
+    ]
 
 
 def test_load_messy_project():


### PR DESCRIPTION
### What I did
Lessen the namespace collision restrictions.

Closes #729 

### How I did it
When looking for collisions, allow multiple uses of the same name so long as only one of the objects is a contract. This way projects using interfaces with the same name as the actual contract will now compile.

### How to verify it
Try to compile https://github.com/compound-finance/compound-protocol using Brownie
