### PR TITLE
feat: add option to choose console editing mode

### DIFF
--- a/brownie/_cli/console.py
+++ b/brownie/_cli/console.py
@@ -11,11 +11,11 @@ from io import StringIO
 from prompt_toolkit import PromptSession
 from prompt_toolkit.auto_suggest import AutoSuggest, Suggestion
 from prompt_toolkit.completion import Completer, Completion
+from prompt_toolkit.enums import EditingMode
 from prompt_toolkit.history import FileHistory
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.key_binding.defaults import load_key_bindings
 from prompt_toolkit.keys import Keys
-from prompt_toolkit.enums import EditingMode
 from prompt_toolkit.lexers import PygmentsLexer
 from prompt_toolkit.styles.pygments import style_from_pygments_cls
 from pygments.lexers import PythonLexer

--- a/brownie/_cli/console.py
+++ b/brownie/_cli/console.py
@@ -15,6 +15,7 @@ from prompt_toolkit.history import FileHistory
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.key_binding.defaults import load_key_bindings
 from prompt_toolkit.keys import Keys
+from prompt_toolkit.enums import EditingMode
 from prompt_toolkit.lexers import PygmentsLexer
 from prompt_toolkit.styles.pygments import style_from_pygments_cls
 from pygments.lexers import PythonLexer
@@ -128,6 +129,8 @@ class Console(code.InteractiveConsole):
             kwargs["auto_suggest"] = ConsoleAutoSuggest(self, locals_dict)
         if console_settings["completions"]:
             kwargs["completer"] = ConsoleCompleter(self, locals_dict)
+        if console_settings["editing_mode"]:
+            kwargs["editing_mode"] = EditingMode(console_settings["editing_mode"].upper())
 
         self.compile_mode = "single"
         self.prompt_session = PromptSession(

--- a/brownie/data/default-config.yaml
+++ b/brownie/data/default-config.yaml
@@ -45,6 +45,7 @@ console:
     color_style: monokai
     auto_suggest: true
     completions: true
+    editing_mode: emacs
 
 reports:
     exclude_paths: null

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -228,6 +228,12 @@ Console
 
     default value: ``true``
 
+.. py:attribute:: editing_mode
+
+    Choose between ``emacs`` and ``vi`` console editing modes.
+
+    default value: ``emacs``
+
 .. _config-reports:
 
 Reports


### PR DESCRIPTION
- pass down prompt_toolkit EMACS or VI

### What I did
Added a new option to console section to be able to choose editing mode.
Related issue: #

### How I did it
Simple patch of Console class.
### How to verify it
1. Change editing_mode in default configuration file from emacs to vi
2. Start brownie console and notice that vim keybindigs are available

### Checklist

- [X] I have confirmed that my PR passes all linting checks
- [-] I have included test cases
- [-] I have updated the documentation
- [-] I have added an entry to the changelog
