### PR TITLE
Fix some broken links

### DIFF
--- a/docs/api-network.rst
+++ b/docs/api-network.rst
@@ -2428,7 +2428,7 @@ TransactionReceipt Attributes
 
 .. py:attribute:: TransactionReceipt.trace
 
-    An expanded `transaction trace <https://github.com/ethereum/go-ethereum/wiki/Tracing:-Introduction#user-content-basic-traces>`_ structLog, returned from the `debug_traceTransaction <https://github.com/ethereum/go-ethereum/wiki/Management-APIs#user-content-debug_tracetransaction>`_ RPC endpoint. If you are using Infura this attribute is not available.
+    An expanded `transaction trace <https://geth.ethereum.org/docs/dapp/tracing#basic-traces>`_ structLog, returned from the `debug_traceTransaction <https://geth.ethereum.org/docs/rpc/ns-debug#debug_tracetransaction>`_ RPC endpoint. If you are using Infura this attribute is not available.
 
     Along with the standard data, the structLog also contains the following additional information:
 
@@ -2752,7 +2752,7 @@ Web3 Attributes
 
 .. py:classmethod:: Web3.supports_traces
 
-    Boolean indicating if the currently connected node client supports the `debug_traceTransaction <https://github.com/ethereum/go-ethereum/wiki/Management-APIs#user-content-debug_tracetransaction>`_ RPC endpoint.
+    Boolean indicating if the currently connected node client supports the `debug_traceTransaction <https://geth.ethereum.org/docs/rpc/ns-debug#debug_tracetransaction>`_ RPC endpoint.
 
     .. code-block:: python
 

--- a/docs/compile.rst
+++ b/docs/compile.rst
@@ -32,7 +32,7 @@ The ``interfaces/`` folder is of particular use in the following situations:
 1. When using Vyper, where interfaces are not necessarily compilable source code and so cannot be included in the ``contracts/`` folder.
 2. When using Solidity and Vyper in the same project, or multiple versions of Solidity, where compatibility issues prevent contracts from directly referencing one another.
 
-Interfaces may be written in `Solidity <https://solidity.readthedocs.io/en/latest/contracts.html#interfaces>`_ (``.sol``) or `Vyper <https://vyper.readthedocs.io/en/latest/structure-of-a-contract.html#contract-interfaces>`_ (``.vy``). Vyper contracts are also able to directly import `JSON encoded ABI <https://solidity.readthedocs.io/en/latest/abi-spec.html#json>`_ (``.json``) files.
+Interfaces may be written in `Solidity <https://solidity.readthedocs.io/en/latest/contracts.html#interfaces>`_ (``.sol``) or `Vyper <https://vyper.readthedocs.io/en/latest/structure-of-a-contract.html#interfaces>`_ (``.vy``). Vyper contracts are also able to directly import `JSON encoded ABI <https://solidity.readthedocs.io/en/latest/abi-spec.html#json>`_ (``.json``) files.
 
 .. _compile_settings:
 

--- a/docs/core-transactions.rst
+++ b/docs/core-transactions.rst
@@ -163,7 +163,7 @@ Debugging Failed Transactions
 
 .. note::
 
-    Debugging functionality relies on the `debug_traceTransaction <https://github.com/ethereum/go-ethereum/wiki/Management-APIs#user-content-debug_tracetransaction>`_ RPC method. If you are using Infura this endpoint is unavailable. Attempts to access this functionality will raise an ``RPCRequestError``.
+    Debugging functionality relies on the `debug_traceTransaction <https://geth.ethereum.org/docs/rpc/ns-debug#debug_tracetransaction>`_ RPC method. If you are using Infura this endpoint is unavailable. Attempts to access this functionality will raise an ``RPCRequestError``.
 
 When a transaction reverts in the console you are still returned a :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>`, but it will show as reverted. If an error string is given, it will be displayed in brackets and highlighted in red.
 
@@ -208,7 +208,7 @@ Inspecting the Trace
 The Trace Object
 ----------------
 
-The best way to understand exactly happened in a transaction is to generate and examine a `transaction trace <https://github.com/ethereum/go-ethereum/wiki/Tracing:-Introduction#user-content-basic-traces>`_. This is available as a list of dictionaries at :func:`TransactionReceipt.trace <TransactionReceipt.trace>`, with several fields added to make it easier to understand.
+The best way to understand exactly happened in a transaction is to generate and examine a `transaction trace <https://geth.ethereum.org/docs/dapp/tracing#basic-traces>`_. This is available as a list of dictionaries at :func:`TransactionReceipt.trace <TransactionReceipt.trace>`, with several fields added to make it easier to understand.
 
 Each step in the trace includes the following data:
 

