### PR TITLE
Fix non-push instructions

### DIFF
--- a/brownie/project/compiler/solidity.py
+++ b/brownie/project/compiler/solidity.py
@@ -463,7 +463,7 @@ def _generate_coverage_data(
         # necessary because sometimes solidity returns an incomplete source map
         pc_list.append({"op": opcodes.popleft(), "pc": pc})
         pc += 1
-        if opcodes and opcodes[0][:2] == "0x":
+        if pc_list[-1]["op"].startswith("PUSH") and opcodes[0][:2] == "0x":
             pc_list[-1]["value"] = opcodes.popleft()
             pc += int(pc_list[-1]["op"][4:])
 


### PR DESCRIPTION
### What I did

There is an issue when processing instructions which are not `PUSH` that will lead to bad `int` conversion.

Related issue: #873 also related to PR #935 

The issue is almost identical to above but occurs in another location.

### How I did it

### How to verify it

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
