### PR TITLE
release: update changelog, bump version to v1.11.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/eth-brownie/brownie)
+## [1.11.6](https://github.com/eth-brownie/brownie/tree/v1.11.6) - 2020-09-26
+### Added
+- `Account.get_deployment_address` ([#763](https://github.com/eth-brownie/brownie/pull/763))
+- Use `eth_unlockUnkonwnAccount` to unlock arbitrary accounts in development mode ([#776](https://github.com/eth-brownie/brownie/pull/776))
+
+### Changed
+- Generalize `sys.argv` handling for `brownie test` to allow arbitrary flags ([#773](https://github.com/eth-brownie/brownie/pull/773))
+- Disable `stdout` capture when compiling a project prior to running tests ([#774](https://github.com/eth-brownie/brownie/pull/774))
+- Attempt to determine proxy implementation without relying on Etherscan APi output ([#777](https://github.com/eth-brownie/brownie/pull/777))
+
+### Fixed
+- Add `gas_limit` kwarg for `Account.estimate_gas` ([#764](https://github.com/eth-brownie/brownie/pull/764))
+- Improve exception message on bytecode exceeding 24kb limit ([#767](https://github.com/eth-brownie/brownie/pull/767))
+- Properly handle no installed compiler when using `compile_source` ([#768](https://github.com/eth-brownie/brownie/pull/768))
+
 ## [1.11.5](https://github.com/eth-brownie/brownie/tree/v1.11.5) - 2020-09-16
 ### Changed
 - `EthAddress` is now hashable ([#756](https://github.com/eth-brownie/brownie/pull/756))

--- a/brownie/_config.py
+++ b/brownie/_config.py
@@ -17,7 +17,7 @@ from hypothesis.database import DirectoryBasedExampleDatabase
 
 from brownie._singleton import _Singleton
 
-__version__ = "1.11.5"
+__version__ = "1.11.6"
 
 BROWNIE_FOLDER = Path(__file__).parent
 DATA_FOLDER = Path.home().joinpath(".brownie")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.11.5
+current_version = 1.11.6
 
 [bumpversion:file:setup.py]
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("requirements.txt", "r") as f:
 setup(
     name="eth-brownie",
     packages=find_packages(),
-    version="1.11.5",  # don't change this manually, use bumpversion instead
+    version="1.11.6",  # don't change this manually, use bumpversion instead
     license="MIT",
     description="A Python framework for Ethereum smart contract deployment, testing and interaction.",  # noqa: E501
     long_description=long_description,


### PR DESCRIPTION
### What I did
* update changelog
* bump version to `v1.11.6`