### PR TITLE
feat: auto-add `tx` as a variable for interactive debugging

### DIFF
--- a/brownie/test/managers/runner.py
+++ b/brownie/test/managers/runner.py
@@ -366,6 +366,9 @@ class PytestBrownieRunner(PytestBrownieBase):
             locals_dict = {k: v for k, v in locals_dict.items() if not k.startswith("@")}
 
             namespace = {"_callinfo": call, **globals_dict, **locals_dict}
+            if "tx" not in namespace and brownie.history:
+                # make it easier to look at the most recent transaction
+                namespace["tx"] = brownie.history[-1]
 
             try:
                 CONFIG.argv["cli"] = "console"


### PR DESCRIPTION
### What I did
Automatically add `tx` as a local variable when dropping into the console to debug a failing test.
