### PR TITLE
Block iterator

### DIFF
--- a/docs/api-network.rst
+++ b/docs/api-network.rst
@@ -1619,6 +1619,22 @@ Chain Methods
         >>> chain.get_transaction(0xf598d43ef34a48478f3bb0ad969c6735f416902c4eb1eb18ebebe0fca786105e)
         <Transaction '0xf598d43ef34a48478f3bb0ad969c6735f416902c4eb1eb18ebebe0fca786105e'>
 
+.. py:method:: Chain.new_blocks(height_buffer, poll_interval)
+
+    Generator for iterating over new blocks.
+
+    ``height_buffer``: The number of blocks behind "latest" to return. A higher value means more delayed results but less likelihood of uncles.
+    ``poll_interval``: Maximum interval between querying for a new block, if the height has not changed. Set this lower to detect uncles more frequently.
+
+    .. code-block:: python
+
+        count = 0
+        for block in chain.new_blocks():
+            print(block.number)
+            count += 1
+            if count == 5:
+                break
+
 .. py:method:: Chain.time()
 
     Return the current epoch time in the RPC as an integer.


### PR DESCRIPTION
### What I did
Add a block iterator to allow simple loops looking at the latest block.

### How I did it
`chain.new_blocks()` returns an iterator that polls `eth_getBlock` and yields new blocks as they arrive. You can set a buffer to get `latest-n` blocks and avoid chain reorgs, and a polling interval to avoid over-frequent requests.

This is a naive implementation and should be replaced with `eth_subscribe` at some point in the future.
