### PR TITLE
Support for dockerized RPC clients + Hostname resolution when attaching to RPC clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/eth-brownie/brownie)
 ### Fixed
 - Bump dependency version for [eth-event](https://github.com/iamdefinitelyahuman/eth-event) to [1.2.1](https://github.com/iamdefinitelyahuman/eth-event/releases/tag/v1.2.1) to mitigate the topic generation bug for events with dynamic/fixed size tuple array inputs ([#957](https://github.com/eth-brownie/brownie/pull/957))
+- Iterate over network connections instead of local process list to support RPC-attaching with host-based and dockerized RPC clients.
+- Resolve hostnames provided in host network field to the actual IP when RPC-attaching.
 
 ## [1.13.1](https://github.com/eth-brownie/brownie/tree/v1.13.1) - 2021-01-31
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -122,6 +122,34 @@ For example, to run the tests in `brownie/tests/test_format_input.py`:
 docker-compose exec sandbox bash -c 'python -m pytest tests/convert/test_format_input.py'
 ```
 
+#### Attaching to dockerized RPC clients
+
+You can also attach to a RPC client already running inside a docker container.
+
+For example for running ganache-cli you could just startup the official ganache-cli docker image:
+
+```bash
+docker run -p 8545:8545 trufflesuite/ganache-cli
+```
+
+Then in another terminal on your host you could connect to it:
+
+```bash
+brownie console
+```
+
+If you have your RPC client bound to a specific hostname e.g. `ganache` you could create a separate brownie network for it:
+
+```bash
+brownie networks add Development dev cmd=ganache-cli host=http://ganache:8545
+```
+
+Then connect to it with:
+
+```bash
+brownie console --network dev
+```
+
 ## Contributing
 
 Help is always appreciated! Feel free to open an issue if you find a problem, or a pull request if you've solved an issue.


### PR DESCRIPTION
### What I did
I've extended the check that is determining if a RPC client is already running to also query the network connections in addition to  the process list. The error I've observed on a `Ubuntu 18.04 LTS` was that only localhost RPC clients could be detected with the existing code. Even dockerized RPC clients bound to the `127.0.0.1` could not be attached.


### How I did it
I've adapted the logic to first try the process list and then the network connections.
I've also implemented hostname resolution which becomes handy when the RPC client is bound to a specific hostname instead of IP which is often the case when used in docker-compose environments.

### How to verify it
```bash
docker run -p 8545:8545 trufflesuite/ganache-cli
```

Then in another terminal

```bash
brownie console
``` 

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [x] I have updated the documentation
- [x] I have added an entry to the changelog
