### PR TITLE
Detect EIP1822 proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/eth-brownie/brownie)
+### Added
+- Detect EIP1822 proxies `Contract.from_explorer` ([#881](https://github.com/eth-brownie/brownie/pull/881))
 
 ## [1.12.1](https://github.com/eth-brownie/brownie/tree/v1.12.1) - 2020-11-28
 ### Fixed

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -790,11 +790,19 @@ class Contract(_DeployedContractBase):
 
         if as_proxy_for is None:
             # always check for an EIP1967 proxy - https://eips.ethereum.org/EIPS/eip-1967
+            # slot is `bytes32(uint256(keccak256("eip1967.proxy.implementation")) - 1))`
             implementation_eip1967 = web3.eth.getStorageAt(
                 address, "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc"
             )
+            # always check for an EIP1822 proxy - https://eips.ethereum.org/EIPS/eip-1822
+            # slot is `keccak256("PROXIABLE")`
+            implementation_eip1822 = web3.eth.getStorageAt(
+                address, "0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7"
+            )
             if int(implementation_eip1967.hex(), 16):
                 as_proxy_for = _resolve_address(implementation_eip1967[12:])
+            elif int(implementation_eip1822.hex(), 16):
+                as_proxy_for = _resolve_address(implementation_eip1822[12:])
             elif data["result"][0].get("Implementation"):
                 # for other proxy patterns, we only check if etherscan indicates
                 # the contract is a proxy. otherwise we could have a false positive

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -790,15 +790,11 @@ class Contract(_DeployedContractBase):
 
         if as_proxy_for is None:
             # always check for an EIP1967 proxy - https://eips.ethereum.org/EIPS/eip-1967
-            # slot is `bytes32(uint256(keccak256("eip1967.proxy.implementation")) - 1))`
             implementation_eip1967 = web3.eth.getStorageAt(
-                address, "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc"
+                address, int(web3.keccak(text="eip1967.proxy.implementation").hex(), 16) - 1
             )
             # always check for an EIP1822 proxy - https://eips.ethereum.org/EIPS/eip-1822
-            # slot is `keccak256("PROXIABLE")`
-            implementation_eip1822 = web3.eth.getStorageAt(
-                address, "0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7"
-            )
+            implementation_eip1822 = web3.eth.getStorageAt(address, web3.keccak(text="PROXIABLE"))
             if int(implementation_eip1967.hex(), 16):
                 as_proxy_for = _resolve_address(implementation_eip1967[12:])
             elif int(implementation_eip1822.hex(), 16):

--- a/tests/network/contract/test_contract.py
+++ b/tests/network/contract/test_contract.py
@@ -291,14 +291,24 @@ def test_autofetch_missing(network, config, mocker):
     assert requests.get.call_count == 2
 
 
-def test_as_proxy_for(network):
+@pytest.mark.parametrize(
+    "original,impl",
+    [
+        [
+            "0x3d9819210a31b4961b30ef54be2aed79b9c9cd3b",
+            "0x7b5e3521a049C8fF88e6349f33044c6Cc33c113c",
+        ],
+        [
+            "0x87a3eF113C210Ab35AFebe820fF9880bf0DD4bfC",
+            "0x1BA2F447E620E3Ec027992d20234A9715a124041",
+        ],
+    ],
+)
+def test_as_proxy_for(network, original, impl):
     network.connect("mainnet")
-    original = Contract.from_explorer("0x3d9819210a31b4961b30ef54be2aed79b9c9cd3b")
-    proxy = Contract.from_explorer(
-        "0x3d9819210a31b4961b30ef54be2aed79b9c9cd3b",
-        as_proxy_for="0x7b5e3521a049C8fF88e6349f33044c6Cc33c113c",
-    )
-    implementation = Contract("0x7b5e3521a049C8fF88e6349f33044c6Cc33c113c")
+    original = Contract.from_explorer(original)
+    proxy = Contract.from_explorer(original, as_proxy_for=impl)
+    implementation = Contract(impl)
 
     assert original.abi == proxy.abi
     assert original.address == proxy.address


### PR DESCRIPTION
### What I did

Added support for [EIP-1822](https://eips.ethereum.org/EIPS/eip-1822) proxy pattern detection to `Contract.from_explorer`.

### How I did it

### How to verify it

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [x] I have updated the documentation
- [x] I have added an entry to the changelog
