### PR TITLE
Exit console via `continue` during pytest interactive debugging

### DIFF
--- a/brownie/test/managers/runner.py
+++ b/brownie/test/managers/runner.py
@@ -466,13 +466,15 @@ class PytestBrownieRunner(PytestBrownieBase):
 
             try:
                 CONFIG.argv["cli"] = "console"
-                shell = Console(self.project, extra_locals=namespace)
-                shell.interact(
-                    banner="\nInteractive mode enabled. Use quit() to continue running tests.",
-                    exitmsg="",
+                shell = Console(self.project, extra_locals=namespace, exit_on_continue=True)
+                banner = (
+                    "\nInteractive mode enabled. Type `continue` to"
+                    " resume testing or `quit()` to halt execution."
                 )
-            except SystemExit:
-                pass
+                shell.interact(banner=banner, exitmsg="")
+            except SystemExit as exc:
+                if exc.code != "continue":
+                    pytest.exit("Test execution halted due to SystemExit")
             finally:
                 CONFIG.argv["cli"] = "test"
 


### PR DESCRIPTION
### What I did
Modify how the console is exited during pytest interactive debugging:

* `continue` runs the next test
* `exit()` or `quit()` halts execution

This might surprise some people who've gotten used to the current behavior but I'm guessing more will like it than dislike it.

### How I did it
Added a `exit_on_continue` kwarg to the init method of `Console`. When `True`, a check in `Console.runsource` checks the source before compiling, and if `continue` is found, it raises a `SystemExit` with error message `"continue"`. This error message is then caught in the pytest runner and used to decide how to interpret the exit command.

### How to verify it
Try it.
