### PR TITLE
target correct ConnectionError when pulling vyper versions

### DIFF
--- a/brownie/project/compiler/vyper.py
+++ b/brownie/project/compiler/vyper.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Optional, Tuple, Union
 
 import vvm
 import vyper
+from requests.exceptions import ConnectionError
 from semantic_version import Version
 from vyper.cli import vyper_json
 from vyper.exceptions import VyperException


### PR DESCRIPTION
### What I did
Expect `requests.ConnectionError` when querying vyper versions, instead of the builtin `ConnectionError`
