### PR TITLE
Fix: source offset for nonpayable revert in Vyper >=0.2.5

### DIFF
--- a/brownie/project/compiler/vyper.py
+++ b/brownie/project/compiler/vyper.py
@@ -371,6 +371,8 @@ def _generate_coverage_data(
     if len(pc_list) > 7 and pc_list[0]["op"] == "CALLVALUE" and pc_list[6]["op"] == "REVERT":
         # special case - initial nonpayable check on vyper >=0.2.5
         pc_list[6]["dev"] = "Cannot send ether to nonpayable function"
+        # hackiness to prevent the source highlight from showing the entire contract
+        pc_list[5].update(path="0", offset=[0, 0])
 
     pc_map = dict((i.pop("pc"), i) for i in pc_list)
 

--- a/brownie/project/sources.py
+++ b/brownie/project/sources.py
@@ -163,6 +163,10 @@ def highlight_source(source: str, offset: Tuple, pad: int = 3) -> Tuple:
     count = source[offset[1] : pad_stop].count("\n")
     final = final.replace("\n ", f"\n{color('dark white')} ", count)
 
+    # prepend with a newline if the offset starts on the first line
+    if offset[0] < newlines[1]:
+        final = f"\n{final}"
+
     return final, ln
 
 


### PR DESCRIPTION
### What I did
Ensure that the entire source code is not displayed during the revert message on an attempt to pay a Vyper >=0.2.5 nonpayable contract

### How I did it
A bit of hackiness.
