### PR TITLE
fix: convert `to` to address prior to gas estimation

### DIFF
--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -541,7 +541,7 @@ class _PrivateKeyAccount(PublicKeyAccount):
         """
         tx: Dict = {
             "from": self.address,
-            "to": str(to) if to else None,
+            "to": to_address(str(to)) if to else None,
             "value": Wei(amount),
             "data": HexBytes(data or ""),
         }


### PR DESCRIPTION
### What I did
Ensure `to` field is correctly checksummed prior to calling `eth_estimateGas` 

