### PR TITLE
fix: bump eth-event minimum version to 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/eth-brownie/brownie)
+### Fixed
+- Bump dependency version for [eth-event](https://github.com/iamdefinitelyahuman/eth-event) to [1.2.1](https://github.com/iamdefinitelyahuman/eth-event/releases/tag/v1.2.1) to mitigate the topic generation bug for events with dynamic/fixed size tuple array inputs ([#957](https://github.com/eth-brownie/brownie/pull/957))
 
 ## [1.13.1](https://github.com/eth-brownie/brownie/tree/v1.13.1) - 2021-01-31
 ### Fixed

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ black==19.10b0
 colorama>=0.4.1;platform_system=='Windows'
 eth-abi==2.1.1
 eth-account==0.5.2
-eth-event>=1.2.0,<2.0.0
+eth-event>=1.2.1,<2.0.0
 eth-hash[pycryptodome]==0.2.0
 eth-utils==1.9.5
 hexbytes==0.2.1


### PR DESCRIPTION
### What I did
Bumped eth-event version in requirements.txt to 1.2.1 to mitigate the topic generation bug for events with dynamic/fixed size tuple inputs.

Resolves #955
Related iamdefinitelyahuman/eth-event#15

### How I did it
Just changed the 1.2.0 -> 1.2.1 :)

### How to verify it
Since this changes a dependency I ran the `pytest` suite just to verify stuff doesn't break.

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have added an entry to the changelog
