### PR TITLE
Attempt to determine implementation address without etherscan

### DIFF
--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -671,7 +671,13 @@ class Contract(_DeployedContractBase):
             )
 
         if as_proxy_for is None and data["result"][0].get("Implementation"):
-            as_proxy_for = _resolve_address(data["result"][0]["Implementation"])
+            try:
+                # many proxy patterns use an `implementation()` function, so first we
+                # try to determine the implementation address without trusting etherscan
+                contract = cls.from_abi(name, address, abi)
+                as_proxy_for = contract.implementation()
+            except Exception:
+                as_proxy_for = _resolve_address(data["result"][0]["Implementation"])
 
         if as_proxy_for == address:
             as_proxy_for = None


### PR DESCRIPTION
### What I did
Check for `implementation()` method to determine proxy implementation. If this is not found, the previous method (trust etherscan) is used.