--- a/docs/network-management.rst
+++ b/docs/network-management.rst
@@ -185,14 +185,14 @@ Running your Own Node
 
 Clients such as `Geth <https://geth.ethereum.org/>`_ or `Parity <https://www.parity.io/ethereum/>`_ can be used to run your own Ethereum node, that Brownie can then connect to. Having your node gives you complete control over which RPC endpoints are available and ensures you have a private and dedicated connection to the network. Unfortunately, keeping a node operating and synced can be a challenging task.
 
-If you wish to learn more about running a node, ethereum.org provides a `list of resources <https://ethereum.org/developers/#testnets-and-faucets>`_ that you can use to get started.
+If you wish to learn more about running a node, ethereum.org provides a `list of resources <https://ethereum.org/en/developers/docs/nodes-and-clients/>`_ that you can use to get started.
 
 Using a Hosted Node
 *******************
 
 Services such as `Infura <https://infura.io>`_ provide public access to Ethereum nodes. This is a much simpler option than running your own, but it is not without limitations:
 
-    1. Some RPC endpoints may be unavailable. In particular, Infura does not provide access to the `debug_traceTransaction <https://github.com/ethereum/go-ethereum/wiki/Management-APIs#user-content-debug_tracetransaction>`_ method. For this reason, Brownie's :ref:`debugging tools<debug>` will not work when connected via Infura.
+    1. Some RPC endpoints may be unavailable. In particular, Infura does not provide access to the `debug_traceTransaction <https://geth.ethereum.org/docs/rpc/ns-debug#debug_tracetransaction>`_ method. For this reason, Brownie's :ref:`debugging tools<debug>` will not work when connected via Infura.
     2. Hosted nodes do not provide access to accounts - this would be a major security hazard! You will have to manually unlock your own :ref:`local account<local-accounts>` before you can make a transaction.
 
 Using Infura

--- a/docs/structure.rst
+++ b/docs/structure.rst
@@ -32,7 +32,7 @@ Contracts may be written in Solidity (with a ``.sol`` extension) or Vyper (with 
 
 The ``interfaces`` folder holds interface source files that may be referenced by contract sources, but which are not considered to be primary components of the project. Adding or modifying an interface source onlys triggers a recompile if the interface is required by a contract.
 
-Interfaces may be written in `Solidity <https://solidity.readthedocs.io/en/latest/contracts.html#interfaces>`_ (``.sol``) or `Vyper <https://vyper.readthedocs.io/en/latest/structure-of-a-contract.html#contract-interfaces>`_ (``.vy``), or supplied as a `JSON encoded ABI <https://solidity.readthedocs.io/en/latest/abi-spec.html#json>`_ (``.json``).
+Interfaces may be written in `Solidity <https://solidity.readthedocs.io/en/latest/contracts.html#interfaces>`_ (``.sol``) or `Vyper <https://vyper.readthedocs.io/en/latest/structure-of-a-contract.html#interfaces>`_ (``.vy``), or supplied as a `JSON encoded ABI <https://solidity.readthedocs.io/en/latest/abi-spec.html#json>`_ (``.json``).
 
 ``scripts/``
 ============

--- a/docs/tests-pytest-intro.rst
+++ b/docs/tests-pytest-intro.rst
@@ -165,7 +165,7 @@ To apply an isolation fixture to all tests in a module, require it in another fi
     def shared_setup(module_isolation):
         pass
 
-You can also place this fixture in a `conftest.py <https://docs.pytest.org/en/latest/fixture.html#conftest-py-sharing-fixture-functions>`_ file to apply it across many modules.
+You can also place this fixture in a `conftest.py <https://docs.pytest.org/en/latest/fixture.html#conftest-py-sharing-fixtures-across-multiple-files>`_ file to apply it across many modules.
 
 Defining a Shared Initial State
 -------------------------------


### PR DESCRIPTION
### What I did
Updated some links that showed as broken in `tox` output.

Related issue: #

### How I did it
Manually

### How to verify it
Click 'em

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [x] I have updated the documentation
- [ ] I have added an entry to the changelog
