### PR TITLE
Automatic transaction repricing / replacement

### DIFF
--- a/brownie/exceptions.py
+++ b/brownie/exceptions.py
@@ -131,6 +131,10 @@ class VirtualMachineError(Exception):
         return self
 
 
+class TransactionError(Exception):
+    pass
+
+
 class EventLookupError(LookupError):
     pass
 

--- a/brownie/network/gas/bases.py
+++ b/brownie/network/gas/bases.py
@@ -1,9 +1,20 @@
+import threading
+import time
 from abc import ABC, abstractmethod
-from typing import Optional
+from collections import deque
+from typing import Any, Optional
+
+from brownie.network.web3 import web3
 
 
 class GasABC(ABC):
-    pass
+    def _add_tx(self, txreceipt: Any) -> None:
+        if isinstance(self, SimpleGasStrategy):
+            return
+
+        number = web3.eth.blockNumber if isinstance(self, BlockGasStrategy) else time.time()
+        _queue.append((self, txreceipt, number, number))
+        _event.set()
 
 
 class SimpleGasStrategy(GasABC):
@@ -34,3 +45,43 @@ class TimeGasStrategy(GasABC):
     @abstractmethod
     def get_gas_price(self, current_gas_price: int, elapsed_time: int) -> Optional[int]:
         raise NotImplementedError
+
+
+def _update_loop():
+    while True:
+        if not _queue:
+            _event.wait()
+            _event.clear()
+
+        try:
+            gas_strategy, tx, initial, latest = _queue.popleft()
+        except IndexError:
+            continue
+
+        if tx.status >= 0:
+            continue
+
+        if isinstance(gas_strategy, BlockGasStrategy):
+            height = web3.eth.blockNumber
+            if height - latest >= gas_strategy.block_duration:
+                gas_price = gas_strategy.get_gas_price(tx.gas_price, height - initial)
+                if gas_price is not None:
+                    tx = tx.replace(gas_price=gas_price, silent=True)
+                    latest = web3.eth.blockNumber
+
+        else:
+            if time.time() - latest >= gas_strategy.time_duration:
+                gas_price = gas_strategy.get_gas_price(tx.gas_price, time.time() - initial)
+                if gas_price is not None:
+                    tx = tx.replace(gas_price=gas_price, silent=True)
+                    latest = time.time()
+
+        _queue.append((gas_strategy, tx, initial, latest))
+        time.sleep(1)
+
+
+_queue: deque = deque()
+_event = threading.Event()
+
+_repricing_thread = threading.Thread(target=_update_loop, daemon=True)
+_repricing_thread.start()

--- a/brownie/network/gas/bases.py
+++ b/brownie/network/gas/bases.py
@@ -1,0 +1,36 @@
+from abc import ABC, abstractmethod
+from typing import Optional
+
+
+class GasABC(ABC):
+    pass
+
+
+class SimpleGasStrategy(GasABC):
+    @abstractmethod
+    def get_gas_price(self) -> int:
+        raise NotImplementedError
+
+
+class BlockGasStrategy(GasABC):
+
+    block_duration = 2
+
+    def __init__(self, block_duration: int = 2):
+        self.block_duration = block_duration
+
+    @abstractmethod
+    def get_gas_price(self, current_gas_price: int, elapsed_blocks: int) -> Optional[int]:
+        raise NotImplementedError
+
+
+class TimeGasStrategy(GasABC):
+
+    time_duration = 30
+
+    def __init__(self, time_duration: int = 30) -> None:
+        self.time_duration = time_duration
+
+    @abstractmethod
+    def get_gas_price(self, current_gas_price: int, elapsed_time: int) -> Optional[int]:
+        raise NotImplementedError

--- a/brownie/network/gas/bases.py
+++ b/brownie/network/gas/bases.py
@@ -142,7 +142,7 @@ def _update_loop() -> None:
                 gas_price = gas_strategy.update_gas_price(tx.gas_price, height - initial)
                 if gas_price is not None:
                     try:
