### PR TITLE
`ContractContainer.decode_input`

### DIFF
--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -105,10 +105,17 @@ class _ContractBase:
         Any
             Decoded input arguments
         """
-        if not isinstance(calldata, bytes):
+        if not isinstance(calldata, HexBytes):
             calldata = HexBytes(calldata)
 
-        abi = next((i for i in self.abi if build_function_selector(i) == calldata[:4].hex()), None)
+        abi = next(
+            (
+                i
+                for i in self.abi
+                if i["type"] == "function" and build_function_selector(i) == calldata[:4].hex()
+            ),
+            None,
+        )
         if abi is None:
             raise ValueError("Four byte selector does not match the ABI for this contract")
 
@@ -387,10 +394,17 @@ class InterfaceConstructor:
         Any
             Decoded input arguments
         """
-        if not isinstance(calldata, bytes):
+        if not isinstance(calldata, HexBytes):
             calldata = HexBytes(calldata)
 
-        abi = next((i for i in self.abi if build_function_selector(i) == calldata[:4].hex()), None)
+        abi = next(
+            (
+                i
+                for i in self.abi
+                if i["type"] == "function" and build_function_selector(i) == calldata[:4].hex()
+            ),
+            None,
+        )
         if abi is None:
             raise ValueError("Four byte selector does not match the ABI for this contract")
 

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -371,6 +371,37 @@ class InterfaceConstructor:
     def __repr__(self) -> str:
         return f"<{type(self).__name__} '{self._name}'>"
 
+    def decode_input(self, calldata: Union[str, bytes]) -> Tuple[str, Any]:
+        """
+        Decode input calldata for this contract.
+
+        Arguments
+        ---------
+        calldata : str | bytes
+            Calldata for a call to this contract
+
+        Returns
+        -------
+        str
+            Signature of the function that was called
+        Any
+            Decoded input arguments
+        """
+        if not isinstance(calldata, bytes):
+            calldata = HexBytes(calldata)
+
+        abi = next((i for i in self.abi if build_function_selector(i) == calldata[:4].hex()), None)
+        if abi is None:
+            raise ValueError("Four byte selector does not match the ABI for this contract")
+
+        function_sig = build_function_signature(abi)
+
+        types_list = get_type_strings(abi["inputs"])
+        result = eth_abi.decode_abi(types_list, calldata[4:])
+        input_args = format_input(abi, result)
+
+        return function_sig, input_args
+
 
 class _DeployedContractBase(_ContractBase):
     """Methods for interacting with a deployed contract.

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -89,6 +89,37 @@ class _ContractBase:
         sig = calldata[:10].lower()
         return self.selectors.get(sig)
 
+    def decode_input(self, calldata: Union[str, bytes]) -> Tuple[str, Any]:
+        """
+        Decode input calldata for this contract.
+
+        Arguments
+        ---------
+        calldata : str | bytes
+            Calldata for a call to this contract
+
+        Returns
+        -------
+        str
+            Signature of the function that was called
+        Any
+            Decoded input arguments
+        """
+        if not isinstance(calldata, bytes):
+            calldata = HexBytes(calldata)
+
+        abi = next((i for i in self.abi if build_function_selector(i) == calldata[:4].hex()), None)
+        if abi is None:
+            raise ValueError("Four byte selector does not match the ABI for this contract")
+
+        function_sig = build_function_signature(abi)
+
+        types_list = get_type_strings(abi["inputs"])
+        result = eth_abi.decode_abi(types_list, calldata[4:])
+        input_args = format_input(abi, result)
+
+        return function_sig, input_args
+
 
 class ContractContainer(_ContractBase):
 

--- a/docs/api-network.rst
+++ b/docs/api-network.rst
@@ -765,6 +765,16 @@ ContractContainer Methods
             raise ValueError("No contract deployed at {}".format(address))
         ValueError: No contract deployed at 0xefb1336a2E6B5dfD83D4f3a8F3D2f85b7bfb61DC
 
+.. py:classmethod:: ContractContainer.decode_input(calldata)
+
+    Given the call data of a transaction, returns the function signature as a string and the decoded input arguments.
+
+    Raises ``ValueError`` if the call data cannot be decoded.
+
+    .. code-block:: python
+
+        >>> Token.decode_input('0xa9059cbb0000000000000000000000009dc9431ccccd2c73f0a2f68dc69a4a527ab5d8090000000000000000000000000000000000000000000000000000000000002710')
+        ("transfer(address,uint256)", ['0x9DC9431CcCCD2C73F0a2F68Dc69A4a527aB5d809', 10000])
 
 .. py:classmethod:: ContractContainer.get_method(calldata)
 


### PR DESCRIPTION
### What I did
Add `ContractContainer.decode_input` for decoding arbitrary calldata into a contract.

