### PR TITLE
wip: Add diagnostic output when reading networks list verbosity fails

### DIFF
--- a/brownie/_cli/networks.py
+++ b/brownie/_cli/networks.py
@@ -73,7 +73,11 @@ def main():
 
 def _list(verbose=False):
     if isinstance(verbose, str):
-        verbose = eval(verbose.capitalize())
+        try:
+            verbose = eval(verbose.capitalize())
+        except:
+            print("Please pass 'True' or 'False'.")
+            raise
 
     with _get_data_folder().joinpath("network-config.yaml").open() as fp:
         networks = yaml.safe_load(fp)

--- a/brownie/_cli/networks.py
+++ b/brownie/_cli/networks.py
@@ -75,9 +75,9 @@ def _list(verbose=False):
     if isinstance(verbose, str):
         try:
             verbose = eval(verbose.capitalize())
-        except:
+        except (NameError, SyntaxError) as e:
             print("Please pass 'True' or 'False'.")
-            raise
+            raise e
 
     with _get_data_folder().joinpath("network-config.yaml").open() as fp:
         networks = yaml.safe_load(fp)


### PR DESCRIPTION
### What I did
Add a diagnostic message when users pass `brownie networks list verbose=true` to nudge them towards passing `brownie networks list True`.

### How I did it

### How to verify it

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
