### PR TITLE
Expand `getCode` caching logic for SELFDESTRUCT via DELEGATECALL

### DIFF
--- a/tests/network/rpc/test_cache.py
+++ b/tests/network/rpc/test_cache.py
@@ -1,0 +1,72 @@
+from brownie import compile_source
+from brownie.network.middlewares.caching import is_cacheable_bytecode
+
+good_code = """
+# @version ^0.2.11
+@external
+def foo() -> Bytes[2]:
+    # caching should still be possible because the return value is stripped
+    return 0xFFF4
+"""
+
+selfdestruct_code = """
+pragma solidity ^0.4.22;
+contract Boom{
+    function innocence() {
+        selfdestruct(msg.sender);
+    }
+}
+"""
+
+delegatecall_code = """
+pragma solidity ^0.4.22;
+contract BadDecision {
+    function call(address a) {
+        a.delegatecall(bytes4(sha3("innocence()")));
+    }
+}"""
+
+factory_code = """
+# @version ^0.2.11
+@external
+def make_forwarder(target: address) -> address:
+    return create_forwarder_to(target)
+"""
+
+
+def test_good_code(accounts, web3):
+    bytecode = compile_source(good_code).Vyper.deploy({"from": accounts[0]}).bytecode
+    assert is_cacheable_bytecode(web3, bytecode)
+
+
+def test_selfdestruct(accounts, web3):
+    bytecode = compile_source(selfdestruct_code).Boom.deploy({"from": accounts[0]}).bytecode
+    assert not is_cacheable_bytecode(web3, bytecode)
+
+
+def test_dynamic_delecatecall(accounts, web3):
+    bytecode = compile_source(delegatecall_code).BadDecision.deploy({"from": accounts[0]}).bytecode
+    assert not is_cacheable_bytecode(web3, bytecode)
+
+
+def test_factory(accounts, web3):
+    factory = compile_source(factory_code).Vyper.deploy({"from": accounts[0]})
+    assert is_cacheable_bytecode(web3, factory.bytecode)
+
+
+def test_forwarder_to_good_code(accounts, web3):
+    factory = compile_source(factory_code).Vyper.deploy({"from": accounts[0]})
+    target = compile_source(good_code).Vyper.deploy({"from": accounts[0]})
+    tx = factory.make_forwarder(target, {"from": accounts[0]})
+
+    bytecode = web3.eth.getCode(tx.return_value)
+    assert is_cacheable_bytecode(web3, bytecode)
+
+
+def test_forwarder_to_bad_code(accounts, web3):
+    factory = compile_source(factory_code).Vyper.deploy({"from": accounts[0]})
+    target = compile_source(selfdestruct_code).Boom.deploy({"from": accounts[0]})
+    tx = factory.make_forwarder(target, {"from": accounts[0]})
+
+    bytecode = web3.eth.getCode(tx.return_value)
+    assert not is_cacheable_bytecode(web3, bytecode)


### PR DESCRIPTION
### What I did
Expand the logic when determining if bytecode may be cached. In particular, consider an indirect `SELFDESTRUCT` via `DELEGATECALL`.

Thanks to @banteg for pointing this one out.  I am a bad devloper and I'm not sure why any of you use my code.

### How I did it
The new implementation is fairly well commented, but the gist of it is:

* remove the bytecode after `PUSH` instructions to avoid false positives
* scan for `DELEGATECALL` and if it isn't preceded by `PUSH20 [address] GAS` assume it to be dynamic and thus not cacheable
* where an address is hardcoded, also check if the target address is cachable

This isn't perfect but it should err on the side of caution.

### How to verify it
I actually wrote tests on this! Good job, me.