### PR TITLE
feat: warn instead of raising on incorrectly formatted event

### DIFF
--- a/brownie/network/event.py
+++ b/brownie/network/event.py
@@ -1,11 +1,13 @@
 #!/usr/bin/python3
 
 import json
+import warnings
 from collections import OrderedDict
 from pathlib import Path
 from typing import Dict, Iterator, List, Optional, Sequence, Tuple, Union, ValuesView
 
 import eth_event
+from eth_event import EventError
 
 from brownie._config import _get_data_folder
 from brownie.convert.normalize import format_event
@@ -222,7 +224,11 @@ def _decode_logs(logs: List) -> Union["EventDict", List[None]]:
             log_slice = logs[idx:]
 
         topics_map = _deployment_topics.get(address, _topics)
-        events.extend(eth_event.decode_logs(log_slice, topics_map, allow_undecoded=True))
+        for item in log_slice:
+            try:
+                events.extend(eth_event.decode_logs([item], topics_map, allow_undecoded=True))
+            except EventError as exc:
+                warnings.warn(str(exc))
 
         if log_slice[-1] == logs[-1]:
             break

--- a/tests/network/contract/test_contract.py
+++ b/tests/network/contract/test_contract.py
@@ -296,9 +296,9 @@ def test_as_proxy_for(network):
     original = Contract.from_explorer("0x3d9819210a31b4961b30ef54be2aed79b9c9cd3b")
     proxy = Contract.from_explorer(
         "0x3d9819210a31b4961b30ef54be2aed79b9c9cd3b",
-        as_proxy_for="0xAf601CbFF871d0BE62D18F79C31e387c76fa0374",
+        as_proxy_for="0x7b5e3521a049C8fF88e6349f33044c6Cc33c113c",
     )
-    implementation = Contract("0xAf601CbFF871d0BE62D18F79C31e387c76fa0374")
+    implementation = Contract("0x7b5e3521a049C8fF88e6349f33044c6Cc33c113c")
 
     assert original.abi == proxy.abi
     assert original.address == proxy.address


### PR DESCRIPTION
### What I did
Warning instead of raising when an event is undecodable from incorrect number of topics.

Fixes https://github.com/iearn-finance/yearn-protocol/issues/7