### PR TITLE
Convert `skip_coverage` and `no_call_coverage` to markers

### DIFF
--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -525,7 +525,7 @@ class TransactionReceipt:
             msg = f"Encountered a {type(e).__name__} while requesting "
             msg += "debug_traceTransaction. The local RPC client has likely crashed."
             if CONFIG.argv["coverage"]:
-                msg += " If the error persists, add the skip_coverage fixture to this test."
+                msg += " If the error persists, add the `skip_coverage` marker to this test."
             raise RPCRequestError(msg) from None
 
         if "error" in trace:

--- a/brownie/test/fixtures.py
+++ b/brownie/test/fixtures.py
@@ -109,10 +109,11 @@ class PytestBrownieFixtures:
 
     @pytest.fixture
     def no_call_coverage(self):
-        """
-        Prevents coverage evaluation on contract calls during this test. Useful for speeding
-        up tests that contain many repetetive calls.
-        """
+        warnings.warn(
+            "`no_call_coverage` as a fixture has been deprecated, use it as a marker instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         CONFIG.argv["always_transact"] = False
         yield
         CONFIG.argv["always_transact"] = CONFIG.argv["coverage"]

--- a/brownie/test/fixtures.py
+++ b/brownie/test/fixtures.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 import sys
+import warnings
 
 import pytest
 
@@ -118,9 +119,11 @@ class PytestBrownieFixtures:
 
     @pytest.fixture(scope="session")
     def skip_coverage(self):
-        """Skips a test when coverage evaluation is active."""
-        # implemented in pytest_collection_modifyitems
-        pass
+        warnings.warn(
+            "`skip_coverage` as a fixture has been deprecated, use it as a marker instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
     @pytest.fixture
     def state_machine(self):

--- a/brownie/test/managers/base.py
+++ b/brownie/test/managers/base.py
@@ -98,6 +98,9 @@ class PytestBrownieBase:
         config.addinivalue_line(
             "markers", "require_network: only run test when a specific network is active"
         )
+        config.addinivalue_line(
+            "markers", "skip_coverage: skips a test when coverage evaluation is active"
+        )
 
         for key in ("coverage", "always_transact"):
             CONFIG.argv[key] = config.getoption("--coverage")

--- a/brownie/test/managers/runner.py
+++ b/brownie/test/managers/runner.py
@@ -336,6 +336,27 @@ class PytestBrownieRunner(PytestBrownieBase):
             "results": "".join(self.results[path]),
         }
 
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_runtest_call(self, item):
+        """
+        Called to run the test for test item (the call phase).
+
+        * Handles logic for the `always_transact` marker.
+
+        Arguments
+        ---------
+        item : _pytest.nodes.Item
+            Test item for which setup is performed.
+        """
+        no_call_coverage = next(item.iter_markers(name="no_call_coverage"), None)
+        if no_call_coverage:
+            CONFIG.argv["always_transact"] = False
+
+        yield
+
+        if no_call_coverage:
+            CONFIG.argv["always_transact"] = CONFIG.argv["coverage"]
+
     def pytest_report_teststatus(self, report):
         """
         Return result-category, shortletter and verbose word for status reporting.

--- a/brownie/test/managers/runner.py
+++ b/brownie/test/managers/runner.py
@@ -152,8 +152,7 @@ class PytestBrownieRunner(PytestBrownieBase):
         items in-place.
 
         Determines which modules are isolated, and skips tests based on
-        the `--update` and `--stateful` flags as well as the `skip_coverage`
-        fixture.
+        the `--update` and `--stateful` flags.
 
         Arguments
         ---------
@@ -166,10 +165,6 @@ class PytestBrownieRunner(PytestBrownieBase):
 
         tests = {}
         for i in items:
-            # apply skip_coverage
-            if "skip_coverage" in i.fixturenames and CONFIG.argv["coverage"]:
-                i.add_marker("skip")
-
             # apply --stateful flag
             if stateful is not None:
                 if stateful == "true" and "state_machine" not in i.fixturenames:
@@ -276,6 +271,13 @@ class PytestBrownieRunner(PytestBrownieBase):
                 raise ValueError("`require_network` marker must include a network name")
             if brownie.network.show_active() not in marker.args:
                 pytest.skip("Active network does not match `require_network` marker")
+                return
+
+        if CONFIG.argv["coverage"] and (
+            next(item.iter_markers(name="skip_coverage"), None)
+            or "skip_coverage" in item.fixturenames
+        ):
+            pytest.skip("`skip_coverage` marker and coverage is active")
 
     def pytest_runtest_logreport(self, report):
         """

--- a/docs/api-test.rst
+++ b/docs/api-test.rst
@@ -68,19 +68,6 @@ These fixtures are used to effectively isolate tests. If included on every test 
 
     Applies the :func:`module_isolation <fixtures.module_isolation>` fixture, and additionally takes a snapshot prior to running each test which is then reverted to after the test completes. The snapshot is taken immediately after any module-scoped fixtures are applied, and before all function-scoped ones.
 
-Coverage Fixtures
-*****************
-
-These fixtures alter the behaviour of tests when coverage evaluation is active.
-
-.. py:attribute:: fixtures.no_call_coverage
-
-    Function scope. Coverage evaluation will not be performed on called contact methods during this test.
-
-.. py:attribute:: fixtures.skip_coverage
-
-    Function scope. If coverage evaluation is active, this test will be skipped.
-
 ``brownie.test.strategies``
 ===========================
 

--- a/docs/tests-coverage.rst
+++ b/docs/tests-coverage.rst
@@ -82,8 +82,8 @@ During coverage analysis, all contract calls are executed as transactions. This 
 Some things to keep in mind that can help to reduce your test runtime when evaluating coverage:
 
     1. Coverage is analyzed on a per-transaction basis, and the results are cached. If you repeat an identical transaction, Brownie will not analyze it the 2nd time. Keep this in mind when designing and sequencing setup fixtures.
-    2. For tests that involve many calls to the same getter method, use :func:`no_call_coverage <fixtures.no_call_coverage>` to significantly speed execution.
-    3. Omit very complex tests altogether with :func:`skip_coverage <fixtures.skip_coverage>`.
+    2. For tests that involve many calls to the same getter method, use the :func:`no_call_coverage <pytest.mark.no_call_coverage>` marker to significantly speed execution.
+    3. Omit very complex tests altogether with the :func:`skip_coverage <pytest.mark.skip_coverage>` marker.
     4. If possible, always run your tests in parralel with :ref:`xdist<xdist>`.
 
-You can use the ``--durations`` flag to view a profile of your slowest tests. You may find good candidates for optimization, or the use of the :func:`no_call_coverage <fixtures.no_call_coverage>` and :func:`skip_coverage <fixtures.skip_coverage>` fixtures.
+You can use the ``--durations`` flag to view a profile of your slowest tests. You may find good candidates for optimization, or the use of the :func:`no_call_coverage <pytest.mark.no_call_coverage>` and :func:`skip_coverage <pytest.mark.skip_coverage>` fixtures.

--- a/docs/tests-pytest-fixtures.rst
+++ b/docs/tests-pytest-fixtures.rst
@@ -18,105 +18,105 @@ These fixtures provide quick access to Brownie objects that are frequently used 
 
     Yields an :func:`Accounts <brownie.network.account.Accounts>` container for the active project, used to interact with your local accounts.
 
-    .. code-block:: python
-        :linenos:
+        .. code-block:: python
+            :linenos:
 
-        def test_account_balance(accounts):
-            assert accounts[0].balance() == "100 ether"
+            def test_account_balance(accounts):
+                assert accounts[0].balance() == "100 ether"
 
 .. py:attribute:: a
 
     Short form of the ``accounts`` fixture.
 
-    .. code-block:: python
-        :linenos:
+        .. code-block:: python
+            :linenos:
 
-        def test_account_balance(a):
-            assert a[0].balance() == "100 ether"
+            def test_account_balance(a):
+                assert a[0].balance() == "100 ether"
 
 .. py:attribute:: chain
 
     Yields an :func:`Chain <brownie.network.state.Chain>` object, used to access block data and interact with the local test chain.
 
-    .. code-block:: python
-        :linenos:
+        .. code-block:: python
+            :linenos:
 
-        def test_account_balance(accounts, chain):
-            balance = accounts[1].balance()
-            accounts[0].transfer(accounts[1], "10 ether")
-            assert accounts[1].balance() == balance + "10 ether"
+            def test_account_balance(accounts, chain):
+                balance = accounts[1].balance()
+                accounts[0].transfer(accounts[1], "10 ether")
+                assert accounts[1].balance() == balance + "10 ether"
 
-            chain.reset()
-            assert accounts[1].balance() == balance
+                chain.reset()
+                assert accounts[1].balance() == balance
 
 .. py:attribute:: Contract
 
     Yields the :func:`Contract <brownie.network.contract.Contract>` class, used to interact with contracts outside of the active project.
 
-    .. code-block:: python
-        :linenos:
+        .. code-block:: python
+            :linenos:
 
-        @pytest.fixture(scope="session")
-        def dai(Contract):
-            yield Contract.from_explorer("0x6B175474E89094C44Da98b954EedeAC495271d0F")
+            @pytest.fixture(scope="session")
+            def dai(Contract):
+                yield Contract.from_explorer("0x6B175474E89094C44Da98b954EedeAC495271d0F")
 
 .. py:attribute:: history
 
     Yields a :func:`TxHistory <brownie.network.state.TxHistory>` container for the active project, used to access transaction data.
 
-    .. code-block:: python
-        :linenos:
+        .. code-block:: python
+            :linenos:
 
-        def test_account_balance(accounts, history):
-            accounts[0].transfer(accounts[1], "10 ether")
-            assert len(history) == 1
+            def test_account_balance(accounts, history):
+                accounts[0].transfer(accounts[1], "10 ether")
+                assert len(history) == 1
 
 .. py:attribute:: interface
 
     Yields the :func:`InterfaceContainer <brownie.network.contract.InterfaceContainer>` object for the active project, which provides access to project interfaces.
 
-    .. code-block:: python
-        :linenos:
+        .. code-block:: python
+            :linenos:
 
-        @pytest.fixture(scope="session")
-        def dai(interface):
-            yield interface.Dai("0x6B175474E89094C44Da98b954EedeAC495271d0F")
+            @pytest.fixture(scope="session")
+            def dai(interface):
+                yield interface.Dai("0x6B175474E89094C44Da98b954EedeAC495271d0F")
 
 .. py:attribute:: pm
 
     Callable fixture that provides access to :func:`Project <brownie.project.main.Project>` objects, used for testing against installed packages.
 
-    .. code-block:: python
-        :linenos:
+        .. code-block:: python
+            :linenos:
 
-        @pytest.fixture(scope="module")
-        def compound(pm, accounts):
-            ctoken = pm('defi.snakecharmers.eth/compound@1.1.0').CToken
-            yield ctoken.deploy({'from': accounts[0]})
+            @pytest.fixture(scope="module")
+            def compound(pm, accounts):
+                ctoken = pm('defi.snakecharmers.eth/compound@1.1.0').CToken
+                yield ctoken.deploy({'from': accounts[0]})
 
 .. py:attribute:: state_machine
 
     Yields the :func:`state_machine <brownie.test.stateful.state_machine>` method, used for running a :ref:`stateful test <hypothesis-stateful>`.
 
-    .. code-block:: python
-        :linenos:
+        .. code-block:: python
+            :linenos:
 
-        def test_stateful(Token, accounts, state_machine):
-            token = Token.deploy("Test Token", "TST", 18, 1e23, {'from': accounts[0]})
+            def test_stateful(Token, accounts, state_machine):
+                token = Token.deploy("Test Token", "TST", 18, 1e23, {'from': accounts[0]})
 
-            state_machine(StateMachine, accounts, token)
+                state_machine(StateMachine, accounts, token)
 
 .. py:attribute:: web3
 
     Yields a :func:`Web3 <brownie.network.web3.Web3>` object.
 
-    .. code-block:: python
-        :linenos:
+        .. code-block:: python
+            :linenos:
 
-        def test_account_balance(accounts, web3):
-            height = web3.eth.blockNumber
-            accounts[0].transfer(accounts[1], "10 ether")
-            assert web3.eth.blockNumber == height + 1
+            def test_account_balance(accounts, web3):
+                height = web3.eth.blockNumber
+                accounts[0].transfer(accounts[1], "10 ether")
+                assert web3.eth.blockNumber == height + 1
 
 Contract Fixtures
 =================
@@ -125,12 +125,12 @@ Brownie creates dynamically named fixtures to access each :func:`ContractContain
 
 For example - if your project contains a contract named ``Token``, there will be a ``Token`` fixture available.
 
-.. code-block:: python
-    :linenos:
+    .. code-block:: python
+        :linenos:
 
-    def test_token_deploys(Token, accounts):
-        token = accounts[0].deploy(Token, "Test Token", "TST", 18, 1e24)
-        assert token.name() == "Test Token"
+        def test_token_deploys(Token, accounts):
+            token = accounts[0].deploy(Token, "Test Token", "TST", 18, 1e24)
+            assert token.name() == "Test Token"
 
 
 Isolation Fixtures
@@ -151,38 +151,6 @@ Coverage Fixtures
 
 Coverage fixtures alter the behaviour of tests when coverage evaluation is active. They are useful for tests with many repetitive functions, to avoid the slowdown caused by ``debug_traceTransaction`` queries.
 
-.. py:attribute:: no_call_coverage
-
-    Coverage evaluation will not be performed on called contact methods during this test.
-
-    .. code-block:: python
-        :linenos:
-
-        import pytest
-
-        @pytest.fixture(scope="module", autouse=True)
-        def token(Token, accounts):
-            t = accounts[0].deploy(Token, "Test Token", "TST", 18, 1000)
-            t.transfer(accounts[1], 100, {'from': accounts[0]})
-            yield t
-
-        def test_normal(token):
-            # this call is handled as a transaction, coverage is evaluated
-            assert token.balanceOf(accounts[0]) == 900
-
-        def test_no_call_cov(Token, no_call_coverage):
-            # this call happens normally, no coverage evaluation
-            assert token.balanceOf(accounts[1]) == 100
-
-.. py:attribute:: skip_coverage
-
-    Skips a test if coverage evaluation is active.
-
-    .. code-block:: python
-        :linenos:
-
-        def test_heavy_lifting(skip_coverage):
-            pass
 
 .. _pytest-fixtures-reference-markers:
 
@@ -195,9 +163,38 @@ Brownie provides the following :ref:`markers<pytest-markers-docs>` for use withi
 
     Mark a test so that it only runs if the active network is named ``network_name``. This is useful when you have some tests intended for a local development environment and others for a forked mainnet.
 
-    .. code-block:: python
-        :linenos:
+        .. code-block:: python
+            :linenos:
 
-        @pytest.mark.require_network("mainnet-fork")
-        def test_almost_in_prod():
-            pass
+            @pytest.mark.require_network("mainnet-fork")
+            def test_almost_in_prod():
+                pass
+
+.. py:attribute:: pytest.mark.no_call_coverage
+
+    Only evaluate coverage for transactions made during this test, not calls.
+
+    This marker is useful for speeding up slow tests that involve many calls to the same view method.
+
+        .. code-block:: python
+            :linenos:
+
+            def test_normal(token):
+                # during coverage analysis this call is handled as a transaction
+                assert token.balanceOf(accounts[0]) == 900
+
+            @pytest.mark.no_call_coverage
+            def test_no_call_cov(Token):
+                # this call is handled as a call, the test execution is quicker
+                assert token.balanceOf(accounts[1]) == 100
+
+.. py:attribute:: pytest.mark.skip_coverage
+
+    Skips a test if coverage evaluation is active.
+
+        .. code-block:: python
+            :linenos:
+
+            @pytest.mark.skip_coverage
+            def test_heavy_lifting():
+                pass

--- a/tests/test/plugin/test_skip_coverage.py
+++ b/tests/test/plugin/test_skip_coverage.py
@@ -4,8 +4,10 @@ import pytest
 
 test_source = """
 import brownie
+import pytest
 
-def test_call_and_transact(BrownieTester, accounts, skip_coverage):
+@pytest.mark.skip_coverage
+def test_call_and_transact(BrownieTester, accounts):
     c = accounts[0].deploy(BrownieTester, True)
     c.doNothing({'from': accounts[0]})
 


### PR DESCRIPTION
### What I did
Convert `skip_coverage` and `no_call_coverage` to markers, deprecate them as fixtures.

### How I did it
The marker logic is how handled via `pytest_runtest_call` or `pytest_runtest_setup`.  Using the fixtures raises a deprecation warning.

### How to verify it
Run the tests.  I've updated some existing cases.
