### PR TITLE
963 Fixes

### DIFF
--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -1100,9 +1100,9 @@ class Contract(_DeployedContractBase):
             # always check for an EIP1822 proxy - https://eips.ethereum.org/EIPS/eip-1822
             implementation_eip1822 = web3.eth.getStorageAt(address, web3.keccak(text="PROXIABLE"))
             if len(implementation_eip1967) > 0 and int(implementation_eip1967.hex(), 16):
-                as_proxy_for = _resolve_address(implementation_eip1967[12:])
+                as_proxy_for = _resolve_address(implementation_eip1967[-20:])
             elif len(implementation_eip1822) > 0 and int(implementation_eip1822.hex(), 16):
-                as_proxy_for = _resolve_address(implementation_eip1822[12:])
+                as_proxy_for = _resolve_address(implementation_eip1822[-20:])
             elif data["result"][0].get("Implementation"):
                 # for other proxy patterns, we only check if etherscan indicates
                 # the contract is a proxy. otherwise we could have a false positive

--- a/brownie/project/compiler/solidity.py
+++ b/brownie/project/compiler/solidity.py
@@ -347,6 +347,12 @@ def _generate_coverage_data(
     active_fn_name: Optional[str] = None
     first_source = source_map[0]
 
+    while source_map and source_map[-1][2] == -1:
+        # trim the end of the source map where there are no contracts associated
+        # this is required because sometimes the source map is too long
+        # likely a side effect of the YUL optimizer ¯\_(ツ)_/¯
+        source_map.pop()
+
     while source_map:
         # format of source_map is [start, stop, contract_id, jump code]
         source = source_map.popleft()


### PR DESCRIPTION
### What I did
Address two issues reported in #963 

* inability to compile certain contracts (e.g. `0xEAA081a9fad4607CdF046fEA7D4BF3DfEf533282`)
* inability to process implementations for certain proxy contracts when in fork mode (e.g. `0x0b8f12b1788BFdE65Aa1ca52E3e9F3Ba401be16D`)

Closes #963

### How I did it
The compilation issue stems from an incorrect-length `sourceMap` output from the Solidity compiler. I'm not sure when/why this happens but sometimes the source map extends beyond the length of the actual bytecode. These final instructions appear to always have no related contact (the 3rd value within the source map). As such, to fix I trim all source map data from the right side, so long as it maps to contract id `-1` (no contract).  It's hacky and probably some edge case will appear, but..  such is the reality when working with Solidity.

The implementation issue is due to a regression in Ganache `v6.12.2` where calls to `eth_getStorageAt` do not return leading zero bytes. To fix it, I do `[-20:]` instead of `[12:]` which has the same effect on a 32 byte hex string while correctly handling the 20 byte hex returned in that specific ganache version.

Thanks to @poolpitako for helping me find all this.

### How to verify it
Hope and pray nothing else breaks.