### PR TITLE
fix: check that instruction is PUSH before popping pushed bytes

### DIFF
--- a/brownie/project/compiler/solidity.py
+++ b/brownie/project/compiler/solidity.py
@@ -367,7 +367,7 @@ def _generate_coverage_data(
             pc_list[-1]["jump"] = source[3]
 
         pc += 1
-        if opcodes[0][:2] == "0x":
+        if pc_list[-1]["op"].startswith("PUSH") and opcodes[0][:2] == "0x":
             pc_list[-1]["value"] = opcodes.popleft()
             pc += int(pc_list[-1]["op"][4:])
 


### PR DESCRIPTION
### What I did
Fixes #873 

### How I did it

### How to verify it

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
