### PR TITLE
fix: add zero-bytes when memory ends too soon

### DIFF
--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -1234,7 +1234,10 @@ def _step_external(
 def _get_memory(step: Dict, idx: int) -> HexBytes:
     offset = int(step["stack"][idx], 16)
     length = int(step["stack"][idx - 1], 16)
-    return HexBytes("".join(step["memory"]))[offset : offset + length]
+    data = HexBytes("".join(step["memory"]))[offset : offset + length]
+    # append zero-bytes if allocated memory ends before `length` bytes
+    data = HexBytes(data + b"\x00" * (length - len(data)))
+    return data
 
 
 def _get_last_map(address: EthAddress, sig: str) -> Dict:


### PR DESCRIPTION
### What I did
When pulling data from the memory within a trace, append zero-bytes when the available memory ends prior to the expected length.

Fixes an issue found as reported by @banteg and found in https://github.com/banteg/cornichon/pull/1
