### PR TITLE
fix: check min version when using from_explorer

### DIFF
--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -685,7 +685,8 @@ class Contract(_DeployedContractBase):
             try:
                 version = Version(compiler_str.lstrip("v")).truncate()
                 is_compilable = (
-                    version
+                    version >= Version("0.4.22")
+                    and version
                     in solcx.get_installable_solc_versions() + solcx.get_installed_solc_versions()
                 )
             except Exception:


### PR DESCRIPTION
### What I did
Check that solc version is `>=0.4.22` when fetching from Etherscan.  Fixes a bug introduced when updating to use solc v1