### PR TITLE
Interface selectors

### DIFF
--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -292,6 +292,9 @@ class InterfaceConstructor:
     def __init__(self, name: str, abi: List) -> None:
         self._name = name
         self.abi = abi
+        self.selectors = {
+            build_function_selector(i): i["name"] for i in self.abi if i["type"] == "function"
+        }
 
     def __call__(self, address: str, owner: Optional[AccountsType] = None) -> "Contract":
         return Contract.from_abi(self._name, address, self.abi, owner)

--- a/brownie/project/compiler/__init__.py
+++ b/brownie/project/compiler/__init__.py
@@ -413,7 +413,7 @@ def get_abi(
             continue
         name = Path(path).stem
         final_output[name] = {
-            "abi": output_json["contracts"][path][name],
+            "abi": output_json["contracts"][path][name]["abi"],
             "contractName": name,
             "type": "interface",
             "sha1": sha1(contract_sources[path].encode()).hexdigest(),


### PR DESCRIPTION
### What I did
* Add a `selectors` attribute to `InterfaceConstructor`.
* Fix a formatting bug when compiling vyper interfaces to ABIs
