### PR TITLE
Update install.rst

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -64,6 +64,13 @@ Brownie has the following dependencies:
 * `python3 <https://www.python.org/downloads/release/python-368/>`_ version 3.6 or greater, python3-dev
 * `ganache-cli <https://github.com/trufflesuite/ganache-cli>`_ - tested with version `6.11.0 <https://github.com/trufflesuite/ganache-cli/releases/tag/v6.11.0>`_
 
+.. _install-ganache-cli:
+
+Ganache-cli
+-----------
+
+You can either install ganache-cli globally with `npm install -g ganache-cli`, or locally in your project folder with `npm install ganache-cli`. If you prefer the local installation, you need to point `brownie console` to the local installation with `brownie networks modify development cmd="npx ganache-cli"`. Then it will work just like the global installation would.
+
 .. _install-tk:
 
 Tkinter


### PR DESCRIPTION
Local installation should be the default TBH, and `npx ganache-cli` should be the default command. It will also work if installation was global, so nothing would be lost there.

### What I did

Improve docs on how to avoid globally installing ganache-cli

### How I did it

Editing install doc

### How to verify it

Take a look

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ X ] I have updated the documentation
- [ ] I have added an entry to the changelog
