### PR TITLE
TxHistory.filter

### DIFF
--- a/brownie/network/state.py
+++ b/brownie/network/state.py
@@ -6,7 +6,7 @@ import time
 import weakref
 from hashlib import sha1
 from sqlite3 import OperationalError
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
 
 from hexbytes import HexBytes
 from requests.exceptions import ConnectionError as RequestsConnectionError
@@ -75,6 +75,31 @@ class TxHistory(metaclass=_Singleton):
     def copy(self) -> List:
         """Returns a shallow copy of the object as a list"""
         return self._list.copy()
+
+    def filter(self, key: Optional[Callable] = None, **kwargs: Dict) -> List:
+        """
+        Return a filtered list of transactions.
+
+        Arguments
+        ---------
+        key : Callable, optional
+            An optional function to filter with. It should expect one agument and return
+            True or False.
+
+        Keyword Arguments
+        -----------------
+        **kwargs : Any
+            Names and expected values for TransactionReceipt attributes.
+
+        Returns
+        -------
+        List
+            A filtered list of TransactionReceipt objects.
+        """
+        result = [i for i in self._list if all(getattr(i, k) == v for k, v in kwargs.items())]
+        if key is None:
+            return result
+        return [i for i in result if key(i)]
 
     def from_sender(self, account: str) -> List:
         """Returns a list of transactions where the sender is account"""

--- a/docs/api-network.rst
+++ b/docs/api-network.rst
@@ -1525,6 +1525,24 @@ TxHistory Methods
         >>> type(c)
         <class 'list'>
 
+.. py:classmethod:: TxHistory.filter(key=None, **kwargs)
+
+    Return a filtered list of transactions.
+
+    Each keyword argument corresponds to a :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>` attribute. Only transactions where every attributes matches the given value are returned.
+
+    .. code-block:: python
+
+        >>> history.filter(sender=accounts[0], value="1 ether")
+        [<Transaction object '0xe803698b0ade1598c594b2c73ad6a656560a4a4292cc7211b53ffda4a1dbfbe8'>]
+
+    You can also use ``key`` to prodive a function or lambda. It should receive one argument, a :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>`, and return a boolean indicating if the object is to be included in the result.
+
+    .. code-block:: python
+
+        >>> history.filter(key=lambda k: k.nonce < 2)
+        [<Transaction '0x03569ee152b04ba5b55c2bf05f99f7ec153db715acfe0c1600f144ded58f31fe'>, <Transaction '0x42193c0ff7007c6e2a5e5572a3c6b5706cd133d21e30e5826add3d971134504c'>]
+
 .. py:classmethod:: TxHistory.from_sender(account)
 
     Returns a list of transactions where the sender is :func:`Account <brownie.network.account.Account>`.

--- a/docs/core-chain.rst
+++ b/docs/core-chain.rst
@@ -66,6 +66,16 @@ The :func:`TxHistory <brownie.network.state.TxHistory>` container, available as 
         <Transaction object '0xa7616a96ef571f1791586f570017b37f4db9decb1a5f7888299a035653e8b44b'>
     ]
 
+You can use :func:`history.filter <TxHistory.filter>` to filter for specific transactions, either with key-value pairs or a lambda function:
+
+.. code-block:: python
+
+    >>> history.filter(sender=accounts[0], value="1 ether")
+    [<Transaction object '0xe803698b0ade1598c594b2c73ad6a656560a4a4292cc7211b53ffda4a1dbfbe8'>]
+
+    >>> history.filter(key=lambda k: k.nonce < 2)
+    [<Transaction '0x03569ee152b04ba5b55c2bf05f99f7ec153db715acfe0c1600f144ded58f31fe'>, <Transaction '0x42193c0ff7007c6e2a5e5572a3c6b5706cd133d21e30e5826add3d971134504c'>]
+
 Other Transactions
 ------------------
 

--- a/tests/network/state/test_txhistory.py
+++ b/tests/network/state/test_txhistory.py
@@ -67,3 +67,13 @@ def test_copy(accounts, history, chain):
     assert h[0] == history[0]
     chain.reset()
     assert len(h) == 1
+
+
+def test_filter(accounts, history):
+    tx1 = accounts[0].transfer(accounts[1], "1 ether")
+    tx2 = accounts[1].transfer(accounts[2], "2 ether")
+    tx3 = accounts[0].transfer(accounts[2], "3 ether")
+
+    assert history.filter(sender=accounts[0]) == [tx1, tx3]
+    assert history.filter(sender=accounts[1], receiver=accounts[2]) == [tx2]
+    assert history.filter(sender=accounts[0], key=lambda k: k.value > "1 ether") == [tx3]


### PR DESCRIPTION
### What I did
Add a `filter` method to the `TxHistory` object.

### How I did it
`TxHistory.filter` returns a filtered list of transactions. Each kwarg value must match against an attribute in the `TransactionReceipt`. A lambda can also be provided via `key`.

### How to verify it
Run the tests. I added some test cases.