-                        tx = tx.replace(gas_price=gas_price, silent=True)
+                        tx = tx.replace(gas_price=gas_price)
                         latest = web3.eth.blockNumber
                     except ValueError:
                         pass
@@ -152,7 +152,7 @@ def _update_loop() -> None:
                 gas_price = gas_strategy.update_gas_price(tx.gas_price, time.time() - initial)
                 if gas_price is not None:
                     try:
-                        tx = tx.replace(gas_price=gas_price, silent=True)
+                        tx = tx.replace(gas_price=gas_price)
                         latest = time.time()
                     except ValueError:
                         pass

--- a/brownie/network/gas/bases.py
+++ b/brownie/network/gas/bases.py
@@ -8,16 +8,48 @@ from brownie.network.web3 import web3
 
 
 class GasABC(ABC):
+    """
+    Base ABC for all gas strategies.
+
+    This class should not be directly subclassed from. Instead, use
+    `SimpleGasStrategy`, `BlockGasStrategy` or `TimeGasStrategy`.
+    """
+
     @abstractmethod
     def get_gas_price(self) -> int:
+        """
+        Return the initial gas price for a transaction.
+
+        Returns
+        -------
+        int
+            Gas price, given as an integer in wei.
+        """
         raise NotImplementedError
 
 
 class SimpleGasStrategy(GasABC):
-    pass
+    """
+    Abstract base class for simple gas strategies.
+
+    Simple gas strategies are called once to provide a gas price
+    at the time a transaction is broadcasted. Transactions using simple
+    gas strategies are not automatically rebroadcasted.
+
+    Subclass from this ABC to implement your own simple gas strategy.
+    """
 
 
 class BlockGasStrategy(GasABC):
+    """
+    Abstract base class for block gas strategies.
+
+    Block gas strategies are called every `block_duration` blocks and
+    can be used to automatically rebroadcast a pending transaction with
+    a higher gas price.
+
+    Subclass from this ABC to implement your own block gas strategy.
+    """
 
     block_duration = 2
 
@@ -26,10 +58,39 @@ class BlockGasStrategy(GasABC):
 
     @abstractmethod
     def update_gas_price(self, last_gas_price: int, elapsed_blocks: int) -> Optional[int]:
+        """
+        Return an updated gas price.
+
+        This method is called every `block_duration` blocks while a transaction
+        is still pending. If the return value is an integer, the transaction
+        is rebroadcasted with the new gas price.
+
+        Arguments
+        ---------
+        last_gas_price : int
+            The gas price of the most recently broadcasted transaction.
+        elapsed_blocks : int
+            The total number of blocks that have been mined since the first
+            transaction using this strategy was broadcasted.
+
+        Returns
+        -------
+        int, optional
+            New gas price to rebroadcast the transaction with.
+        """
         raise NotImplementedError
 
 
 class TimeGasStrategy(GasABC):
+    """
+    Abstract base class for time gas strategies.
+
+    Time gas strategies are called every `time_duration` seconds and
+    can be used to automatically rebroadcast a pending transaction with
+    a higher gas price.
+
+    Subclass from this ABC to implement your own time gas strategy.
+    """
 
     time_duration = 30
 
@@ -38,6 +99,26 @@ class TimeGasStrategy(GasABC):
 
     @abstractmethod
     def update_gas_price(self, last_gas_price: int, elapsed_time: int) -> Optional[int]:
+        """
+        Return an updated gas price.
+
+        This method is called every `time_duration` seconds while a transaction
+        is still pending. If the return value is an integer, the transaction
+        is rebroadcasted with the new gas price.
+
+        Arguments
+        ---------
+        last_gas_price : int
+            The gas price of the most recently broadcasted transaction.
+        elapsed_time : int
+            The number of seconds that have passed since the first
+            transaction using this strategy was broadcasted.
+
+        Returns
+        -------
+        int, optional
+            New gas price to rebroadcast the transaction with.
+        """
         raise NotImplementedError
 
 

