### PR TITLE
fix: add cwd to path when console is opened without an active project

### DIFF
--- a/brownie/_cli/console.py
+++ b/brownie/_cli/console.py
@@ -49,6 +49,7 @@ def main():
         print(f"{active_project._name} is the active project.")
     else:
         active_project = None
+        sys.path.insert(0, "")
         print("No project was loaded.")
 
     network.connect(CONFIG.argv["network"])


### PR DESCRIPTION
### What I did
When loading the console without an active project, ensure the cwd is within `sys.path`.
