### PR TITLE
Lazy event decoding

### DIFF
--- a/brownie/network/event.py
+++ b/brownie/network/event.py
@@ -235,7 +235,7 @@ def _decode_logs(logs: List) -> EventDict:
             try:
                 events.extend(eth_event.decode_logs([item], topics_map, allow_undecoded=True))
             except EventError as exc:
-                warnings.warn(str(exc))
+                warnings.warn(f"{address}: {exc}")
 
         if log_slice[-1] == logs[-1]:
             break

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -202,12 +202,15 @@ class TransactionReceipt:
 
     @trace_property
     def events(self) -> Optional[EventDict]:
-        if not self.status and self._events is None:
-            self._get_trace()
-            # get events from the trace - handled lazily so that other
-            # trace operations are not blocked in case of a decoding error
-            initial_address = str(self.receiver or self.contract_address)
-            self._events = _decode_trace(self._raw_trace, initial_address)  # type: ignore
+        if self._events is None:
+            if self.status:
+                self._events = _decode_logs(self.logs)  # type: ignore
+            else:
+                self._get_trace()
+                # get events from the trace - handled lazily so that other
+                # trace operations are not blocked in case of a decoding error
+                initial_address = str(self.receiver or self.contract_address)
+                self._events = _decode_trace(self._raw_trace, initial_address)  # type: ignore
         return self._events
 
     @trace_property


### PR DESCRIPTION
### What I did
Lazily decode events even for confirmed transactions.  This avoids the warning for an incorrectly structured event, except when the user explicitly asks to look at the events.

### How I did it
The `@property` decorator is my friend.

### How to verify it
Run the tests.