--- a/brownie/network/gas/bases.py
+++ b/brownie/network/gas/bases.py
@@ -66,15 +66,21 @@ def _update_loop():
             if height - latest >= gas_strategy.block_duration:
                 gas_price = gas_strategy.get_gas_price(tx.gas_price, height - initial)
                 if gas_price is not None:
-                    tx = tx.replace(gas_price=gas_price, silent=True)
-                    latest = web3.eth.blockNumber
+                    try:
+                        tx = tx.replace(gas_price=gas_price, silent=True)
+                        latest = web3.eth.blockNumber
+                    except ValueError:
+                        pass
 
         else:
             if time.time() - latest >= gas_strategy.time_duration:
                 gas_price = gas_strategy.get_gas_price(tx.gas_price, time.time() - initial)
                 if gas_price is not None:
-                    tx = tx.replace(gas_price=gas_price, silent=True)
-                    latest = time.time()
+                    try:
+                        tx = tx.replace(gas_price=gas_price, silent=True)
+                        latest = time.time()
+                    except ValueError:
+                        pass
 
         _queue.append((gas_strategy, tx, initial, latest))
         time.sleep(1)

--- a/brownie/network/gas/bases.py
+++ b/brownie/network/gas/bases.py
@@ -8,30 +8,24 @@ from brownie.network.web3 import web3
 
 
 class GasABC(ABC):
-    def _add_tx(self, txreceipt: Any) -> None:
-        if isinstance(self, SimpleGasStrategy):
-            return
-
-        number = web3.eth.blockNumber if isinstance(self, BlockGasStrategy) else time.time()
-        _queue.append((self, txreceipt, number, number))
-        _event.set()
-
-
-class SimpleGasStrategy(GasABC):
     @abstractmethod
     def get_gas_price(self) -> int:
         raise NotImplementedError
+
+
+class SimpleGasStrategy(GasABC):
+    pass
 
 
 class BlockGasStrategy(GasABC):
 
     block_duration = 2
 
-    def __init__(self, block_duration: int = 2):
+    def __init__(self, block_duration: int = 2) -> None:
         self.block_duration = block_duration
 
     @abstractmethod
-    def get_gas_price(self, current_gas_price: int, elapsed_blocks: int) -> Optional[int]:
+    def update_gas_price(self, last_gas_price: int, elapsed_blocks: int) -> Optional[int]:
         raise NotImplementedError
 
 
@@ -43,11 +37,11 @@ class TimeGasStrategy(GasABC):
         self.time_duration = time_duration
 
     @abstractmethod
-    def get_gas_price(self, current_gas_price: int, elapsed_time: int) -> Optional[int]:
+    def update_gas_price(self, last_gas_price: int, elapsed_time: int) -> Optional[int]:
         raise NotImplementedError
 
 
-def _update_loop():
+def _update_loop() -> None:
     while True:
         if not _queue:
             _event.wait()
@@ -64,7 +58,7 @@ def _update_loop():
         if isinstance(gas_strategy, BlockGasStrategy):
             height = web3.eth.blockNumber
             if height - latest >= gas_strategy.block_duration:
-                gas_price = gas_strategy.get_gas_price(tx.gas_price, height - initial)
+                gas_price = gas_strategy.update_gas_price(tx.gas_price, height - initial)
                 if gas_price is not None:
                     try:
                         tx = tx.replace(gas_price=gas_price, silent=True)
@@ -72,9 +66,9 @@ def _update_loop():
                     except ValueError:
                         pass
 
-        else:
+        elif isinstance(gas_strategy, TimeGasStrategy):
             if time.time() - latest >= gas_strategy.time_duration:
-                gas_price = gas_strategy.get_gas_price(tx.gas_price, time.time() - initial)
+                gas_price = gas_strategy.update_gas_price(tx.gas_price, time.time() - initial)
                 if gas_price is not None:
                     try:
                         tx = tx.replace(gas_price=gas_price, silent=True)
@@ -84,6 +78,15 @@ def _update_loop():
 
         _queue.append((gas_strategy, tx, initial, latest))
         time.sleep(1)
