### PR TITLE
Target dev revert reason in `brownie.reverts`

### DIFF
--- a/brownie/exceptions.py
+++ b/brownie/exceptions.py
@@ -104,14 +104,16 @@ class VirtualMachineError(Exception):
                 raise ValueError(exc["message"]) from None
 
             self.txid: str = txid
-            self.revert_type: str = data["error"]
-            self.revert_msg: Optional[str] = data.get("reason")
-            self.pc: Optional[str] = data.get("program_counter")
             self.source: str = ""
+            self.revert_type: str = data["error"]
+            self.pc: Optional[str] = data.get("program_counter")
             if self.revert_type == "revert":
                 self.pc -= 1
+
+            self.revert_msg: Optional[str] = data.get("reason")
+            self.dev_revert_msg = brownie.project.build._get_dev_revert(self.pc)
             if self.revert_msg is None and self.revert_type in ("revert", "invalid opcode"):
-                self.revert_msg = brownie.project.build._get_dev_revert(self.pc)
+                self.revert_msg = self.dev_revert_msg
         else:
             raise ValueError(str(exc)) from None
 

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -355,7 +355,7 @@ class TransactionReceipt:
             # if traces are not available, do not attempt to determine the revert reason
             raise exc or ValueError("Execution reverted")
 
-        if self._revert_msg is None:
+        if self._dev_revert_msg is None:
             # no revert message and unable to check dev string - have to get trace
             self._expand_trace()
         if self.contract_address:
@@ -364,7 +364,9 @@ class TransactionReceipt:
             source = self._traceback_string()
         else:
             source = self._error_string(1)
-        raise exc._with_attr(source=source, revert_msg=self._revert_msg)
+        raise exc._with_attr(
+            source=source, revert_msg=self._revert_msg, dev_revert_msg=self._dev_revert_msg
+        )
 
     def _await_transaction(self, required_confs: int, is_blocking: bool) -> None:
         # await tx showing in mempool

--- a/docs/api-test.rst
+++ b/docs/api-test.rst
@@ -132,11 +132,12 @@ RevertContextManager
 
 The ``RevertContextManager`` closely mimics the behaviour of :func:`pytest.raises <pytest.raises>`.
 
-.. py:class:: brownie.test.plugin.RevertContextManager(revert_msg=None)
+.. py:class:: brownie.test.plugin.RevertContextManager(revert_msg=None, dev_revert_msg=None)
 
     Context manager used to handle :func:`VirtualMachineError <brownie.exceptions.VirtualMachineError>` exceptions. Raises ``AssertionError`` if no transaction has reverted when the context closes.
 
-    * ``revert_msg``: Optional. Raises an ``AssertionError`` if the transaction does not revert with this error string.
+    * ``revert_msg``: Optional. Raises if the transaction does not revert with this error string.
+    * ``dev_revert_msg``: Optional. Raises if the transaction does not revert with this :ref:`dev revert string<dev-revert>`.
 
     This class is available as ``brownie.reverts`` when ``pytest`` is active.
 

--- a/tests/network/transaction/test_revert_msg.py
+++ b/tests/network/transaction/test_revert_msg.py
@@ -40,7 +40,7 @@ REVERT_FUNCTIONS_INPUT = [
 
 @pytest.mark.parametrize("expr", ["revert()", "require(false)"])
 @pytest.mark.parametrize("func", REVERT_FUNCTIONS_NO_INPUT)
-def test_final_stmt_revert_no_input(console_mode, evmtester, accounts, expr, func):
+def test_final_stmt_revert_no_input_no_msg(console_mode, evmtester, accounts, expr, func):
 
     func = func.format(expr)
     code = f"""
@@ -53,9 +53,45 @@ contract Foo {{
     contract = compile_source(code).Foo.deploy({"from": accounts[0]})
     tx = contract.foo()
     assert tx.revert_msg == "dev: yuss"
+    assert tx.dev_revert_msg == "dev: yuss"
+
+
+@pytest.mark.parametrize("expr", ["revert('foo')", "require(false, 'foo')"])
+@pytest.mark.parametrize("func", REVERT_FUNCTIONS_NO_INPUT)
+def test_final_stmt_revert_no_input(console_mode, evmtester, accounts, expr, func):
+
+    func = func.format(expr)
+    code = f"""
+pragma solidity >=0.4.22;
+contract Foo {{
+    {func}
+}}
+    """
+
+    contract = compile_source(code).Foo.deploy({"from": accounts[0]})
+    tx = contract.foo()
+    assert tx.revert_msg == "foo"
+    assert tx.dev_revert_msg == "dev: yuss"
 
 
 @pytest.mark.parametrize("expr", ["revert()", "require(false)"])
+@pytest.mark.parametrize("func", REVERT_FUNCTIONS_INPUT)
+def test_final_stmt_revert_input_no_msg(console_mode, evmtester, accounts, expr, func):
+
+    func = func.format(expr)
+    code = f"""
+pragma solidity >=0.4.22;
+contract Foo {{
+    {func}
+}}
+    """
+
+    contract = compile_source(code).Foo.deploy({"from": accounts[0]})
+    tx = contract.foo(4)
+    assert tx.revert_msg == "dev: yuss"
+
+
+@pytest.mark.parametrize("expr", ["revert('foo')", "require(false, 'foo')"])
 @pytest.mark.parametrize("func", REVERT_FUNCTIONS_INPUT)
 def test_final_stmt_revert_input(console_mode, evmtester, accounts, expr, func):
 
@@ -69,7 +105,8 @@ contract Foo {{
 
     contract = compile_source(code).Foo.deploy({"from": accounts[0]})
     tx = contract.foo(4)
-    assert tx.revert_msg == "dev: yuss"
+    assert tx.revert_msg == "foo"
+    assert tx.dev_revert_msg == "dev: yuss"
 
 
 def test_revert_msg_via_jump(ext_tester, console_mode):

--- a/tests/test/plugin/test_reverts.py
+++ b/tests/test/plugin/test_reverts.py
@@ -13,7 +13,7 @@ def tester(BrownieTester, accounts):
 def test_reverts_success(tester):
     with brownie.reverts("zero"):
         tester.revertStrings(0)
-    with brownie.reverts("dev: one"):
+    with brownie.reverts(dev_revert_msg="dev: one"):
         tester.revertStrings(1)
 
 @pytest.mark.xfail(condition=True, reason="", raises=AssertionError, strict=True)


### PR DESCRIPTION
### What I did
Allow specific targeting of dev revert string within `brownie.reverts`

Closes #806 

### How I did it

```python
with brownie.reverts(dev_revert_msg="dev: foo"):
    ...
```

Also fixed a bug that I missed in #805 causing the dev revert string to not always be queried when requested.

### How to verify it
Run tests.  I added a few new cases.
