### PR TITLE
Incorrect location of key for yaml

### DIFF
--- a/docs/ethpm.rst
+++ b/docs/ethpm.rst
@@ -200,7 +200,7 @@ Here is an example configuration for ``ethpm-config.yaml``:
     settings:
       deployment_networks:
         - mainnet
-    include_dependencies: false
+      include_dependencies: false
 
     # optional fields
     meta:


### PR DESCRIPTION
### What I did
Noticed that I couldn't create a manifest due to the organization of the keys in the example