+
+
+def _add_to_gas_strategy_queue(gas_strategy: GasABC, txreceipt: Any) -> None:
+    if isinstance(gas_strategy, SimpleGasStrategy):
+        return
+
+    number = web3.eth.blockNumber if isinstance(gas_strategy, BlockGasStrategy) else time.time()
+    _queue.append((gas_strategy, txreceipt, number, number))
+    _event.set()
 
 
 _queue: deque = deque()

--- a/brownie/network/gas/strategies.py
+++ b/brownie/network/gas/strategies.py
@@ -1,0 +1,59 @@
+import threading
+import time
+
+import requests
+
+from .bases import BlockGasStrategy, SimpleGasStrategy
+
+_gasnow = {"time": 0, "data": None}
+_gasnow_lock = threading.Lock()
+
+
+def _fetch_gasnow(key):
+    with _gasnow_lock:
+        if time.time() - _gasnow["time"] > 15:
+            data = None
+            for i in range(12):
+                response = requests.get(
+                    "https://www.gasnow.org/api/v3/gas/price?utm_source=brownie"
+                )
+                if response.status_code != 200:
+                    time.sleep(5)
+                    continue
+                data = response.json()["data"]
+            if data is None:
+                raise ValueError
+            _gasnow["time"] = data.pop("timestamp") // 1000
+            _gasnow["data"] = data
+
+    return _gasnow["data"][key]
+
+
+class GasNowStrategy(SimpleGasStrategy):
+    def __init__(self, speed: str = "fast"):
+        if speed not in ("rapid", "fast", "standard", "slow"):
+            raise ValueError("`speed` must be one of: rapid, fast, standard, slow")
+        self.speed = speed
+
+    def get_gas_price(self):
+        return _fetch_gasnow(self.speed)
+
+
+class GasNowScalingStrategy(BlockGasStrategy):
+    def __init__(
+        self, initial_speed: str = "standard", increment: float = 1.1, block_duration: int = 2
+    ):
+        super().__init__(block_duration)
+        if initial_speed not in ("rapid", "fast", "standard", "slow"):
+            raise ValueError("`initial_speed` must be one of: rapid, fast, standard, slow")
+        self.speed = initial_speed
+        self.increment = increment
+
+    def get_gas_price(self, current_gas_price, elapsed_blocks):
+        if current_gas_price is None:
+            return _fetch_gasnow(self.speed)
+        rapid_gas_price = _fetch_gasnow("rapid")
+        new_gas_price = max(int(current_gas_price * self.increment), _fetch_gasnow(self.speed))
+        if new_gas_price <= rapid_gas_price:
+            return new_gas_price
+        return None

--- a/brownie/network/gas/strategies.py
+++ b/brownie/network/gas/strategies.py
@@ -33,6 +33,22 @@ def _fetch_gasnow(key: str) -> int:
 
 
 class GasNowStrategy(SimpleGasStrategy):
+    """
+    Gas strategy for determing a price using the GasNow API.
+
+    GasNow returns 4 possible prices:
+
+    rapid: the median gas prices for all transactions currently included
+           in the mining block
+    fast: the gas price transaction "N", the minimum priced tx currently
+          included in the mining block
+    standard: the gas price of the Max(2N, 500th) transaction in the mempool
+    slow: the gas price of the max(5N, 1000th) transaction within the mempool
+
+    Visit https://www.gasnow.org/ for more information on how GasNow
+    calculates gas prices.
+    """
+
     def __init__(self, speed: str = "fast"):
         if speed not in ("rapid", "fast", "standard", "slow"):
             raise ValueError("`speed` must be one of: rapid, fast, standard, slow")
@@ -43,6 +59,16 @@ class GasNowStrategy(SimpleGasStrategy):
 
 
 class GasNowScalingStrategy(BlockGasStrategy):
