### PR TITLE
Fix for RPC-attaching to a dockerized ganache in OSX.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/eth-brownie/brownie)
+- Attaching to dockerized RPC-clients works on OSX without sudo ([#995](https://github.com/eth-brownie/brownie/pull/995))
 ## [1.14.1](https://github.com/eth-brownie/brownie/tree/v1.14.1) - 2021-03-19
 ### Fixed
 - Improve logic around `eth_getCode` caching to consider selfdestruct via delegate call ([#1002](https://github.com/eth-brownie/brownie/pull/1002))

--- a/tests/network/rpc/test_attach.py
+++ b/tests/network/rpc/test_attach.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python3
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 
@@ -39,3 +41,32 @@ def test_kill(attachable_rpc, temp_port):
 def test_no_port(rpc):
     with pytest.raises(ValueError):
         rpc.attach("http://127.0.0.1")
+
+
+def test_no_docker(rpc):
+    with patch("brownie.network.rpc._get_pid_from_connections", MagicMock(value=1337)):
+        with patch(
+            "brownie.network.rpc._get_pid_from_net_connections"
+        ) as _get_pid_from_net_connections_call:
+            rpc._find_rpc_process_pid(("laddr-tuple"))
+            _get_pid_from_net_connections_call.assert_not_called()
+
+
+def test_dockerized_rpc_osx(rpc):
+    with patch(
+        "brownie.network.rpc._get_pid_from_connections", MagicMock(side_effect=ProcessLookupError)
+    ):
+        with patch("platform.system", MagicMock(return_value="Darwin")):
+            with patch("brownie.network.rpc._find_proc_by_name") as find_proc_by_name_call:
+                rpc._find_rpc_process_pid(("laddr-tuple"))
+                find_proc_by_name_call.assert_called_with("com.docker.backend")
+
+
+def test_dockerized_rpc(rpc):
+    with patch(
+        "brownie.network.rpc._get_pid_from_connections", MagicMock(side_effect=ProcessLookupError)
+    ):
+        with patch("platform.system", MagicMock(return_value="Not Darwin")):
+            with patch("brownie.network.rpc._check_net_connections") as check_net_connections_call:
+                rpc._find_rpc_process_pid(("laddr-tuple"))
+                check_net_connections_call.assert_called()


### PR DESCRIPTION
### What I did

I've fixed the bug where OSX clients would get a `psutil.AccessDenied` exception when connecting to a dockerized ganache without sudo.

Fixes #992 

### How I did it

I've added an extra check for the `platform.system()` to handle OSX clients a bit differently due to the open issue in psutils: https://github.com/giampaolo/psutil/issues/1219

Instead of querying all available network connections, I'm searching for the `com.docker.backend` process and attach to that. Added some tests for it as well.

### How to verify it

On a mac run:
```bash
docker run -p 8545:8545 trufflesuite/ganache-cli
```

and then in another terminal:
```bash
brownie console
```

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [x] I have updated the documentation
- [x] I have added an entry to the changelog
