### PR TITLE
Improved error message for EIP170

### DIFF
--- a/brownie/exceptions.py
+++ b/brownie/exceptions.py
@@ -76,7 +76,7 @@ class VirtualMachineError(Exception):
 
     def __init__(self, exc: ValueError) -> None:
         try:
-            exc = yaml.safe_load(str(exc))
+            exc = exc.args[0]
         except Exception:
             pass
 

--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -415,6 +415,9 @@ class _PrivateKeyAccount(PublicKeyAccount):
                 exc, revert_data = None, None
             except ValueError as e:
                 exc = VirtualMachineError(e)
+                size = len(contract._build["deployedBytecode"]) // 2
+                if exc.revert_type == "out of gas" and size > 24577:
+                    exc.revert_msg = "exceeds EIP-170 size limit"
                 if not hasattr(exc, "txid"):
                     raise exc from None
                 txid = exc.txid


### PR DESCRIPTION
### What I did
When a contract fails to deploy because the bytecode is too large, give a more meaningful error message.