### PR TITLE
fix: issue 945

### DIFF
--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -1099,9 +1099,9 @@ class Contract(_DeployedContractBase):
             )
             # always check for an EIP1822 proxy - https://eips.ethereum.org/EIPS/eip-1822
             implementation_eip1822 = web3.eth.getStorageAt(address, web3.keccak(text="PROXIABLE"))
-            if int(implementation_eip1967.hex(), 16):
+            if len(implementation_eip1967) > 0 and int(implementation_eip1967.hex(), 16):
                 as_proxy_for = _resolve_address(implementation_eip1967[12:])
-            elif int(implementation_eip1822.hex(), 16):
+            elif len(implementation_eip1822) > 0 and int(implementation_eip1822.hex(), 16):
                 as_proxy_for = _resolve_address(implementation_eip1822[12:])
             elif data["result"][0].get("Implementation"):
                 # for other proxy patterns, we only check if etherscan indicates


### PR DESCRIPTION
### What I did
magic

Related issue: Fixes #945

### How I did it
Printed `implementation_eip1967` and `implementation_eip1822` and saw:
```
implementation_eip1967: b''
implementation_eip1822: b''
```

No idea why they are empty now 🤷 


### How to verify it
Run `weth = Contract("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")`
Make sure you are running with a clean `~/.brownie` folder.


