### PR TITLE
Event return types and comparisons

### DIFF
--- a/brownie/network/event.py
+++ b/brownie/network/event.py
@@ -10,6 +10,7 @@ import eth_event
 from eth_event import EventError
 
 from brownie._config import _get_data_folder
+from brownie.convert.datatypes import ReturnValue
 from brownie.convert.normalize import format_event
 from brownie.exceptions import EventLookupError
 
@@ -166,17 +167,17 @@ class _EventItem:
             return other == self._ordered[0]
         return other == self._ordered
 
-    def items(self) -> List:
+    def items(self) -> ReturnValue:
         """_EventItem.items() -> a list object providing a view on _EventItem[0]'s items"""
-        return [(i, self[i]) for i in self.keys()]
+        return ReturnValue([(i, self[i]) for i in self.keys()])
 
-    def keys(self) -> List:
+    def keys(self) -> ReturnValue:
         """_EventItem.keys() -> a list object providing a view on _EventItem[0]'s keys"""
-        return [i.replace(" (indexed)", "") for i in self._ordered[0].keys()]
+        return ReturnValue([i.replace(" (indexed)", "") for i in self._ordered[0].keys()])
 
-    def values(self) -> List:
+    def values(self) -> ReturnValue:
         """_EventItem.values() -> a list object providing a view on _EventItem[0]'s values"""
-        return list(self._ordered[0].values())
+        return ReturnValue(self._ordered[0].values())
 
 
 def __get_path() -> Path:

--- a/brownie/network/event.py
+++ b/brownie/network/event.py
@@ -164,6 +164,9 @@ class _EventItem:
 
     def __eq__(self, other: object) -> bool:
         if len(self._ordered) == 1:
+            if isinstance(other, (tuple, list, ReturnValue)):
+                # sequences compare directly against the event values
+                return self._ordered[0].values() == other
             return other == self._ordered[0]
         return other == self._ordered
 


### PR DESCRIPTION
### What I did
* use `ReturnValue` instead of `List` for some return types related to events.
* Allow direct comparison of a sequence with an `_EventItem`. The comparison assumes a check against the values within the event, in the same order as they're given in the ABI.

### How to verify it
Run tests.

