### PR TITLE
fix: expand_trace with unknown contract

### DIFF
--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -616,9 +616,11 @@ class TransactionReceipt:
                     last["address"], trace[i]["stack"][-2][-40:], trace[i]["stack"][-3]
                 )
 
-            if not last["pc_map"]:
+            try:
+                pc = last["pc_map"][trace[i]["pc"]]
+            except (KeyError, TypeError):
+                # we don't have enough information about this contract
                 continue
-            pc = last["pc_map"][trace[i]["pc"]]
 
             if trace[i]["depth"] and opcode in ("RETURN", "REVERT", "INVALID", "SELFDESTRUCT"):
                 subcall: dict = next(


### PR DESCRIPTION
### What I did
Fix a bug when expanding a trace where the contract being called is not known (or incorrectly known).

### How I did it
Instead of only checking for the existence of a pcMap, handle a `KeyError` or `TypeError` when attempting to access it.