+    """
+    Block based scaling gas strategy using the GasNow API.
+
+    The initial gas price is set according to `initial_speed`. The gas price
+    for each subsequent transaction is increased by multiplying the previous gas
+    price by `increment`, or increasing to the current `initial_speed` gas price,
+    whichever is higher. No repricing occurs if the new gas price would exceed
+    the current "rapid" price as given by the API.
+    """
+
     def __init__(
         self, initial_speed: str = "standard", increment: float = 1.1, block_duration: int = 2
     ):

--- a/brownie/network/gas/strategies.py
+++ b/brownie/network/gas/strategies.py
@@ -1,6 +1,6 @@
 import threading
 import time
-from typing import Dict, Optional
+from typing import Dict
 
 import requests
 
@@ -83,12 +83,13 @@ class GasNowScalingStrategy(BlockGasStrategy):
         self.max_speed = max_speed
         self.increment = increment
 
-    def update_gas_price(self, last_gas_price: int, elapsed_blocks: int) -> Optional[int]:
+    def update_gas_price(self, last_gas_price: int, elapsed_blocks: int) -> int:
+        initial_gas_price = _fetch_gasnow(self.initial_speed)
         max_gas_price = _fetch_gasnow(self.max_speed)
-        new_gas_price = max(int(last_gas_price * self.increment), _fetch_gasnow(self.initial_speed))
-        if new_gas_price <= max_gas_price:
-            return new_gas_price
-        return None
+
+        incremented_gas_price = int(last_gas_price * self.increment)
+        new_gas_price = max(initial_gas_price, incremented_gas_price)
+        return min(max_gas_price, new_gas_price)
 
     def get_gas_price(self) -> int:
         return _fetch_gasnow(self.initial_speed)

--- a/brownie/network/main.py
+++ b/brownie/network/main.py
@@ -9,6 +9,7 @@ from brownie.convert import Wei
 from brownie.exceptions import BrownieEnvironmentWarning
 
 from .account import Accounts
+from .gas.bases import GasABC
 from .rpc import Rpc
 from .state import Chain, _notify_registry
 from .web3 import web3
@@ -114,7 +115,9 @@ def gas_price(*args: Tuple[Union[int, str, bool, None]]) -> Union[int, bool]:
     if not is_connected():
         raise ConnectionError("Not connected to any network")
     if args:
-        if args[0] in (None, False, True, "auto"):
+        if isinstance(args[0], GasABC):
+            CONFIG.active_network["settings"]["gas_price"] = args[0]
+        elif args[0] in (None, False, True, "auto"):
             CONFIG.active_network["settings"]["gas_price"] = False
         else:
             try:

--- a/brownie/network/state.py
+++ b/brownie/network/state.py
@@ -75,14 +75,6 @@ class TxHistory(metaclass=_Singleton):
 
     def _add_tx(self, tx: TransactionReceipt) -> None:
         self._list.append(tx)
