### PR TITLE
Console completions for attributes on containers

### DIFF
--- a/brownie/_cli/console.py
+++ b/brownie/_cli/console.py
@@ -385,7 +385,10 @@ def _obj_from_token(obj, token):
     if isinstance(obj, dict):
         return obj[key]
     if isinstance(obj, Iterable):
-        return obj[int(key)]
+        try:
+            return obj[int(key)]
+        except ValueError:
+            pass
     return getattr(obj, key)
 
 


### PR DESCRIPTION
### What I did
More tweaking of console autocomplete.

This fixes an issue preventing hints on `Contract.deploy(`
