### PR TITLE
Middlewares and Caching

### DIFF
--- a/brownie/network/middlewares/__init__.py
+++ b/brownie/network/middlewares/__init__.py
@@ -1,0 +1,114 @@
+import functools
+import importlib
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Callable, Dict, List, Optional
+
+from web3 import Web3
+
+
+class BrownieMiddlewareABC(ABC):
+
+    """
+    Base ABC for all middlewares.
+
+    This class must be inherited in order for a middleware to be discovered
+    and added to the `web3` object upon connecting to a network.
+    """
+
+    def __init__(self, w3: Web3) -> None:
+        """
+        Initialize the middleware.
+
+        Subclasses may optionally include this method. It is called only once,
+        when the middleware is being added.
+        """
+        self.w3 = w3
+
+    @classmethod
+    @abstractmethod
+    def get_layer(cls, w3: Web3, network_type: str) -> Optional[int]:
+        """
+        Return the target layer of this middleware.
+
+        All builtin middlewares are considered to be on layer 0. Middlewares are called in
+        ascending order prior to the request, and descending order after the request.
+        """
+        raise NotImplementedError
+
+    def __call__(self, make_request: Callable, w3: Web3) -> Callable:
+        """
+        Receive the initial middleware request and return `process_request`.
+
+        Subclasses should NOT include this method.
+        """
+        return functools.partial(self.process_request, make_request)
+
+    @abstractmethod
+    def process_request(self, make_request: Callable, method: str, params: List) -> Dict:
+        """
+        Process an RPC request.
+
+        Data is pre-processed, sent onward via `make_request`, processed further and returned.
+        See https://web3py.readthedocs.io/en/stable/internals.html#middlewares for more info.
+
+        Arguments
+        ---------
+        method : str
+            A string representing the JSON-RPC method that is being called.
+        params : List
+            An iterable of the parameters for the JSON-RPC method being called.
+
+        Returns
+        -------
+        Dict
+            A dictionary containing either a 'result' key in the case
+            of success, or an 'error' key in the case of failure.
+        """
+        raise NotImplementedError
+
+    def uninstall(self) -> None:
+        """
+        Uninstall a middleware.
+
+        Subclasses may optionally include this method if any cleanup is required
+        when they are removed. Note that you must not assume network connectivity
+        when this method is called.
+        """
+        pass
+
+
+def get_middlewares(web3: Web3, network_type: str) -> Dict:
+    """
+    Get a list of middlewares to be used for the given web3 object.
+
+    Arguments
+    ---------
+    web3 : Web3
+        The active web3 object, already connected to the current network.
+    network_type : str
+        One of "live" or "development".
+    """
+    middleware_layers: Dict[int, List] = {}
+    for obj in _middlewares:
+        layer = obj.get_layer(web3, network_type)
+        if layer is not None:
+            middleware_layers.setdefault(layer, []).append(obj)
+
+    return middleware_layers
+
+
+_middlewares: List = []
+
+for path in Path(__file__).parent.glob("[!_]*.py"):
+    # load middleware classes from all modules within `brownie/networks/middlewares/`
+    # to be included the module name must not begin with `_` and the middleware
+    # must subclass `BrownieMiddlewareABC`
+    module = importlib.import_module(f"{__package__}.{path.stem}")
+    _middlewares.extend(
+        obj
+        for obj in module.__dict__.values()
+        if isinstance(obj, type)
+        and obj.__module__ == module.__name__
+        and BrownieMiddlewareABC in obj.mro()
+    )

