### PR TITLE
Allow broadcasting reverting transactions in a live environment

### DIFF
--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -1078,6 +1078,7 @@ class _ContractMethod:
             nonce=tx["nonce"],
             required_confs=tx["required_confs"],
             data=self.encode_input(*args),
+            allow_revert=tx["allow_revert"],
         )
 
     def decode_input(self, hexstr: str) -> List:
@@ -1271,6 +1272,7 @@ def _get_tx(owner: Optional[AccountsType], args: Tuple) -> Tuple:
         "gasPrice": None,
         "nonce": None,
         "required_confs": 1,
+        "allow_revert": None,
     }
     if args and isinstance(args[-1], dict):
         tx.update(args[-1])

--- a/docs/api-network.rst
+++ b/docs/api-network.rst
@@ -357,7 +357,7 @@ Account Methods
         >>> accounts[0].get_deployment_address()
         '0xd495633B90a237de510B4375c442C0469D3C161C'
 
-.. py:classmethod:: Account.transfer(self, to=None, amount=0, gas_limit=None, gas_price=None, data=None, nonce=None, required_confs=1, silent=False)
+.. py:classmethod:: Account.transfer(self, to=None, amount=0, gas_limit=None, gas_price=None, data=None, nonce=None, required_confs=1, allow_revert=None, silent=False)
 
     Broadcasts a transaction from this account.
 
@@ -369,6 +369,7 @@ Account Methods
     * ``data``: Transaction data hexstring.
     * ``nonce``: Nonce for the transaction. If none is given, the nonce is set using :meth:`web3.eth.getTransactionCount <web3.eth.Eth.getTransactionCount>` while also considering any pending transactions of the Account.
     * ``required_confs``: The required :attr:`confirmations<TransactionReceipt.confirmations>` before the :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>` is processed. If none is given, defaults to 1 confirmation.  If 0 is given, immediately returns a pending :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>`, while waiting for a confirmation in a separate thread.
+    * ``allow_revert``: Boolean indicating whether the transaction should be broadacsted when it is expected to revert. If not set, the default behaviour is to allow reverting transactions in development and disallow them in a live environment.
     * ``silent``: Toggles console verbosity. If ``True`` is given, suppresses all console output for this transaction.
 
     Returns a :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>` instance.

--- a/docs/core-contracts.rst
+++ b/docs/core-contracts.rst
@@ -146,6 +146,7 @@ When executing a transaction to a contract, you can optionally include a :py:cla
     * ``amount``: The amount of Ether to include with the transaction, in wei.
     * ``nonce``: The nonce for the transaction. If not given, the nonce is set according to :meth:`web3.eth.getTransactionCount <web3.eth.Eth.getTransactionCount>` while taking pending transactions from the sender into account.
     * ``required_confs``: The required :attr:`confirmations<TransactionReceipt.confirmations>` before the :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>` is processed. If none is given, defaults to 1 confirmation.  If 0 is given, immediately returns a pending :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>`, while waiting for a confirmation in a separate thread.
+    * ``allow_revert``: Boolean indicating whether the transaction should be broadacsted when it is expected to revert. If not set, the default behaviour is to allow reverting transactions in development and disallow them in a live environment.
 
 All currency integer values can also be given as strings that will be converted by :func:`Wei <brownie.convert.datatypes.Wei>`.
 

--- a/tests/network/account/test_account_transfer.py
+++ b/tests/network/account/test_account_transfer.py
@@ -64,15 +64,15 @@ def test_returns_tx_on_revert_in_console(accounts, tester, console_mode):
     assert tx.status == 0
 
 
-def test_broadcast_revert(accounts, tester, config):
-    config.active_network["settings"]["reverting_tx_gas_limit"] = False
-    assert accounts[1].nonce == 0
+def test_allow_revert(accounts, tester, config):
     with pytest.raises(VirtualMachineError):
         accounts[1].transfer(tester, 0)
-    assert accounts[1].nonce == 0
-    config.active_network["settings"]["reverting_tx_gas_limit"] = 1000000
-    with pytest.raises(VirtualMachineError):
-        accounts[1].transfer(tester, 0)
+
+    assert accounts[1].nonce == 1
+
+    with pytest.raises(ValueError):
+        accounts[1].transfer(tester, 0, allow_revert=False)
+
     assert accounts[1].nonce == 1
 
 


### PR DESCRIPTION
### What I did
Allow broadcasting reverting transactions in a live environment

Closes #765 

### How I did it
* Added the `allow_revert` position arg to `Account.deploy` and `Account.transfer`
* Expanded the exception messages when a tx fails to broadcast due to a failed `eth_estimateGas` call or because `allow_revert == False`.

### How to verify it
* Run the tests.
* Attempt to make a reverting tx on the mainnet
