### PR TITLE
Solidity error codes

### DIFF
--- a/brownie/project/compiler/solidity.py
+++ b/brownie/project/compiler/solidity.py
@@ -26,6 +26,20 @@ solcx_logger.addHandler(sh)
 
 AVAILABLE_SOLC_VERSIONS = None
 
+# error codes used in Solidity >=0.8.0
+# docs.soliditylang.org/en/v0.8.0/control-structures.html#panic-via-assert-and-error-via-require
+SOLIDITY_ERROR_CODES = {
+    1: "Failed assertion",
+    17: "Integer overflow",
+    18: "Division or modulo by zero",
+    33: "Conversion to enum out of bounds",
+    24: "Access to storage byte array that is incorrectly encoded",
+    49: "Pop from empty array",
+    50: "Index out of range",
+    65: "Attempted to allocate too much memory",
+    81: "Call to zero-initialized variable of internal function type",
+}
+
 
 def get_version() -> Version:
     return solcx.get_solc_version().truncate()

--- a/tests/network/transaction/test_revert_msg.py
+++ b/tests/network/transaction/test_revert_msg.py
@@ -163,7 +163,7 @@ def test_nonpayable(tester, evmtester, console_mode):
 def test_solidity_invalid_opcodes(evmtester):
     with pytest.raises(VirtualMachineError) as exc:
         evmtester.invalidOpcodes(0, 0)
-    assert exc.value.revert_msg == "invalid opcode"
+    assert exc.value.revert_msg in ("Failed assertion", "invalid opcode")
     with pytest.raises(VirtualMachineError) as exc:
         evmtester.invalidOpcodes(1, 0)
     assert exc.value.revert_msg == "dev: foobar"
@@ -172,10 +172,10 @@ def test_solidity_invalid_opcodes(evmtester):
     assert exc.value.revert_msg == "Index out of range"
     with pytest.raises(VirtualMachineError) as exc:
         evmtester.invalidOpcodes(2, 0)
-    assert exc.value.revert_msg == "Division by zero"
+    assert exc.value.revert_msg in ("Division or modulo by zero", "Division by zero")
     with pytest.raises(VirtualMachineError) as exc:
         evmtester.modulusByZero(2, 0)
-    assert exc.value.revert_msg == "Modulus by zero"
+    assert exc.value.revert_msg in ("Division or modulo by zero", "Modulus by zero")
 
 
 def test_vyper_revert_reasons(vypertester, console_mode):


### PR DESCRIPTION
### What I did
Add support for the new solidity [error codes](docs.soliditylang.org/en/v0.8.0/control-structures.html#panic-via-assert-and-error-via-require)

Related issue: #897 

### How to verify it
The tests should be _mostly_ passing now. There's still one more issue to address before we can consider 0.8.0 fully supported.
