### PR TITLE
Allow regex in `brownie.reverts`

### DIFF
--- a/docs/api-test.rst
+++ b/docs/api-test.rst
@@ -130,14 +130,16 @@ One of these classes is instantiated in the ``pytest_configure`` method of ``bro
 RevertContextManager
 --------------------
 
-The ``RevertContextManager`` closely mimics the behaviour of :func:`pytest.raises <pytest.raises>`.
+The ``RevertContextManager`` behaves similarly to :func:`pytest.raises <pytest.raises>`.
 
-.. py:class:: brownie.test.plugin.RevertContextManager(revert_msg=None, dev_revert_msg=None)
+.. py:class:: brownie.test.plugin.RevertContextManager(revert_msg=None, dev_revert_msg=None, revert_pattern=None, dev_revert_pattern=None)
 
     Context manager used to handle :func:`VirtualMachineError <brownie.exceptions.VirtualMachineError>` exceptions. Raises ``AssertionError`` if no transaction has reverted when the context closes.
 
     * ``revert_msg``: Optional. Raises if the transaction does not revert with this error string.
     * ``dev_revert_msg``: Optional. Raises if the transaction does not revert with this :ref:`dev revert string<dev-revert>`.
+    * ``revert_pattern``: Regex pattern to compare against the transaction error string. Raises if the error string does not fully match the regex (partial matches are not allowed).
+    * ``dev_revert_pattern``: Regex pattern to compare against the transaction dev revert string.
 
     This class is available as ``brownie.reverts`` when ``pytest`` is active.
 

--- a/tests/test/test_revert_context_manager.py
+++ b/tests/test/test_revert_context_manager.py
@@ -1,0 +1,75 @@
+import pytest
+
+from brownie.test.managers.runner import RevertContextManager as reverts
+
+
+def test_no_args(vypertester):
+    with reverts():
+        vypertester.revertStrings(0)
+
+
+def test_revert_msg(vypertester):
+    with reverts("zero"):
+        vypertester.revertStrings(0)
+
+
+def test_both(vypertester):
+    with reverts(revert_msg="two", dev_revert_msg="dev: error"):
+        vypertester.revertStrings(2)
+
+
+def test_revert_msg_raises_incorrect(vypertester):
+    with pytest.raises(AssertionError):
+        with reverts("one"):
+            vypertester.revertStrings(0)
+
+
+def test_revert_msg_raises_partial(vypertester):
+    with pytest.raises(AssertionError):
+        with reverts("ze"):
+            vypertester.revertStrings(0)
+
+
+def test_revert_pattern(vypertester):
+    with reverts(revert_pattern="z..o"):
+        vypertester.revertStrings(0)
+
+
+def test_revert_pattern_raises_incorrect(vypertester):
+    with pytest.raises(AssertionError):
+        with reverts(revert_pattern="foo[a-zA-Z]."):
+            vypertester.revertStrings(0)
+
+
+def test_revert_pattern_raises_partial(vypertester):
+    with pytest.raises(AssertionError):
+        with reverts(revert_pattern=".ro"):
+            vypertester.revertStrings(0)
+
+
+def test_dev_revert(vypertester):
+    with reverts(dev_revert_msg="dev: error"):
+        vypertester.revertStrings(2)
+
+
+def test_dev_revert_fails(vypertester):
+    with pytest.raises(AssertionError):
+        with reverts(dev_revert_msg="dev: foo"):
+            vypertester.revertStrings(2)
+
+
+def test_dev_revert_pattern(vypertester):
+    with reverts(dev_revert_pattern="[a-z]*:\\serror"):
+        vypertester.revertStrings(2)
+
+
+def test_dev_revert_pattern_raises_incorrect(vypertester):
+    with pytest.raises(AssertionError):
+        with reverts(dev_revert_pattern="bleerg[a-zA-Z]."):
+            vypertester.revertStrings(2)
+
+
+def test_dev_revert_pattern_raises_partial(vypertester):
+    with pytest.raises(AssertionError):
+        with reverts(dev_revert_pattern="\\sfoo"):
+            vypertester.revertStrings(2)

--- a/tox.ini
+++ b/tox.ini
@@ -12,11 +12,11 @@ passenv =
     GITHUB_TOKEN
     WEB3_INFURA_PROJECT_ID
 deps =
-    py{36,37,38},{pm,plugin}test,evm-{byzantium,petersburg,istanbul,latest}: coverage==5.1
-    py{36,37,38},{pm,plugin}test,evm-{byzantium,petersburg,istanbul,latest}: pytest==5.4.3
-    py{36,37,38},{pm,plugin}test,evm-{byzantium,petersburg,istanbul,latest}: pytest-cov==2.9.0
-    py{36,37,38},{pm,plugin}test,evm-{byzantium,petersburg,istanbul,latest}: pytest-mock==3.1.1
-    py{36,37,38},{pm,plugin}test,evm-{byzantium,petersburg,istanbul,latest}: pytest-xdist==1.32.0
+    py{36,37,38},{pm,plugin}test,evm-{byzantium,petersburg,istanbul,latest}: coverage==5.2.1
+    py{36,37,38},{pm,plugin}test,evm-{byzantium,petersburg,istanbul,latest}: pytest==6.0.1
+    py{36,37,38},{pm,plugin}test,evm-{byzantium,petersburg,istanbul,latest}: pytest-cov==2.10.1
+    py{36,37,38},{pm,plugin}test,evm-{byzantium,petersburg,istanbul,latest}: pytest-mock==3.3.1
+    py{36,37,38},{pm,plugin}test,evm-{byzantium,petersburg,istanbul,latest}: pytest-xdist==1.34.0
     docs-{local,external}: sphinx
     docs-{local,external}: sphinx_rtd_theme
     docs-{local,external}: pygments_lexer_solidity
@@ -27,7 +27,7 @@ commands =
     evm-istanbul: python -m pytest tests/ --evm 0.5.13,0.5.17,0.6.3,0.6.9 istanbul 0,10000
     evm-latest: python -m pytest tests/ --evm latest byzantium,petersburg,istanbul 0,200,10000
     pmtest: python -m pytest tests/ --target pm -n 0
-    plugintest: python -m pytest tests/ --target plugin -n 0
+    plugintest: python -m pytest tests/test/plugin --target plugin -n 0
     docs-local: sphinx-build {posargs:-E} -b html docs dist/docs -n -q --color
     docs-external: sphinx-build -b linkcheck docs dist/docs -n -q --color
 


### PR DESCRIPTION
### What I did
Allow use of regex matching in `brownie.reverts` context manager (continuation of #862)

Closes #807 

### How I did it
Added two new kwargs, `revert_pattern` and `dev_revert_pattern`, for matching error strings and dev revert strings.

### How to verify it
Run the tests.  I've added some new tests to cover this.