--- a/brownie/network/middlewares/caching.py
+++ b/brownie/network/middlewares/caching.py
@@ -1,0 +1,103 @@
+import json
+import threading
+import time
+from collections import OrderedDict
+from typing import Callable, Dict, List, Optional
+
+from web3 import Web3
+
+from brownie.network.middlewares import BrownieMiddlewareABC
+
+
+class RequestCachingMiddleware(BrownieMiddlewareABC):
+
+    """
+    Web3 middleware for request caching.
+    """
+
+    def __init__(self, w3: Web3) -> None:
+        self.w3 = w3
+
+        latest = w3.eth.getBlock("latest")
+        self.last_block = latest.hash
+        self.last_block_seen = latest.timestamp
+        self.last_request = 0.0
+        self.block_cache: OrderedDict = OrderedDict()
+        self.block_filter = w3.eth.filter("latest")
+
+        self.lock = threading.Lock()
+        self.event = threading.Event()
+        threading.Thread(target=self.block_filter_loop, daemon=True).start()
+
+    @classmethod
+    def get_layer(cls, w3: Web3, network_type: str) -> Optional[int]:
+        if network_type == "live":
+            return 0
+        else:
+            return None
+
+    @property
+    def time_since(self) -> float:
+        return time.time() - self.last_request
+
+    def block_filter_loop(self) -> None:
+        while True:
+            # if the last RPC request was > 60 seconds ago, reduce the rate of updates.
+            # we eventually settle at one query per minute after 10 minutes of no requests.
+            with self.lock:
+                if self.time_since > 60:
+                    self.block_cache.clear()
+                    self.event.clear()
+            while self.time_since > 60:
+                self.event.wait(min(self.time_since / 10, 60))
+
+            # query the filter for new blocks
+            with self.lock:
+                try:
+                    new_blocks = self.block_filter.get_new_entries()
+                except AttributeError:
+                    return
+                if new_blocks:
+                    self.block_cache[new_blocks[-1]] = {}
+                    self.last_block = new_blocks[-1]
+                    self.last_block_seen = time.time()
+                    if len(self.block_cache) > 5:
+                        old_key = list(self.block_cache)[0]
+                        del self.block_cache[old_key]
+
+            if new_blocks and self.time_since < 15:
+                # if this update found a new block and we've been querying
+                # frequently, we can wait a few seconds before the next update
+                time.sleep(5)
+            elif time.time() - self.last_block_seen < 15:
+                # if it's been less than 15 seconds since the last block, wait 2 seconds
+                time.sleep(2)
+            else:
+                # if it's been more than 15 seconds, only wait 1 second
+                time.sleep(1)
+
+    def process_request(self, make_request: Callable, method: str, params: List) -> Dict:
+        # do not apply this middleware to filter updates or we'll die recursion death
+        if method in ("eth_getFilterChanges", "eth_uninstallFilter"):
+            return make_request(method, params)
+
+        # try to return a cached value
+        param_str = json.dumps(params, separators=(",", ""), default=str)
+        with self.lock:
+            self.last_request = time.time()
+            self.event.set()
+            try:
+                return self.block_cache[self.last_block][method][param_str]
+            except KeyError:
+                pass
+
+        # cached value is unavailable, make a request and cache the result
+        with self.lock:
+            response = make_request(method, params)
+            self.block_cache.setdefault(self.last_block, {}).setdefault(method, {})
+            self.block_cache[self.last_block][method][param_str] = response
+        return response
+
+    def uninstall(self) -> None:
+        if self.w3.provider:
+            self.w3.eth.uninstallFilter(self.block_filter.filter_id)

--- a/brownie/network/middlewares/geth_poa.py
+++ b/brownie/network/middlewares/geth_poa.py
@@ -1,0 +1,21 @@
+from typing import Callable, Dict, List, Optional
+
+from web3 import Web3
+from web3.exceptions import ExtraDataLengthError
+from web3.middleware import geth_poa_middleware
+
+from brownie.network.middlewares import BrownieMiddlewareABC
+
+
+class GethPOAMiddleware(BrownieMiddlewareABC):
+    @classmethod
+    def get_layer(cls, w3: Web3, network_type: str) -> Optional[int]:
+        try:
+            w3.eth.getBlock("latest")
+            return None
+        except ExtraDataLengthError:
+            return -1
+
+    def process_request(self, make_request: Callable, method: str, params: List) -> Dict:
+        middleware_fn = geth_poa_middleware(make_request, self.w3)
+        return middleware_fn(method, params)


### PR DESCRIPTION
### What I did
* generalized logic for adding middlewares to the brownie `web3` object
* a basic implementation of for RPC-call caching

### How I did it
Middlewares are automagically loaded from all files within `brownie/network/middlewares`. The only requirement is that they subclass `BrownieMiddlewareABC`. They are automatically added upon connection and removed at disconnect.  The exact spec is fairly well documented within the natspec and comments.

The cache has two components:

* A short-term cache that lasts as long as the current block. This is useful because it means elsewhere in the code, there's no longer an onus to think about "am I hitting this endpoint too often?" - which gets exponentially more complex when you start using threading (such as with tx replacement). Related - #850
* A long-term cache that persists between sessions. Currently this is only storing `eth_getCode` under specific conditions (non-zero return value, no presence of the `SELFDESTRUCT` opcode). Looking at the Infura dashboard for my most commonly used API key, this endpoint accounts for >20% of the network traffic from Brownie, so it seems like a good first candidate. With the base logic in place for this cache it should be possible to expand it to other endpoints.
