### PR TITLE
Allow replacing pending transactions

### DIFF
--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -450,14 +450,16 @@ class _PrivateKeyAccount(PublicKeyAccount):
                 txid,
                 self,
                 silent=silent,
-                required_confs=0,
+                required_confs=required_confs,
+                is_blocking=False,
                 name=contract._name + ".constructor",
                 revert_data=revert_data,
             )
             # add the TxHistory before waiting for confirmation, this way the tx
             # object is available if the user CTRL-C to stop waiting in the console
             history._add_tx(receipt)
-            receipt.wait(required_confs)
+            if required_confs > 0:
+                receipt._confirmed.wait()
 
         add_thread = threading.Thread(target=contract._add_from_tx, args=(receipt,), daemon=True)
         add_thread.start()
@@ -589,12 +591,18 @@ class _PrivateKeyAccount(PublicKeyAccount):
                 revert_data = (exc.revert_msg, exc.pc, exc.revert_type)
 
             receipt = TransactionReceipt(
-                txid, self, required_confs=0, silent=silent, revert_data=revert_data
+                txid,
+                self,
+                required_confs=required_confs,
+                is_blocking=False,
+                silent=silent,
+                revert_data=revert_data,
             )
             # add the TxHistory before waiting for confirmation, this way the tx
             # object is available if the user CTRL-C to stop waiting in the console
             history._add_tx(receipt)
-            receipt.wait(required_confs)
+            if required_confs > 0:
+                receipt._confirmed.wait()
 
         if rpc.is_active():
             undo_thread = threading.Thread(

--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -450,11 +450,15 @@ class _PrivateKeyAccount(PublicKeyAccount):
                 txid,
                 self,
                 silent=silent,
-                required_confs=required_confs,
+                required_confs=0,
                 name=contract._name + ".constructor",
                 revert_data=revert_data,
             )
+            # add the TxHistory before waiting for confirmation, this way the tx
+            # object is available if the user CTRL-C to stop waiting in the console
             history._add_tx(receipt)
+            receipt.wait(required_confs)
+
         add_thread = threading.Thread(target=contract._add_from_tx, args=(receipt,), daemon=True)
         add_thread.start()
 
@@ -585,9 +589,13 @@ class _PrivateKeyAccount(PublicKeyAccount):
                 revert_data = (exc.revert_msg, exc.pc, exc.revert_type)
 
             receipt = TransactionReceipt(
-                txid, self, required_confs=required_confs, silent=silent, revert_data=revert_data
+                txid, self, required_confs=0, silent=silent, revert_data=revert_data
             )
+            # add the TxHistory before waiting for confirmation, this way the tx
+            # object is available if the user CTRL-C to stop waiting in the console
             history._add_tx(receipt)
