### PR TITLE
fix: unknown test when attempting to enter console

### DIFF
--- a/brownie/test/managers/runner.py
+++ b/brownie/test/managers/runner.py
@@ -349,13 +349,18 @@ class PytestBrownieRunner(PytestBrownieBase):
             Result/Exception info for the failed test.
         """
         if self.config.getoption("interactive") and report.failed:
+            location = self._path(report.location[0])
+            if location not in self.node_map:
+                # if the exception happened prior to collection it is likely a
+                # SyntaxError and we cannot open an interactive debugger
+                return
+
             capman = self.config.pluginmanager.get_plugin("capturemanager")
             if capman:
                 capman.suspend_global_capture(in_=True)
 
             tw = TerminalWriter()
             report.longrepr.toterminal(tw)
-            location = self._path(report.location[0])
 
             # find last traceback frame within the active test
             excinfo = call.excinfo


### PR DESCRIPTION
### What I did
Fix an unhandled exception when attempting to use `--interactive` and a test contains a syntax error.

### How I did it
If a test cannot be collected, it is not added to `node_map` within the runner.  This results in a `KeyError` when trying to access the value to filter the local namespace.

To fix it, I've added a check that the path is present in `node_map` prior to opening the console. 

### How to verify it
Try to interactively debug a test with a syntax error.  It still won't be possible, but you'll receive the correct exception.