### PR TITLE
[wip] Fork mode as a context manager 

### DIFF
--- a/brownie/network/main.py
+++ b/brownie/network/main.py
@@ -47,7 +47,7 @@ def connect(network: str = None, launch_rpc: bool = True) -> None:
                     )
                 rpc.attach(host)
             else:
-                rpc.launch(active["cmd"], **active["cmd_settings"])
+                rpc.launch(active["cmd"], force=False, **active["cmd_settings"])
         else:
             Accounts()._reset()
         if CONFIG.network_type == "live" or CONFIG.settings["dev_deployment_artifacts"]:

--- a/brownie/network/web3.py
+++ b/brownie/network/web3.py
@@ -89,6 +89,8 @@ class Web3(_Web3):
     def disconnect(self) -> None:
         """Disconnects from a provider"""
         if self.provider:
+            # TODO: if the provider is a websocket provider, we need to do more cleanup
+
             self.provider = None
             self._genesis_hash = None
             self._chain_uri = None

--- a/brownie/network/web3.py
+++ b/brownie/network/web3.py
@@ -34,6 +34,7 @@ class Web3(_Web3):
         self._chain_uri: Optional[str] = None
         self._custom_middleware: Set = set()
         self._supports_traces = None
+        self._uri = None
 
     def connect(self, uri: str, timeout: int = 30) -> None:
         """Connects to a provider"""
@@ -42,19 +43,20 @@ class Web3(_Web3):
         self._custom_middleware.clear()
         self.provider = None
 
-        uri = _expand_environment_vars(uri)
+        self._uri = _expand_environment_vars(uri)
+
         try:
-            if Path(uri).exists():
-                self.provider = IPCProvider(uri, timeout=timeout)
+            if Path(self._uri).exists():
+                self.provider = IPCProvider(self._uri, timeout=timeout)
         except OSError:
             pass
 
         if self.provider is None:
-            if uri.startswith("ws"):
-                self.provider = WebsocketProvider(uri, {"close_timeout": timeout})
-            elif uri.startswith("http"):
+            if self._uri.startswith("ws"):
+                self.provider = WebsocketProvider(self._uri, {"close_timeout": timeout})
+            elif self._uri.startswith("http"):
 