+            receipt.wait(required_confs)
+
         if rpc.is_active():
             undo_thread = threading.Thread(
                 target=Chain()._add_to_undo_buffer,

--- a/brownie/network/event.py
+++ b/brownie/network/event.py
@@ -19,11 +19,14 @@ class EventDict:
     Dict/list hybrid container, base class for all events fired in a transaction.
     """
 
-    def __init__(self, events: List) -> None:
+    def __init__(self, events: Optional[List] = None) -> None:
         """Instantiates the class.
 
         Args:
             events: event data as supplied by eth_event.decode_logs or eth_event.decode_trace"""
+        if events is None:
+            events = []
+
         self._ordered = [
             _EventItem(
                 i["name"],
@@ -208,9 +211,9 @@ def _add_deployment_topics(address: str, abi: List) -> None:
     _deployment_topics[address] = eth_event.get_topic_map(abi)
 
 
-def _decode_logs(logs: List) -> Union["EventDict", List[None]]:
+def _decode_logs(logs: List) -> EventDict:
     if not logs:
-        return []
+        return EventDict()
 
     idx = 0
     events: List = []
@@ -237,9 +240,9 @@ def _decode_logs(logs: List) -> Union["EventDict", List[None]]:
     return EventDict(events)
 
 
-def _decode_trace(trace: Sequence, initial_address: str) -> Union["EventDict", List[None]]:
+def _decode_trace(trace: Sequence, initial_address: str) -> EventDict:
     if not trace:
-        return []
+        return EventDict()
 
     events = eth_event.decode_traceTransaction(
         trace, _topics, allow_undecoded=True, initial_address=initial_address

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -254,6 +254,8 @@ class TransactionReceipt:
         return web3.eth.blockNumber - self.block_number + 1
 
     def wait(self, required_confs: int) -> None:
+        if required_confs < 1:
+            return
         if self.confirmations > required_confs:
             print(f"This transaction already has {self.confirmations} confirmations.")
             return

--- a/docs/api-network.rst
+++ b/docs/api-network.rst
@@ -2219,7 +2219,12 @@ TransactionReceipt Attributes
 
 .. py:attribute:: TransactionReceipt.status
 
-    The status of the transaction: -1 for pending, 0 for failed, 1 for success.
+    An :class:`IntEnum <enum.IntEnum>` object representing the status of the transaction:
+
+        * ``1``: Successful
+        * ``0``: Reverted
+        * ``-1``: Pending
+        * ``-2``: Dropped
 
     .. code-block:: python
 
@@ -2314,6 +2319,29 @@ TransactionReceipt Attributes
 
 TransactionReceipt Methods
 **************************
+
+.. py:method:: TransactionReceipt.replace(increment=None, gas_price=None)
+
+    Broadcast an identical transaction with the same nonce and a higher gas price.
+
+    Exactly one of the following arguments must be provided:
+
+    * ``increment``: Multiplier applied to the gas price of the current transaction in order to determine a new gas price
+    * ``gas_price``: Absolute gas price to use in the replacement transaction
+
+    Returns a :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>` object.
+
+    .. code-block:: python
+
+        >>> tx = accounts[0].transfer(accounts[1], 100, required_confs=0, gas_price="1 gwei")
+        Transaction sent: 0xc1aab54599d7875fc1fe8d3e375abb0f490cbb80d5b7f48cedaa95fa726f29be
+          Gas price: 13.0 gwei   Gas limit: 21000   Nonce: 3
+        <Transaction object '0xc1aab54599d7875fc1fe8d3e375abb0f490cbb80d5b7f48cedaa95fa726f29be'>
+
+        >>> tx.replace(1.1)
+        Transaction sent: 0x9a525e42b326c3cd57e889ad8c5b29c88108227a35f9763af33dccd522375212
+          Gas price: 14.3 gwei   Gas limit: 21000   Nonce: 3
+        <Transaction '0x9a525e42b326c3cd57e889ad8c5b29c88108227a35f9763af33dccd522375212'>
 
 .. py:classmethod:: TransactionReceipt.info()
 

--- a/docs/core-accounts.rst
+++ b/docs/core-accounts.rst
@@ -89,3 +89,22 @@ Additionally, setting ``silent = True`` suppresses the console output.
     [1, -1, -1]
 
 These transactions are initially pending (``status == -1``) and appear yellow in the console.
+
+Replacing Transactions
+======================
+
+The :func:`TransactionReceipt.replace <TransactionReceipt.replace>` method can be used to replace underpriced transactions while they are still pending:
+
+.. code-block:: python
+
+    >>> tx = accounts[0].transfer(accounts[1], 100, required_confs=0, gas_price="1 gwei")
+    Transaction sent: 0xc1aab54599d7875fc1fe8d3e375abb0f490cbb80d5b7f48cedaa95fa726f29be
+        Gas price: 13.0 gwei   Gas limit: 21000   Nonce: 3
+    <Transaction object '0xc1aab54599d7875fc1fe8d3e375abb0f490cbb80d5b7f48cedaa95fa726f29be'>
+
+    >>> tx.replace(1.1)
+    Transaction sent: 0x9a525e42b326c3cd57e889ad8c5b29c88108227a35f9763af33dccd522375212
+        Gas price: 14.3 gwei   Gas limit: 21000   Nonce: 3
+    <Transaction '0x9a525e42b326c3cd57e889ad8c5b29c88108227a35f9763af33dccd522375212'>
+
+All pending transactions are available within the :func:`history <brownie.network.state.TxHistory>` object. As soon as one transaction confirms, the remaining dropped transactions are removed. See the documentation on :ref:`accessing transaction history <core-chain-history>` for more info.

--- a/docs/core-chain.rst
+++ b/docs/core-chain.rst
@@ -53,6 +53,8 @@ The :func:`Chain <brownie.network.state.Chain>` object, available as ``chain``, 
 Accessing Transaction Data
 ==========================
 
+.. _core-chain-history:
+
 Local Transaction History
 -------------------------
 

--- a/tests/network/transaction/test_confirmation.py
+++ b/tests/network/transaction/test_confirmation.py
@@ -4,31 +4,31 @@
 def test_await_conf_simple_xfer(accounts):
     tx = accounts[0].transfer(accounts[1], "1 ether")
     assert tx.status == 1
-    tx._await_transaction()
+    tx._await_transaction(1, True)
 
 
 def test_await_conf_successful_contract_call(accounts, tester):
     tx = tester.revertStrings(6, {"from": accounts[1]})
     assert tx.status == 1
-    tx._await_transaction()
+    tx._await_transaction(1, True)
 
 
 def test_await_conf_failed_contract_call(accounts, tester, console_mode):
     tx = tester.revertStrings(1, {"from": accounts[1]})
     assert tx.status == 0
-    tx._await_transaction()
+    tx._await_transaction(1, True)
 
 
 def test_await_conf_successful_contract_deploy(accounts, BrownieTester):
     tx = BrownieTester.deploy(True, {"from": accounts[0]}).tx
     assert tx.status == 1
-    tx._await_transaction()
+    tx._await_transaction(1, True)
 
 
 def test_await_conf_failed_contract_deploy(accounts, BrownieTester, console_mode):
     tx = BrownieTester.deploy(False, {"from": accounts[0]})
     assert tx.status == 0
-    tx._await_transaction()
+    tx._await_transaction(1, True)
 
 
 def test_transaction_confirmations(accounts, chain):


### PR DESCRIPTION
### What I did
Add the `TransactionReceipt.replace` method for replacing pending transactions.

Closes #726

### How I did it
The logic flow for creating a `TransactionReceipt` had to be modified slightly. Creating the object is now optionally-blocking via the `is_blocking` kwarg (this had to be done to avoid making a breaking change). When broadcasting, the object is initially created via a non-blocking call, then added to `history`, then if `required_confs` is non-zero it calls `wait` to block until the necessary confirmations. By using this approach, each tx object is added to history immediately, so that users can `CTRL-C` and still access the pending the tx.

Replacement happens via `TransactionReceipt.replace` which accepts either an `increment` modifier or `gas_price` absolute and returns a new tx object.

As soon as any one transaction confirms, the other tx's are marked with status `-2` (dropped) and removed from `history`.

### How to verify it
This is difficult to write tests for.  I've played with it a fair bit on the mainnet and everything seems to work, but unfortunately I think the only real test here is to release and solve bugs are they appear.
