### PR TITLE
fix: filter heuristics from dev revert map

### DIFF
--- a/brownie/project/build.py
+++ b/brownie/project/build.py
@@ -88,12 +88,15 @@ class Build:
                 except (KeyError, ValueError):
                     pass
 
-            msg = "" if data["op"] == "REVERT" else "invalid opcode"
+            msg = data.get("dev")
+            if msg is None or not msg.startswith("dev:"):
+                # filter out revert strings generated via heuristics (overflows, bounds checks, etc)
+                msg = "" if data["op"] == "REVERT" else "invalid opcode"
             revert = (
                 path_str,
                 tuple(data["offset"]),
                 data.get("fn", "<None>"),
-                data.get("dev", msg),
+                msg,
                 self._sources,
             )
 


### PR DESCRIPTION
### What I did
When generating the dev revert map, do not include revert strings generated from heuristics.

Fixes an issue encountered with Curve DAO's test suite: https://github.com/curvefi/curve-dao-contracts/runs/1317870437?check_suite_focus=true#step:8:1361

### How I did it
Filter revert messages that do not begin with `dev: `

