### PR TITLE
reset_middlewares, standardize connection init sequence

### DIFF
--- a/brownie/network/rpc/__init__.py
+++ b/brownie/network/rpc/__init__.py
@@ -82,8 +82,9 @@ class Rpc(metaclass=_Singleton):
         uri = web3.provider.endpoint_uri if web3.provider else None
         for i in range(100):
             if web3.isConnected():
-                chain._network_connected()
+                web3.reset_middlewares()
                 self.backend.on_connection()
+                chain._network_connected()
                 return
             time.sleep(0.1)
             if isinstance(self.process, psutil.Popen):
@@ -120,8 +121,9 @@ class Rpc(metaclass=_Singleton):
                 self.backend = module
                 break
 
-        chain._network_connected()
+        web3.reset_middlewares()
         self.backend.on_connection()
+        chain._network_connected()
 
     def kill(self, exc: bool = True) -> None:
         """Terminates the RPC process and all children with SIGKILL.

--- a/brownie/network/web3.py
+++ b/brownie/network/web3.py
@@ -68,13 +68,20 @@ class Web3(_Web3):
                 )
 
         try:
-            if not self.isConnected():
-                return
+            if self.isConnected():
+                self.reset_middlewares()
         except Exception:
             # checking an invalid connection sometimes raises on windows systems
-            return
+            pass
 
-        # # add middlewares
+    def reset_middlewares(self) -> None:
+        """
+        Uninstall and reinject all custom middlewares.
+        """
+        if self.provider is None:
+            raise ConnectionError("web3 is not currently connected")
+        self._remove_middlewares()
+
         middleware_layers = get_middlewares(self, CONFIG.network_type)
 
         # middlewares with a layer below zero are injected


### PR DESCRIPTION
### What I did
Fix an issue when connecting to `ethnode` that I really should've caught yesterday.

### How I did it
* Add the `Web3.reset_middlewares` method, that uninstalls and readds all middlewares for the given `Web3` object.
* Standardize the sequence of post-init actions within `Rpc.launch` and `Rpc.attach` to ensure that middlewares are always correctly added __after__ the local client has finished loading.
