### PR TITLE
add ZERO_ADDRESS constant to main namespace

### DIFF
--- a/brownie/__init__.py
+++ b/brownie/__init__.py
@@ -9,11 +9,13 @@ from brownie.convert import Fixed, Wei
 from brownie.network import accounts, alert, chain, history, rpc, web3
 from brownie.network.contract import Contract  # NOQA: F401
 
+ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 
 config = _CONFIG.settings
 
 __all__ = [
     "Contract",
+    "ZERO_ADDRESS",
     "accounts",  # accounts is an Accounts singleton
     "alert",
     "chain",


### PR DESCRIPTION
### What I did
Add `ZERO_ADDRESS` to the main brownie namespace:

```python
>>> from brownie import ZERO_ADDRESS
>>> ZERO_ADDRESS
"0x0000000000000000000000000000000000000000"
```