-        confirm_thread = threading.Thread(target=self._await_confirm, args=(tx,), daemon=True)
-        confirm_thread.start()
-
-    def _await_confirm(self, tx: TransactionReceipt) -> None:
-        # in case of multiple tx's with the same nonce, remove the dropped tx's upon confirmation
-        tx._confirmed.wait()
-        for dropped_tx in self.filter(sender=tx.sender, nonce=tx.nonce, key=lambda k: k != tx):
-            self._list.remove(dropped_tx)
 
     def clear(self) -> None:
         self._list.clear()

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -262,7 +262,10 @@ class TransactionReceipt:
         return web3.eth.blockNumber - self.block_number + 1
 
     def replace(
-        self, increment: Optional[float] = None, gas_price: Optional[Wei] = None,
+        self,
+        increment: Optional[float] = None,
+        gas_price: Optional[Wei] = None,
+        silent: Optional[bool] = None,
     ) -> "TransactionReceipt":
         """
         Rebroadcast this transaction with a higher gas price.
@@ -274,8 +277,10 @@ class TransactionReceipt:
         increment : float, optional
             Multiplier applied to the gas price of this transaction in order
             to determine the new gas price
-        gas_price: Wei, optional
+        gas_price : Wei, optional
             Absolute gas price to use in the replacement transaction
+        silent : bool, optional
+            Toggle console verbosity (default is same setting as this transaction)
 
         Returns
         -------
@@ -292,6 +297,9 @@ class TransactionReceipt:
         if increment is not None:
             gas_price = Wei(self.gas_price * 1.1)
 
+        if silent is None:
+            silent = self._silent
+
         return self.sender.transfer(  # type: ignore
             self.receiver,
             self.value,
@@ -300,7 +308,7 @@ class TransactionReceipt:
             data=self.input,
             nonce=self.nonce,
             required_confs=0,
-            silent=self._silent,
+            silent=silent,
         )
 
     def wait(self, required_confs: int) -> None:

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -341,7 +341,7 @@ class TransactionReceipt:
             return
         if not web3.supports_traces:
             # if traces are not available, do not attempt to determine the revert reason
-            raise exc
+            raise exc or ValueError("Execution reverted")
 
         if self._revert_msg is None:
             # no revert message and unable to check dev string - have to get trace

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -327,7 +327,7 @@ class TransactionReceipt:
                     sender_nonce = web3.eth.getTransactionCount(str(self.sender))
                     if sender_nonce > self.nonce:
                         self.status = Status(-2)
-                        print("This transaction was replaced.")
+                        self._confirmed.set()
                         return
                 time.sleep(1)
 
@@ -412,6 +412,7 @@ class TransactionReceipt:
                 if expect_confirmed:
                     # if we expected confirmation based on the nonce, tx likely dropped
                     self.status = Status(-2)
+                    self._confirmed.set()
                     return
 
         self.block_number = receipt["blockNumber"]

--- a/docs/core-accounts.rst
+++ b/docs/core-accounts.rst
@@ -70,6 +70,8 @@ In a development environment, it is possible to send transactions from an addres
 
 See :ref:`local-accounts` for more information on working with accounts.
 
+.. _core-accounts-non-blocking:
+
 Broadcasting Multiple Transactions
 ==================================
 

--- a/docs/core-gas.rst
+++ b/docs/core-gas.rst
@@ -1,0 +1,131 @@
+.. _core-accounts:
+
+==============
+Gas Strategies
+==============
+
+Gas strategies are objects that dynamically generate a gas price for a transaction. They can also be used to automatically replace pending transactions within the mempool.
+
+Gas strategies come in three basic types:
+
+* **Simple** strategies provide a gas price once, but do not replace pending transactions.
+* **Block** strategies provide an initial price, and optionally replace pending transactions based on the number of blocks that have been mined since the first transaction was broadcast.
+* **Time** strategies provide an initial price, and optionally replace pending transactions based on the amount of time that has passed since the first transaction was broadcast.
+
+Using a Gas Strategy
+====================
+
+To use a gas strategy, first import it from ``brownie.network.gas.strategies``:
+
+.. code-block:: python
+
+    >>> from brownie.network.gas.strategies import GasNowStrategy
+    >>> gas_strategy = GasNowStrategy("fast")
+
+You can then provide the object in the ``gas_price`` field when making a transaction:
+
+.. code-block:: python
+
+    >>> accounts[0].transfer(accounts[1], "1 ether", gas_price=gas_strategy)
+
+When the strategy replaces a pending transaction, the returned :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>` object will be for the transaction that confirms.
+
+During :ref:`non-blocking transactions <core-accounts-non-blocking>`, all pending transactions are available within the :func:`history <brownie.network.state.TxHistory>` object. As soon as one transaction confirms, the remaining dropped transactions are removed.
+
+Setting a Default Gas Strategy
+==============================
+
+You can use :func:`network.gas_price <main.gas_price>` to set a gas strategy as the default for all transactions:
+
+.. code-block:: python
+
+    >>> from brownie.network import gas_price
+    >>> gas_price(gas_strategy)
+
+Available Gas Strategies
+========================
+
+.. py:class:: brownie.network.gas.strategies.LinearScalingStrategy(initial_gas_price, max_gas_price, increment=1.125, time_duration=30)
+
+    Time based scaling strategy for linear gas price increase.
+
+    * ``initial_gas_price``: The initial gas price to use in the first transaction
+    * ``max_gas_price``: The maximum gas price to use
+    * ``increment``: Multiplier applied to the previous gas price in order to determine the new gas price
+    * ``time_duration``: Number of seconds between transactions
+
+    .. code-block:: python
+
+        >>> from brownie.network.gas.strategies import LinearScalingStrategy
+        >>> gas_strategy = LinearScalingStrategy("10 gwei", "50 gwei", 1.1)
+
+        >>> accounts[0].transfer(accounts[1], "1 ether", gas_price=gas_strategy)
+
+.. py:class:: brownie.network.gas.strategies.ExponentialScalingStrategy(initial_gas_price, max_gas_price, time_duration=30)
+
+    Time based scaling strategy for exponential gas price increase.
+
+    The gas price for each subsequent transaction is calculated as the previous price multiplied by `1.1 ** n` where n is the number of transactions that have been broadcast. In this way the price increase starts gradually and ramps up until confirmation.
+
+    * ``initial_gas_price``: The initial gas price to use in the first transaction
+    * ``max_gas_price``: The maximum gas price to use
+    * ``time_duration``: Number of seconds between transactions
+
+    .. code-block:: python
+
+        >>> from brownie.network.gas.strategies import ExponentialScalingStrategy
+        >>> gas_strategy = ExponentialScalingStrategy("10 gwei", "50 gwei")
+
+        >>> accounts[0].transfer(accounts[1], "1 ether", gas_price=gas_strategy)
+
+.. py:class:: brownie.network.gas.strategies.GasNowStrategy(speed="fast")
+
+    Simple gas strategy for determing a price using the `GasNow <https://www.gasnow.org/>`_ API.
+
+    * ``speed``: The gas price to use based on the API call. Options are rapid, fast, standard and slow.
+
+    .. code-block:: python
+
+        >>> from brownie.network.gas.strategies import GasNowStrategy
+        >>> gas_strategy = GasNowStrategy("fast")
+
+        >>> accounts[0].transfer(accounts[1], "1 ether", gas_price=gas_strategy)
+
+.. py:class:: brownie.network.gas.strategies.GasNowScalingStrategy(initial_speed="standard", max_speed="rapid", increment=1.125, block_duration=2)
+
+    Block based scaling gas strategy using the GasNow API.
+
+    * ``initial_speed``: The initial gas price to use when broadcasting the first transaction. Options are rapid, fast, standard and slow.
+    * ``max_speed``: The maximum gas price to use when replacing the transaction. Options are rapid, fast, standard and slow.
+    * ``increment``: A multiplier applied to the most recently used gas price in order to determine the new gas price. If the incremented value is less than or equal to the current ``max_speed`` rate, a new transaction is broadcasted. If the current rate for ``initial_speed`` is greater than the incremented rate, it is used instead.
+    * ``block_duration``: The number of blocks to wait between broadcasting new transactions.
+
+    .. code-block:: python
+
+        >>> from brownie.network.gas.strategies import GasNowScalingStrategy
+        >>> gas_strategy = GasNowScalingStrategy("fast", increment=1.2)
+
+        >>> accounts[0].transfer(accounts[1], "1 ether", gas_price=gas_strategy)
+
+.. py:class:: brownie.network.gas.strategies.GethMempoolStrategy(position=500, graphql_endpoint=None, block_duration=2)
+
+    Block based scaling gas strategy using Geth's `GraphQL interface <https://eips.ethereum.org/EIPS/eip-1767>`_.
+
+    In order to use this strategy you must be connecting via a Geth node with GraphQL enabled.
+
+    The yielded gas price is determined by sorting transactions in the mempool according to gas price, and returning the price of the transaction at `position`. This is the same technique used by the GasNow API.
+
+    * A position of 200 or less usually places a transaction within the mining block.
+    * A position of 500 usually places a transaction within the 2nd pending block.
+
+    .. code-block:: python
+
+        >>> from brownie.network.gas.strategies import GethMempoolStrategy
+        >>> gas_strategy = GethMempoolStrategy(200)
+
+        >>> accounts[0].transfer(accounts[1], "1 ether", gas_price=gas_strategy)
+
+Building your own Gas Strategy
+==============================
+
+To implement your own gas strategy you must subclass from one of the :ref:`gas strategy abstract base classes <api-network-gas-abc>`.

--- a/docs/toctree.rst
+++ b/docs/toctree.rst
@@ -31,6 +31,7 @@ Brownie
     core-chain.rst
     core-transactions.rst
     core-types.rst
+    core-gas.rst
 
 
 .. toctree::

--- a/tests/network/test_gas.py
+++ b/tests/network/test_gas.py
@@ -1,0 +1,66 @@
+import pytest
+
+from brownie.network.gas.strategies import ExponentialScalingStrategy, LinearScalingStrategy
+
+
+def test_linear_initial():
+    strat = LinearScalingStrategy(1, 10)
+    generator = strat.get_gas_price()
+    assert next(generator) == 1
+
+
+def test_linear_max():
+    strat = LinearScalingStrategy(100, 1000)
+    generator = strat.get_gas_price()
+    last = next(generator)
+    for i in range(20):
+        if last == 1000:
+            assert next(generator) == 1000
+        else:
+            value = next(generator)
+            assert last < value <= 1000
+            last = value
+
+
+@pytest.mark.parametrize("increment", [1.1, 1.25, 1.337, 2])
+def test_linear_increment(increment):
+    strat = LinearScalingStrategy(100, 100000000000, increment=increment)
+    generator = strat.get_gas_price()
+
+    last = next(generator)
+
+    for i in range(20):
+        value = next(generator)
+        assert int(last * increment) == value
+        last = value
+
+
+def test_exponential_initial():
+    strat = ExponentialScalingStrategy(1, 10)
+    generator = strat.get_gas_price()
+    assert next(generator) == 1
+
+
+def test_exponential_max():
+    strat = ExponentialScalingStrategy(100, 1000)
+    generator = strat.get_gas_price()
+    last = next(generator)
+    for i in range(20):
+        if last == 1000:
+            assert next(generator) == 1000
+        else:
+            value = next(generator)
+            assert last < value <= 1000
+            last = value
+
+
+def test_exponential_increment():
+    strat = ExponentialScalingStrategy(100, 100000000000)
+    generator = strat.get_gas_price()
+
+    values = [next(generator) for i in range(20)]
+
+    diff = values[1] - values[0]
+    for i in range(2, 20):
+        assert values[i] - values[i - 1] > diff
+        diff = values[i] - values[i - 1]

--- a/tests/project/compiler/test_solidity.py
+++ b/tests/project/compiler/test_solidity.py
@@ -186,7 +186,7 @@ def test_compile_empty():
 
 
 def test_get_abi():
-    code = "pragma solidity 0.5.7; contract Foo { function baz() external returns (bool); }"
+    code = "pragma solidity 0.5.0; contract Foo { function baz() external returns (bool); }"
     abi = compiler.solidity.get_abi(code)
     assert len(abi) == 1
     assert abi["Foo"] == [


### PR DESCRIPTION
### What I did
Automatic repricing of transactions.

Closes #727 

### How I did it
When setting `gas_price`, you may now use an object that subclasses from `GasABC`:

* `SimpleGasStrategy` for simple strategies that are called once
* `BlockGasStrategy` which is called every `n` blocks
* `TimeGasStrategy` which is called every `n` seconds

For strategies that trigger tx replacement, returning a non-`None` value broadcasts a new transaction.

Thus far I have created two actual strategies, based around the [gasnow](https://www.gasnow.org/) API.

### How to verify it
Try it out!

### TODO

- [x] more strategies
- [x] consideration / updates to logic re: console output while waiting for a tx to confirm
- [x] detailed natspec for strategies and ABCs
- [x] documentation
- [ ] unit testing (not sure how this will look)
