### PR TITLE
Set bake project names to lowercase

### DIFF
--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -564,7 +564,7 @@ def from_brownie_mix(
 
     Returns the path to the project as a string.
     """
-    project_name = str(project_name).replace("-mix", "")
+    project_name = str(project_name).lower().replace("-mix", "")
     url = MIXES_URL.format(project_name)
     if project_path is None:
         project_path = Path(".").joinpath(project_name)


### PR DESCRIPTION
### What I did
Normalize project names when calling `brownie bake`

Closes #827 

### How I did it
Lowercase the given name.

