### PR TITLE
feat: decode ds-note events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/eth-brownie/brownie)
 
+### Added
+- Detect EIP-1167 and Vyper minimal proxies ([#984](https://github.com/eth-brownie/brownie/pull/984))
+- Decode ds-note events ([#985](https://github.com/eth-brownie/brownie/pull/985))
+
 ## [1.13.3](https://github.com/eth-brownie/brownie/tree/v1.13.3) - 2021-03-08
 ### Added
 - Option to choose console editting mode ([#970](https://github.com/eth-brownie/brownie/pull/970))

--- a/brownie/network/event.py
+++ b/brownie/network/event.py
@@ -249,7 +249,7 @@ def _decode_logs(logs: List, contracts: Optional[Dict] = None) -> EventDict:
     return EventDict(events)
 
 
-def _decode_ds_note(log, contract):
+def _decode_ds_note(log, contract):  # type: ignore
     # ds-note encodes function selector as the first topic
     selector, tail = log.topics[0][:4], log.topics[0][4:]
     if selector.hex() not in contract.selectors or sum(tail):

--- a/brownie/network/event.py
+++ b/brownie/network/event.py
@@ -215,7 +215,7 @@ def _add_deployment_topics(address: str, abi: List) -> None:
     _deployment_topics[address] = eth_event.get_topic_map(abi)
 
 
-def _decode_logs(logs: List) -> EventDict:
+def _decode_logs(logs: List, contracts: Optional[Dict] = None) -> EventDict:
     if not logs:
         return EventDict()
 
@@ -232,6 +232,11 @@ def _decode_logs(logs: List) -> EventDict:
 
         topics_map = _deployment_topics.get(address, _topics)
         for item in log_slice:
+            if contracts and contracts[item.address]:
+                note = _decode_ds_note(item, contracts[item.address])
+                if note:
+                    events.append(note)
+                    continue
             try:
                 events.extend(eth_event.decode_logs([item], topics_map, allow_undecoded=True))
             except EventError as exc:
@@ -242,6 +247,30 @@ def _decode_logs(logs: List) -> EventDict:
 
     events = [format_event(i) for i in events]
     return EventDict(events)
+
+
+def _decode_ds_note(log, contract):
+    # ds-note encodes function selector as the first topic
+    selector, tail = log.topics[0][:4], log.topics[0][4:]
+    if selector.hex() not in contract.selectors or sum(tail):
+        return
+    name = contract.selectors[selector.hex()]
+    data = bytes.fromhex(log.data[2:])
+    # data uses ABI encoding of [uint256, bytes] or [bytes] in different versions
+    # instead of trying them all, assume the payload starts from selector
+    try:
+        func, args = contract.decode_input(data[data.index(selector) :])
+    except ValueError:
+        return
+    return {
+        "name": name,
+        "address": log.address,
+        "decoded": True,
+        "data": [
+            {"name": abi["name"], "type": abi["type"], "value": arg, "decoded": True}
+            for arg, abi in zip(args, contract.get_method_object(selector.hex()).abi["inputs"])
+        ],
+    }
 
 
 def _decode_trace(trace: Sequence, initial_address: str) -> EventDict:

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -120,7 +120,7 @@ class TransactionReceipt:
     contract_name = None
     fn_name = None
     gas_used = None
-    logs = None
+    logs: Optional[List] = None
     nonce = None
     sender = None
     txid: str
@@ -205,9 +205,8 @@ class TransactionReceipt:
         if self._events is None:
             if self.status:
                 # relay contract map so we can decode ds-note logs
-                contracts = {
-                    addr: state._find_contract(addr) for addr in {log.address for log in self.logs}
-                }
+                addrs = {log.address for log in self.logs} if self.logs else set()
+                contracts = {addr: state._find_contract(addr) for addr in addrs}
                 self._events = _decode_logs(self.logs, contracts=contracts)  # type: ignore
             else:
                 self._get_trace()

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -204,7 +204,11 @@ class TransactionReceipt:
     def events(self) -> Optional[EventDict]:
         if self._events is None:
             if self.status:
-                self._events = _decode_logs(self.logs)  # type: ignore
+                # relay contract map so we can decode ds-note logs
+                contracts = {
+                    addr: state._find_contract(addr) for addr in {log.address for log in self.logs}
+                }
+                self._events = _decode_logs(self.logs, contracts=contracts)  # type: ignore
             else:
                 self._get_trace()
                 # get events from the trace - handled lazily so that other


### PR DESCRIPTION
### What I did

Added support to decode different variants of `ds-note` events, commonly used across MakerDAO ecosystem.

<img width="664" alt="Screen Shot 2021-03-11 at 20 08 09" src="https://user-images.githubusercontent.com/4562643/110827665-5c9eea80-82a7-11eb-8ee8-be43ba210187.png">

Tested with:
- https://github.com/dapphub/ds-note/blob/master/src/note.sol
- https://github.com/makerdao/dss/blob/master/src/lib.sol
- https://github.com/makerdao/dss/blob/e2cdd97046d456b760c1223b5ffb86c540b9e096/src/vat.sol#L63

Related issue: #

### How I did it

### How to verify it

```python
network.connect('mainnet')
tx = chain.get_transaction('0x7d5799a3622477847731d22ddd8d38031a949159446a727b3e4e7542ad558806')
tx.info()
```

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
