### PR TITLE
Allow arbitrary tx's from ProjectContract objects

### DIFF
--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -1281,7 +1281,7 @@ def _get_tx(owner: Optional[AccountsType], args: Tuple) -> Tuple:
     # enable the magic of ganache's `evm_unlockUnknownAccount`
     if isinstance(tx["from"], str):
         tx["from"] = accounts.at(tx["from"], force=True)
-    elif isinstance(tx["from"], Contract):
+    elif isinstance(tx["from"], _DeployedContractBase):
         tx["from"] = accounts.at(tx["from"].address, force=True)
 
     return args, tx


### PR DESCRIPTION
### What I did
Allow the use of `ProjectContract` objects in the `from` field when sending a transaction.

### How I did it
In `brownie.network.contracts`, when determining the from address, check for an instance of `_DeployedContractBase` instead of `Contract`.

