### PR TITLE
Add `require_network` marker

### DIFF
--- a/brownie/test/managers/base.py
+++ b/brownie/test/managers/base.py
@@ -95,6 +95,10 @@ class PytestBrownieBase:
         return sha1(hash_.encode()).hexdigest()
 
     def pytest_configure(self, config):
+        config.addinivalue_line(
+            "markers", "require_network: only run test when a specific network is active"
+        )
+
         for key in ("coverage", "always_transact"):
             CONFIG.argv[key] = config.getoption("--coverage")
         CONFIG.argv["cli"] = "test"

--- a/brownie/test/managers/runner.py
+++ b/brownie/test/managers/runner.py
@@ -258,6 +258,25 @@ class PytestBrownieRunner(PytestBrownieBase):
                 # all tests are initially marked as skipped
                 self.results[path] = ["s"] * len(self.node_map[path])
 
+    def pytest_runtest_setup(self, item):
+        """
+        Called to perform the setup phase for a test item.
+
+        * The `require_network` marker is applied.
+
+        Arguments
+        ---------
+        item : _pytest.nodes.Item
+            Test item for which setup is performed.
+        """
+        # `require_network` marker logic
+        marker = next(item.iter_markers(name="require_network"), None)
+        if marker is not None:
+            if not len(marker.args):
+                raise ValueError("`require_network` marker must include a network name")
+            if brownie.network.show_active() not in marker.args:
+                pytest.skip("Active network does not match `require_network` marker")
+
     def pytest_runtest_logreport(self, report):
         """
         Process a test setup/call/teardown report relating to the respective phase

--- a/docs/tests-pytest-fixtures.rst
+++ b/docs/tests-pytest-fixtures.rst
@@ -1,11 +1,11 @@
 
 .. _pytest-fixtures-reference:
 
-=========================
-Pytest Fixtures Reference
-=========================
+============================
+Fixture and Marker Reference
+============================
 
-Brownie provides :ref:`fixtures <pytest-fixtures-docs>` to allow you to interact with your project during tests. To use a fixture, add an argument with the same name to the inputs of your test function.
+Brownie includes custom :ref:`fixtures <pytest-fixtures-docs>` and :ref:`markers<pytest-markers-docs>` that can be used when testing your project.
 
 Session Fixtures
 ================
@@ -182,4 +182,22 @@ Coverage fixtures alter the behaviour of tests when coverage evaluation is activ
         :linenos:
 
         def test_heavy_lifting(skip_coverage):
+            pass
+
+.. _pytest-fixtures-reference-markers:
+
+Markers
+=======
+
+Brownie provides the following :ref:`markers<pytest-markers-docs>` for use within your tests:
+
+.. py:attribute:: pytest.mark.require_network(network_name)
+
+    Mark a test so that it only runs if the active network is named ``network_name``. This is useful when you have some tests intended for a local development environment and others for a forked mainnet.
+
+    .. code-block:: python
+        :linenos:
+
+        @pytest.mark.require_network("mainnet-fork")
+        def test_almost_in_prod():
             pass

--- a/docs/tests-pytest-intro.rst
+++ b/docs/tests-pytest-intro.rst
@@ -54,7 +54,7 @@ Fixtures
 
 A `fixture <http://docs.pytest.org/en/latest/fixture.html>`_ is a function that is applied to one or more test functions, and is called prior to the execution of each test. Fixtures are used to setup the initial conditions required for a test.
 
-Fixtures are declared using the ``@pytest.fixture`` decorator. To pass a fixture to a test, include the fixture name as an input argument for the test:
+Fixtures are declared using the :func:`@pytest.fixture <pytest.fixture>` decorator. To pass a fixture to a test, include the fixture name as an input argument for the test:
 
 .. code-block:: python
     :linenos:
@@ -205,6 +205,35 @@ The sequence of events in the above example is:
 8. The teardown phase of :func:`fn_isolation <fixtures.fn_isolation>` runs. The blockchain is reverted to it's state before ``test_chain_reverted``.
 9. The teardown phase of :func:`module_isolation <fixtures.module_isolation>` runs, resetting the local environment.
 
+.. _pytest-markers-docs:
+
+Markers
+=======
+
+A `marker <https://docs.pytest.org/en/stable/mark.html#mark>`_ is a decorator applied to a test function. Markers are used to pass meta data about the test which is accessible by fixtures and plugins.
+
+To apply a marker to a specific test, use the :func:`@pytest.mark <pytest.mark>` decorator:
+
+.. code-block:: python
+    :linenos:
+
+    @pytest.mark.foo
+    def test_with_example_marker():
+        pass
+
+To apply markers at the module level, add the ``pytestmark`` global variable:
+
+.. code-block:: python
+    :linenos:
+
+    import pytest
+
+    pytestmark = [pytest.mark.foo, pytest.mark.bar]
+
+Along with the standard `pytest markers <https://docs.pytest.org/en/latest/reference.html#marks>`_, Brownie provides additional markers specific to smart contract testing. See the :ref:`markers reference<pytest-fixtures-reference-markers>` section of the documentation for more information.
+
+
+
 Handling Reverted Transactions
 ==============================
 
@@ -273,7 +302,7 @@ If the above function is executed in the console:
 Parametrizing Tests
 ===================
 
-The ``@pytest.mark.parametrize`` decorator enables `parametrization of arguments <http://docs.pytest.org/en/latest/parametrize.html>`_ for a test function. Here is a typical example of a parametrized test function, checking that a certain input results in an expected output:
+The ``@pytest.mark.parametrize`` marker enables `parametrization of arguments <http://docs.pytest.org/en/latest/parametrize.html>`_ for a test function. Here is a typical example of a parametrized test function, checking that a certain input results in an expected output:
 
 .. code-block:: python
     :linenos:

--- a/tests/test/plugin/test_markers.py
+++ b/tests/test/plugin/test_markers.py
@@ -1,0 +1,28 @@
+test_source = """
+import pytest
+
+@pytest.mark.require_network("development")
+def test_require_network_pass():
+    # should run because we are connected to development
+    pass
+
+@pytest.mark.require_network("ropsten")
+def test_require_network_skip():
+    # should skip because we are not connected to ropsten
+    pass
+
+@pytest.mark.require_network
+def test_require_network_error():
+    # should error because no network was given
+    pass
+    """
+
+
+def test_require_network(plugintester):
+    result = plugintester.runpytest()
+    result.assert_outcomes(skipped=1, passed=1, errors=1)
+
+
+def test_require_network_xdist(isolatedtester):
+    result = isolatedtester.runpytest("-n 2")
+    result.assert_outcomes(skipped=1, passed=1, errors=1)


### PR DESCRIPTION
### What I did
Add the `require_network` pytest marker to allow only running a test when a specific network is active.

Closes #810 

### How I did it
* Add the marker via `pytest_configure`
* Implement the logic within `pytest_runtest_setup`
* Add documentation - I've created a new section for markers, expect more in another PR soon:tm:
* update tests

### How to verify it
Run tests.

