### PR TITLE
Feat chainid networkid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/eth-brownie/brownie)
+### Added
+- Exposed `chain_id` and `network_id` ganache-cli parameters ([#908](https://github.com/eth-brownie/brownie/pull/908))
 ### Fixed
 - Typo in link to mixes ([#886](https://github.com/eth-brownie/brownie/pull/886))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/eth-brownie/brownie)
 ### Added
-- Exposed `chain_id` and `network_id` ganache-cli parameters ([#908](https://github.com/eth-brownie/brownie/pull/908))
+- Exposed `chain_id` and `network_id` ganache-cli parameters. Forked networks retain `chain_id`. ([#908](https://github.com/eth-brownie/brownie/pull/908))
 ### Fixed
 - Typo in link to mixes ([#886](https://github.com/eth-brownie/brownie/pull/886))
+
 
 ## [1.12.2](https://github.com/eth-brownie/brownie/tree/v1.12.2) - 2020-12-04
 ### Added

--- a/brownie/_cli/networks.py
+++ b/brownie/_cli/networks.py
@@ -52,6 +52,8 @@ DEV_CMD_SETTINGS = (
     "block_time",
     "default_balance",
     "time",
+    "network_id",
+    "chain_id",
 )
 
 

--- a/brownie/_config.py
+++ b/brownie/_config.py
@@ -85,6 +85,8 @@ class ConfigContainer:
             if fork in self.networks:
                 network["cmd_settings"]["fork"] = self.networks[fork]["host"]
                 network["chainid"] = self.networks[fork]["chainid"]
+                if "chain_id" not in network["cmd_settings"]:
+                    network["cmd_settings"]["chain_id"] = int(self.networks[fork]["chainid"])
                 if "explorer" in self.networks[fork]:
                     network["explorer"] = self.networks[fork]["explorer"]
 

--- a/brownie/network/rpc.py
+++ b/brownie/network/rpc.py
@@ -39,6 +39,8 @@ CLI_FLAGS = {
     "default_balance": "--defaultBalanceEther",
     "time": "--time",
     "unlock": "--unlock",
+    "network_id": "--networkId",
+    "chain_id": "--chainId",
 }
 
 EVM_VERSIONS = ["byzantium", "constantinople", "petersburg", "istanbul"]
@@ -275,6 +277,8 @@ def _validate_cmd_settings(cmd_settings: dict) -> dict:
         "mnemonic": str,
         "account_keys_path": str,
         "fork": str,
+        "network_id": int,
+        "chain_id": int,
     }
     for cmd, value in cmd_settings.items():
         if (

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -85,7 +85,7 @@ Networks
 
         Additional commandline parameters, which are passed into Ganache as commandline arguments. These settings will update the network specific settings defined in :ref:`network management<adding-network>` whenever the project with this configuration file is active.
 
-        The following example shows all commandline settings with their default value. ``fork`` and ``unlock`` have no default values and ``time`` will default to the current time. See :ref:`adding a development network<adding-network>` for more details on the arguments.
+        The following example shows all commandline settings with their default value. ``fork`` and ``unlock`` have no default values. ``network_id`` and ``time`` will default to the current timestamp or time respectively. See :ref:`adding a development network<adding-network>` for more details on the arguments.
 
     .. code-block:: yaml
 
@@ -100,6 +100,8 @@ Networks
                     port: 8545
                     gas_limit: 6721975
                     accounts: 10
+                    chain_id: 1337
+                    network_id: 1588949648
                     evm_version: istanbul
                     fork: null
                     mnemonic: brownie

--- a/docs/network-management.rst
+++ b/docs/network-management.rst
@@ -97,7 +97,7 @@ The following optional fields may be given for development networks, which are p
     * ``gas_limit``: The block gas limit. Defaults to 6721925.
     * ``accounts``: The number of funded, unlocked accounts. Default 10.
     * ``mnemonic``: A mnemonic to use when generating local accounts.
-    * ``chain_id``: The chain id as integer used for ``eth_chainId`` and the ``CHAINID`` opcode. If no value is given, defaults to 1337 and 1 respectively, for legacy reasons.
+    * ``chain_id``: The chain id as integer used for ``eth_chainId`` and the ``CHAINID`` opcode. If no value is given, defaults to the chain id of the forked network or to 1337 and 1 respectively if no fork is specified.
     * ``network_id``: The network id as integer used by ganache to identify itself. Defaults to the current timestamp or the network id of the forked chain.
     * ``evm_version``: The EVM ruleset to use. Default is the most recent available.
     * ``fork``: If given, the local client will fork from another currently running Ethereum client. The value may be an HTTP location and port of the other client, e.g. ``http://localhost:8545``, or the ID of a production network, e.g. ``mainnet``. See :ref:`Using a Forked Development Network <network-management-fork>`.

--- a/docs/network-management.rst
+++ b/docs/network-management.rst
@@ -97,6 +97,8 @@ The following optional fields may be given for development networks, which are p
     * ``gas_limit``: The block gas limit. Defaults to 6721925.
     * ``accounts``: The number of funded, unlocked accounts. Default 10.
     * ``mnemonic``: A mnemonic to use when generating local accounts.
+    * ``chain_id``: The chain id as integer used for ``eth_chainId`` and the ``CHAINID`` opcode. If no value is given, defaults to 1337 and 1 respectively, for legacy reasons.
+    * ``network_id``: The network id as integer used by ganache to identify itself. Defaults to the current timestamp or the network id of the forked chain.
     * ``evm_version``: The EVM ruleset to use. Default is the most recent available.
     * ``fork``: If given, the local client will fork from another currently running Ethereum client. The value may be an HTTP location and port of the other client, e.g. ``http://localhost:8545``, or the ID of a production network, e.g. ``mainnet``. See :ref:`Using a Forked Development Network <network-management-fork>`.
     * ``block_time``: The time waited between mining blocks. Defaults to instant mining.

--- a/tests/project/test_brownie_config.py
+++ b/tests/project/test_brownie_config.py
@@ -4,6 +4,7 @@ import pytest
 import yaml
 
 from brownie._config import _get_data_folder, _load_config
+from brownie.network import web3
 from brownie.network.rpc import _validate_cmd_settings
 
 
@@ -21,6 +22,8 @@ def settings_proj(testproject):
             reverting_tx_gas_limit: 8765432
             default_contract_owner: false
             cmd_settings:
+                network_id: 777
+                chain_id: 666
                 gas_limit: 7654321
                 block_time: 5
                 default_balance: 15 milliether
@@ -85,11 +88,19 @@ def test_rpc_project_cmd_settings(devnetwork, testproject, config, settings_proj
     assert "0x16Fb96a5fa0427Af0C8F7cF1eB4870231c8154B6" == accounts[-2].address
     assert "0x81431b69B1e0E334d4161A13C2955e0f3599381e" == accounts[-1].address
 
+    # Test if gas limit and price are loaded from the config
     tx = accounts[0].transfer(accounts[1], 0)
     assert tx.gas_limit == settings_proj["gas_limit"]
     assert tx.gas_price == settings_proj["gas_price"]
 
+    # Test if chain ID and network ID can be properly queried
+    assert web3.isConnected()
+    assert web3.eth.chainId == 666
+    assert web3.net.version == "777"
+
+    # Test if evm version is returned properly
     assert devnetwork.rpc.evm_version() == cmd_settings_proj["evm_version"]
+
     devnetwork.rpc.kill()
 
 
@@ -98,6 +109,8 @@ def test_validate_cmd_settings():
         port: 1
         gas_limit: 2
         block_time: 3
+        chain_id: 555
+        network_id: 444
         time: 2019-04-05T14:30:11
         accounts: 4
         evm_version: istanbul


### PR DESCRIPTION
### What I did

Exposed `--chainId` -> `chain_id`  and `--networkId` -> `network_id` parameters for ganache-cli to the brownie network config.
Forked networks will default to the `chain_id` of the origin network (can be overwritten).

**IMPORTANT:** `--chainId` requires ganache-cli version 6.11.0 or higher. To use this feature, ganache-cli has to be updated.

Related issue: #901

### How I did it
Added the parameters to the list of accepted network settings.
Fetch `chain_id` from origin network and set as default when a fork (and no custom `chain_id`) is specified.
Accepted types for both values are integers (ganache will ignore anything else). Other types will issue a warning.

### How to verify it
Run updated tests.

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [x] I have updated the documentation
- [x] I have added an entry to the changelog
