### PR TITLE
Disable codecov annotations

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,5 @@
 comment: false
+
 coverage:
   status:
     project:
@@ -8,3 +9,5 @@ coverage:
       default:
         target: 0
 
+github_checks:
+  annotations: false


### PR DESCRIPTION
### What I did
Disable codecov's new [github checks](https://docs.codecov.io/docs/github-checks-beta) annotations. They make the diff of a PR very difficult to grok.