### PR TITLE
Console hinting improvements

### DIFF
--- a/brownie/_cli/console.py
+++ b/brownie/_cli/console.py
@@ -124,7 +124,7 @@ class Console(code.InteractiveConsole):
                 include_default_pygments_style=False,
             )
         if console_settings["auto_suggest"]:
-            kwargs["auto_suggest"] = TestAutoSuggest(self, locals_dict)
+            kwargs["auto_suggest"] = ConsoleAutoSuggest(self, locals_dict)
         if console_settings["completions"]:
             kwargs["completer"] = ConsoleCompleter(self, locals_dict)
 
@@ -324,7 +324,7 @@ class ConsoleCompleter(Completer):
             return
 
 
-class TestAutoSuggest(AutoSuggest):
+class ConsoleAutoSuggest(AutoSuggest):
     """
     AutoSuggest subclass to display contract input hints.
 
@@ -359,7 +359,7 @@ class TestAutoSuggest(AutoSuggest):
                 distance = len(document.text) - offset[1]
 
             if hasattr(obj, "_autosuggest"):
-                inputs = obj._autosuggest()
+                inputs = obj._autosuggest(obj)
             else:
                 inputs = [f" {i}" for i in obj.__code__.co_varnames[: obj.__code__.co_argcount]]
                 if obj.__defaults__:

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -252,8 +252,8 @@ class ContractConstructor:
         )
 
     @staticmethod
-    def _autosuggest(self) -> List:
-        return _contract_method_autosuggest(self.abi["inputs"], True, self.payable)
+    def _autosuggest(obj: "ContractConstructor") -> List:
+        return _contract_method_autosuggest(obj.abi["inputs"], True, obj.payable)
 
     def encode_input(self, *args: tuple) -> str:
         bytecode = self._parent.bytecode
@@ -994,10 +994,10 @@ class _ContractMethod:
             return self.abi["stateMutability"] == "payable"
 
     @staticmethod
-    def _autosuggest(self) -> List:
+    def _autosuggest(obj: "_ContractMethod") -> List:
         # this is a staticmethod to be compatible with `_call_suggest` and `_transact_suggest`
         return _contract_method_autosuggest(
-            self.abi["inputs"], isinstance(self, ContractTx), self.payable
+            obj.abi["inputs"], isinstance(obj, ContractTx), obj.payable
         )
 
     def info(self) -> None:
@@ -1393,14 +1393,14 @@ def _fetch_from_explorer(address: str, action: str, silent: bool) -> Dict:
 # console auto-completion logic
 
 
-def _call_autosuggest(method):
+def _call_autosuggest(method: Any) -> List:
     # since methods are not unique for each object, we use `__reduce__`
     # to locate the specific object so we can access the correct ABI
     method = method.__reduce__()[1][0]
     return _contract_method_autosuggest(method.abi["inputs"], False, False)
 
 
-def _transact_autosuggest(method):
+def _transact_autosuggest(method: Any) -> List:
     method = method.__reduce__()[1][0]
     return _contract_method_autosuggest(method.abi["inputs"], True, method.payable)
 


### PR DESCRIPTION
### What I did
* Generate hints from actual objects when referencing an iterable index
* Show autosuggest for `Contract.function.call` or `Contract.function.transact`
* Add `Contract.function.estimate_gas` method
