### PR TITLE
Fix: console output when auto-replacing transactions

### DIFF
--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -661,6 +661,7 @@ class _PrivateKeyAccount(PublicKeyAccount):
             gas_strategy.run(receipt, gas_iter)  # type: ignore
 
         if required_confs == 0:
+            # set 0-conf tx's as silent to hide the confirmation output
             receipt._silent = True
             return receipt
 

--- a/brownie/network/state.py
+++ b/brownie/network/state.py
@@ -74,7 +74,8 @@ class TxHistory(metaclass=_Singleton):
         self._list = [i for i in self._list if i.block_number <= height]
 
     def _add_tx(self, tx: TransactionReceipt) -> None:
-        self._list.append(tx)
+        if tx not in self._list:
+            self._list.append(tx)
 
     def clear(self) -> None:
         self._list.clear()

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -315,7 +315,7 @@ class TransactionReceipt:
             raise ValueError("Transaction has already confirmed")
 
         if increment is not None:
-            gas_price = Wei(self.gas_price * 1.1)
+            gas_price = Wei(self.gas_price * increment)
 
         if silent is None:
             silent = self._silent


### PR DESCRIPTION
### What I did
Fix an issue with console output when using a gas strategy.

Closes #884 

### How I did it
Track the `silent` status of the original transaction and ensure each subsequent transaction has the same setting.  See the code comments for a more detailed explanation.

### How to verify it
Replace some transactions!
