### PR TITLE
fix: make bake cmd use default brownie-mix branch

### DIFF
--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -974,7 +974,7 @@ def _get_mix_default_branch(mix_name: str) -> str:
     str
         The default branch name on github.
     """
-    REPO_GH_API = "https://api.github.com/repos/brownie-mix/{}-mix".format(mix_name)
+    REPO_GH_API = f"https://api.github.com/repos/brownie-mix/{mix_name}-mix"
     r = requests.get(REPO_GH_API, headers=REQUEST_HEADERS)
     if r.status_code != 200:
         status, repo, message = r.status_code, f"brownie-mix/{mix_name}", r.json()["message"]

--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -53,7 +53,7 @@ from brownie.project.sources import Sources, get_pragma_spec
 from brownie.utils import notify
 
 BUILD_FOLDERS = ["contracts", "deployments", "interfaces"]
-MIXES_URL = "https://github.com/brownie-mix/{}-mix/archive/master.zip"
+MIXES_URL = "https://github.com/brownie-mix/{}-mix/archive/{}.zip"
 
 GITIGNORE = """__pycache__
 .history
@@ -588,7 +588,8 @@ def from_brownie_mix(
     Returns the path to the project as a string.
     """
     project_name = str(project_name).lower().replace("-mix", "")
-    url = MIXES_URL.format(project_name)
+    default_branch = _get_mix_default_branch(project_name)
+    url = MIXES_URL.format(project_name, default_branch)
     if project_path is None:
         project_path = Path(".").joinpath(project_name)
     project_path = Path(project_path).resolve()
@@ -958,3 +959,21 @@ def _stream_download(download_url: str, target_path: str) -> None:
 
     with zipfile.ZipFile(BytesIO(content)) as zf:
         zf.extractall(target_path)
+
+
+def _get_mix_default_branch(mix_name: str) -> str:
+    """Get the default branch for a brownie-mix repository.
+
+    Arguments
+    ---------
+    mix_name : str
+        Name of a brownie-mix repository without -mix appended.
+
+    Returns
+    -------
+    str
+        The default branch name on github.
+    """
+    REPO_GH_API = "https://api.github.com/repos/brownie-mix/{}-mix".format(mix_name)
+    r = requests.get(REPO_GH_API).json()
+    return r["default_branch"]

--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -989,7 +989,7 @@ def _get_mix_default_branch(mix_name: str) -> str:
             msg = "".join(msg_lines)
         raise ConnectionError(msg)
     elif "default_branch" not in r.json():
-        msg = "API results did not include {}'s default branch".format(mix_name)
+        msg = f"API results did not include {mix_name}'s default branch"
         raise KeyError(msg)
 
     return r.json()["default_branch"]

--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -598,9 +598,7 @@ def from_brownie_mix(
 
     print(f"Downloading from {url}...")
     _stream_download(url, str(project_path.parent))
-    project_path.parent.joinpath(project_name + "-mix-{}".format(default_branch)).rename(
-        project_path
-    )
+    project_path.parent.joinpath(f"{project_name}-mix-{default_branch}").rename(project_path)
     _create_folders(project_path)
     _create_gitfiles(project_path)
     _add_to_sys_path(project_path)
@@ -979,17 +977,18 @@ def _get_mix_default_branch(mix_name: str) -> str:
     REPO_GH_API = "https://api.github.com/repos/brownie-mix/{}-mix".format(mix_name)
     r = requests.get(REPO_GH_API, headers=REQUEST_HEADERS)
     if r.status_code != 200:
-        msg = "Status {} when retrieving repo brownie-mix/{} information from GHAPI: '{}'".format(
-            r.status_code, mix_name, r.json()["message"]
-        )
+        status, repo, message = r.status_code, f"brownie-mix/{mix_name}", r.json()["message"]
+        msg = f"Status {status} when retrieving repo {repo} information from GHAPI: '{message}'"
         if r.status_code == 403:
-            msg += (
-                "\n\nIf this issue persists, generate a Github API token and store"
-                " it as the environment variable `GITHUB_TOKEN`:\n"
-                "https://github.blog/2013-05-16-personal-api-tokens/"
+            msg_lines = (
+                msg,
+                "\n\nIf this issue persists, generate a Github API token and store",
+                " it as the environment variable `GITHUB_TOKEN`:\n",
+                "https://github.blog/2013-05-16-personal-api-tokens/",
             )
+            msg = "".join(msg_lines)
         raise ConnectionError(msg)
-    elif r.json().get("default_branch") is None:
+    elif "default_branch" not in r.json():
         msg = "API results did not include {}'s default branch".format(mix_name)
         raise KeyError(msg)
 

--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -598,7 +598,9 @@ def from_brownie_mix(
 
     print(f"Downloading from {url}...")
     _stream_download(url, str(project_path.parent))
-    project_path.parent.joinpath(project_name + "-mix-master").rename(project_path)
+    project_path.parent.joinpath(project_name + "-mix-{}".format(default_branch)).rename(
+        project_path
+    )
     _create_folders(project_path)
     _create_gitfiles(project_path)
     _add_to_sys_path(project_path)


### PR DESCRIPTION
Previously, `brownie bake` would assume the master branch was in each
brownie-mix repository. Now it checks the github api to verify the
default branch first.

Resolves eth-brownie/brownie#915

### What I did

- Modified `MIXES_URL` to now require 2 arguments when formatting the string, the project_name and default_branch
- Created a function `_get_mix_default_branch(mix_name: str) -> str`, which given the brownie-mix name, returns the default branch for the repository
- Modified `from_brownie_mix` function to call `_get_mix_default_branch`, and include the returned value when formatting `MIXES_URL`

Related issue: #915 

### How I did it

I checked [stackoverflow](https://stackoverflow.com/questions/16500461/how-do-i-find-the-default-branch-for-a-repository-using-the-github-v3-api) for how to find the default branch of a repository. Using the [github api docs](https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#get-a-repository) and `curl`, I verified that endpoint worked and that `default_branch` was a key in the json returned. I then created the function `_get_mix_default_branch` to encapsulate the github api request, and then implemented it in the `from_brownie_mix` function.  

### How to verify it

Currently, there are no brownie-mix repositories with a default branch not named `master`. However, the implementation does not break `tests/project/test_brownie_mix.py`.

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
