### PR TITLE
Use evm_unlockUnknownAccount to unlock arbitrary accounts

### DIFF
--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -226,6 +226,11 @@ class Accounts(metaclass=_Singleton):
 
         if acct is None and (address in web3.eth.accounts or force):
             acct = Account(address)
+
+            if CONFIG.network_type == "development" and address not in web3.eth.accounts:
+                # prior to ganache v6.11.0 this does nothing, but should not raise
+                web3.provider.make_request("evm_unlockUnknownAccount", [address])  # type: ignore
+
             self._accounts.append(acct)
 
         if acct:

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -1203,6 +1203,10 @@ def _get_tx(owner: Optional[AccountsType], args: Tuple) -> Tuple:
         for key, target in [("amount", "value"), ("gas_limit", "gas"), ("gas_price", "gasPrice")]:
             if key in tx:
                 tx[target] = tx[key]
+
+    if isinstance(tx["from"], str):
+        tx["from"] = accounts.at(tx["from"], force=True)
+
     return args, tx
 
 


### PR DESCRIPTION
### What I did
Use `evm_unlockUnkownAccount` to unlock arbitrary accounts.

This implements #758, but as it requires a beta version of ganache I am leaving the issue open for now. Once the feature moves from beta to stable I will bump the recommended version, add tests and documentation, and consider the issue closed.

### How I did it
Any address may be given as a string in the `from` field of a transaction dict.  Strings are converted to `Account` objects using `Accounts.at`.  If the address is unknown, it is unlocked with `evm_unlockUnkownAccount`.  Calling this endpoint prior to ganache `v6.11.0` appears to do nothing - and importantly, does not raise an exception.

### How to verify it
Try it out!