### PR TITLE
Add `timestamp` kwarg to `chain.mine`

### DIFF
--- a/brownie/network/state.py
+++ b/brownie/network/state.py
@@ -190,6 +190,9 @@ class Chain(metaclass=_Singleton):
             self._block_gas_time = block["timestamp"]
         return block
 
+    def __iter__(self) -> Iterator:
+        return iter(web3.eth.getBlock(i) for i in range(web3.eth.blockNumber + 1))
+
     def new_blocks(self, height_buffer: int = 0, poll_interval: int = 5) -> Iterator:
         """
         Generator for iterating over new blocks.

--- a/docs/api-network.rst
+++ b/docs/api-network.rst
@@ -1685,11 +1685,12 @@ Chain Methods
         >>> chain.time()
         1550189143
 
-.. py:method:: Chain.mine(blocks=1)
+.. py:method:: Chain.mine(blocks=1, timestamp=None)
 
     Mine one or more empty blocks.
 
     * ``blocks``: Number of blocks to mine
+    * ``timestamp``: Timestamp of the final block being mined. If multiple blocks are mined, they will be mined at equal intervals starting from :ref:`chain.time <Chain.time>` and ending at ``timestamp``.
 
     Returns the block height after all new blocks have been mined.
 

--- a/tests/network/state/test_blocks.py
+++ b/tests/network/state/test_blocks.py
@@ -32,3 +32,22 @@ def test_getitem_positive_index(devnetwork, accounts, chain, web3):
 
     assert chain[0] == block
     assert chain[0] != web3.eth.getBlock("latest")
+
+
+def test_mine_timestamp(devnetwork, chain):
+    chain.mine(timestamp=12345)
+
+    assert chain[-1].timestamp == 12345
+    assert chain.time() - 12345 < 3
+
+
+def test_mine_multiple_timestamp(devnetwork, chain):
+    chain.mine(5, timestamp=chain.time() + 123)
+    timestamps = [i.timestamp for i in list(chain)[-5:]]
+
+    assert chain.time() - timestamps[-1] < 3
+
+    for i in range(1, 5):
+        assert timestamps[i] > timestamps[i - 1]
+
+    assert timestamps[0] + 123 == timestamps[-1]


### PR DESCRIPTION
### What I did
Allow mining blocks at a specific height with `chain.mine`.

If multiple blocks are mined, they will be mined at equal intervals starting from `chain.time` and ending at `timestamp`.