-                self.provider = HTTPProvider(uri, {"timeout": timeout})
+                self.provider = HTTPProvider(self._uri, {"timeout": timeout})
             else:
                 raise ValueError(
                     "Unknown URI - must be a path to an IPC socket, a websocket "

--- a/brownie/utils/__init__.py
+++ b/brownie/utils/__init__.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 
 from .color import Color, notify  # noqa 401
+from .fork import fork
 
 color = Color()

--- a/brownie/utils/fork.py
+++ b/brownie/utils/fork.py
@@ -57,6 +57,7 @@ def fork(block=None, **cmd_settings):
 
     # TODO: get the currently active network
     old_network = network.show_active()
+    old_history = network.history.copy()
 
     network_settings = CONFIG.set_active_network(old_network)
 
@@ -67,8 +68,7 @@ def fork(block=None, **cmd_settings):
 
     fork_port = find_open_port()
 
-    # add customizations to cmd_settings
-    # TODO: do something so that nesting these remembers
+    # add our cmd_settings on top of the active network's settings
     if 'cmd_settings' in network_settings:
         network_settings['cmd_settings'].update(cmd_settings)
     else:
@@ -102,7 +102,8 @@ def fork(block=None, **cmd_settings):
         # CONFIG.set_active_network(old_network)
         network.web3.connect(old_uri, timeout)
 
-        # TODO: account nonces, txhistory, etc.
+        network.history._list = old_history
         network.accounts._reset()
+        # TODO: reset more
 
         print("Returned to network:", network.web3._uri, "@", network.chain.height)

--- a/brownie/utils/fork.py
+++ b/brownie/utils/fork.py
@@ -1,0 +1,105 @@
+from brownie import network
+from brownie._config import CONFIG
+from copy import deepcopy
+import socket
+import time
+
+from contextlib import contextmanager
+
+
+def find_open_port():
+    """
+    Use socket's built in ability to find an open port.
+
+    https://gist.github.com/jdavis/4040223
+
+    TODO: this isn't perfect, but it works for now
+    """
+    sock = socket.socket()
+    sock.bind(('', 0))
+
+    _, port = sock.getsockname()
+
+    return port
+
+
+def wait_for_port(port, host='localhost', timeout=5.0):
+    """Wait until a port starts accepting TCP connections.
+
+    https://gist.github.com/butla/2d9a4c0f35ea47b7452156c96a4e7b12
+
+    Args:
+        port (int): Port number.
+        host (str): Host address on which the port should exist.
+        timeout (float): In seconds. How long to wait before raising errors.
+    Raises:
+        TimeoutError: The port isn't accepting connection after time specified in `timeout`.
+    """
+    start_time = time.perf_counter()
+    while True:
+        try:
+            with socket.create_connection((host, port), timeout=timeout):
+                break
+        except OSError as ex:
+            time.sleep(0.01)
+            if time.perf_counter() - start_time >= timeout:
+                raise TimeoutError('Waited too long for the port {} on host {} to start accepting '
+                                   'connections.'.format(port, host)) from ex
+
+
+@contextmanager
+def fork(block=None, **cmd_settings):
+    print("Forking network:", network.web3._uri, "@", block or "latest")
+
+    # TODO: setup snapshots
+    # brownie.chain.snapshot()
+    old_uri = network.web3._uri
+
+    # TODO: get the currently active network
+    old_network = network.show_active()
+
+    network_settings = CONFIG.set_active_network(old_network)
+
+    if block is None:
+        fork = old_uri
+    else:
+        fork = f"{old_uri}@{block}"
+
+    fork_port = find_open_port()
+
+    # add customizations to cmd_settings
+    # TODO: do something so that nesting these remembers
+    if 'cmd_settings' in network_settings:
+        network_settings['cmd_settings'].update(cmd_settings)
+    else:
+        network_settings['cmd_settings'] = cmd_settings
+
+    network_settings['cmd_settings']['port'] = fork_port
+    network_settings['cmd_settings']['fork'] = fork
+
+    timeout = network_settings.get("timeout", 30)
+
+    # TODO: allow overriding this?
+    cmd = "ganache-cli"
+
+    # launch a new rpc that forks the currently active rpc
+    forked_rpc = network.rpc.launch(cmd, extra=True, **network_settings['cmd_settings'])
+
+    # wait for ganache to start
+    wait_for_port(fork_port)
+
+    try:
+        network.web3.connect(f"http://localhost:{fork_port}", timeout)
+
+        print("Now using network:", network.web3._uri, "@", network.chain.height)
+
+        yield network_settings
+    finally:
+        # TODO: put the global state back
+        # CONFIG.set_active_network(old_network)
+        network.web3.connect(old_uri, timeout)
+
+        # TODO: account nonces, txhistory, etc.
+        network.accounts._reset()
+
+        print("Returned to network:", network.web3._uri, "@", network.chain.height)

--- a/brownie/utils/fork.py
+++ b/brownie/utils/fork.py
@@ -49,6 +49,7 @@ def wait_for_port(port, host='localhost', timeout=5.0):
 
 @contextmanager
 def fork(block=None, **cmd_settings):
+    """TODO: Partly incompatible with websockets."""
     print("Forking network:", network.web3._uri, "@", block or "latest")
 
     # TODO: setup snapshots

--- a/brownie/utils/fork.py
+++ b/brownie/utils/fork.py
@@ -85,16 +85,19 @@ def fork(block=None, **cmd_settings):
     # launch a new rpc that forks the currently active rpc
     forked_rpc = network.rpc.launch(cmd, extra=True, **network_settings['cmd_settings'])
 
-    # wait for ganache to start
-    wait_for_port(fork_port)
-
     try:
+        # wait for ganache to start
+        wait_for_port(fork_port)
+
         network.web3.connect(f"http://localhost:{fork_port}", timeout)
 
         print("Now using network:", network.web3._uri, "@", network.chain.height)
 
         yield network_settings
     finally:
+        # kill this rpc and put the previous back
+        network.rpc.kill_more(forked_rpc, False)
+
         # TODO: put the global state back
         # CONFIG.set_active_network(old_network)
         network.web3.connect(old_uri, timeout)


### PR DESCRIPTION
### What I did

Related issue: #746

### How I did it

Added a `fork` context manager and modified the rpc to support multiple children.

### How to verify it

Something like this:
```
    with fork(unlock=str(account)) as fork_settings:
        print("we forked!")
        print("balance:", account.balance())

        with fork(**fork_settings['cmd_settings']):
            print("we forked the fork!")
            print("balance:", account.balance())
```

Or this:
```
    with fork(unlock=str(account)):
        print("we forked!")
        print("balance:", account.balance())

    with fork(unlock=str(account2)):
        print("we forked again!")
        print("balance:", account.balance())
```

this style is currently broken:
```
    with fork(unlock=str(account)) as fork_settings:
        print("we forked!")
        print("balance:", account.balance())

    print("we are back on mainnet")
    print("balance:", account.balance())
```


### Checklist

- [ ] make sure any global state gets cleaned up
- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
