### PR TITLE
fix: correct link to mixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/eth-brownie/brownie)
+### Fixed
+- Typo in link to mixes ([#886](https://github.com/eth-brownie/brownie/pull/886))
 
 ## [1.12.2](https://github.com/eth-brownie/brownie/tree/v1.12.2) - 2020-12-04
 ### Added

--- a/brownie/_cli/bake.py
+++ b/brownie/_cli/bake.py
@@ -17,7 +17,7 @@ Options:
 Brownie mixes are ready-made templates that you can use as a starting
 point for your own project, or as a part of a tutorial.
 
-For a complete list of Brownie mixes visit https://www.github.com/brownie-mixes
+For a complete list of Brownie mixes visit https://www.github.com/brownie-mix
 """
 
 


### PR DESCRIPTION
### What I did

fixed a typo

### How I did it

### How to verify it

```
$ curl -s -o /dev/null -w "%{http_code}" https://github.com/brownie-mixes
404
$ curl -s -o /dev/null -w "%{http_code}" https://github.com/brownie-mix
200
```

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [x] I have updated the documentation
- [x] I have added an entry to the changelog
