### PR TITLE
Fix: TransactionReceipt for externally broadcasted tx's

### DIFF
--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -361,12 +361,13 @@ class TransactionReceipt:
                 f"   Nonce: {color('bright blue')}{self.nonce}{color}"
             )
 
-        # await confirmation of tx in a separate thread which is blocking if required_confs > 0
+        # await confirmation of tx in a separate thread which is blocking if
+        # required_confs > 0 or tx has already confirmed (`blockNumber` != None)
         confirm_thread = threading.Thread(
             target=self._await_confirmation, args=(tx, required_confs), daemon=True
         )
         confirm_thread.start()
-        if is_blocking and required_confs > 0:
+        if is_blocking and (required_confs > 0 or tx["blockNumber"]):
             confirm_thread.join()
 
     def _await_confirmation(self, tx: Dict, required_confs: int = 1) -> None:

--- a/tests/network/state/test_get_transaction.py
+++ b/tests/network/state/test_get_transaction.py
@@ -19,3 +19,17 @@ def test_not_in_history(accounts, chain, history):
 def test_unknown_tx(accounts, chain, history):
     with pytest.raises(TransactionNotFound):
         chain.get_transaction("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
+
+
+def test_external_tx(network, chain):
+    network.connect("mainnet")
+
+    tx = chain.get_transaction("0x1e0e3df9daa09d009185a1d009b905a9264e296f2d9c8cf6e8a2d0723df249a3")
+    assert tx.status == 1
+
+
+def test_external_tx_reverted(network, chain):
+    network.connect("mainnet")
+
+    tx = chain.get_transaction("0x7c913d12a7692889c364913b7909806de05692abc9312b718f16f444e4a6b94b")
+    assert tx.status == 0


### PR DESCRIPTION
### What I did
Fix two issues when attempting to create `TransactionReceipt` objects for externally broadcasted tx's:

* `EthAddress` object has no nonce, so querying the nonce is now handled via `web3.eth.getTransactionCount`
* even when a transaction request is non-blocking, wait for the transaction receipt if the transaction shows as already confirmed. This fixes an issue where `chain.get_transaction` was always returning tx's marked as pending (that were then marked as confirmed half a second later).

### How to verify it
Run tests.  I added some cases to query txid objects from the mainnet that were failing prior to this PR.

