### PR TITLE
Improved handling of trace queries / exceptions

### DIFF
--- a/docs/api-network.rst
+++ b/docs/api-network.rst
@@ -2568,6 +2568,16 @@ Web3 Attributes
         >>> web3.genesis_hash
         '41941023680923e0fe4d74a34bdac8141f2540e3ae90623718e47d66d1ca4a2d'
 
+.. py:classmethod:: Web3.supports_traces
+
+    Boolean indicating if the currently connected node client supports the `debug_traceTransaction <https://github.com/ethereum/go-ethereum/wiki/Management-APIs#user-content-debug_tracetransaction>`_ RPC endpoint.
+
+    .. code-block:: python
+
+        >>> web3.supports_traces
+        True
+
+
 Web3 Internals
 **************
 

--- a/tests/network/test_web3.py
+++ b/tests/network/test_web3.py
@@ -100,3 +100,26 @@ def test_rinkeby(web3, network):
 
     # this should work because we automatically add the POA middleware
     web3.eth.getBlock("latest")
+
+
+def test_supports_traces_development(web3, devnetwork):
+    # development should return true
+    assert web3.supports_traces
+
+
+def test_supports_traces_not_connected(web3, network):
+    # should return false when disconnected
+    assert not web3.supports_traces
+
+
+def test_supports_traces_infura(web3, network):
+    # ropsten should return false (infura, geth)
+    network.connect("ropsten")
+    assert not web3.supports_traces
+
+
+def test_supports_traces_kovan(web3, network):
+    # kovan should return false (infura, parity)
+    network.connect("kovan")
+
+    assert not web3.supports_traces

--- a/tests/network/transaction/test_trace.py
+++ b/tests/network/transaction/test_trace.py
@@ -6,6 +6,7 @@ possible. These tests check that it is only being called when absolutely necessa
 import pytest
 
 from brownie import Contract
+from brownie.exceptions import RPCRequestError
 from brownie.network.transaction import TransactionReceipt
 from brownie.project import build
 
@@ -248,3 +249,16 @@ def test_contractabi(ExternalCallTester, accounts, tester, ext_tester):
     del ExternalCallTester[0]
     ext_tester = Contract.from_abi("ExternalTesterABI", ext_tester.address, ext_tester.abi)
     tx.call_trace()
+
+
+def test_traces_not_supported(network, chain):
+    network.connect("ropsten")
+
+    tx = chain.get_transaction("0xfd9f98a245d3cff68dd67546fa7e89009a291101f045f81eb9afd14abcbdc6aa")
+
+    # the confirmation output should work even without traces
+    tx._confirm_output()
+
+    # querying the revert message should raise
+    with pytest.raises(RPCRequestError):
+        tx.revert_msg


### PR DESCRIPTION
### What I did
Do not attempt to query a trace when the node client does not support it.

### How I did it
1. Added the `web3.supports_traces` property method. This method calls `debug_traceTransaction` without any arguments and checks the returned error code.  If the return code is -32601, the endpoint does not exist. Any other error means the endpoint does exist.
2. Within various `TransactionReceipt` methods, check for `web3.supports_traces` prior to attempting to query a trace. If `False`, give a more meaningful error than the standard "RPC endpoint does not exist / is not available".
3. Fix an issue where reverting transactions would raise if a trace is not available, because of an attempt to access the revert reason.

### How to verify it
Run the tests. I've added some new cases.

