### PR TITLE
Issue with chain.time timestamp

### DIFF
--- a/brownie/network/rpc/__init__.py
+++ b/brownie/network/rpc/__init__.py
@@ -169,8 +169,8 @@ class Rpc(metaclass=_Singleton):
         return self.backend.sleep(seconds)
 
     @internal
-    def mine(self, blocks: int = 1) -> int:
-        self.backend.mine(blocks)
+    def mine(self, timestamp: int = None) -> int:
+        self.backend.mine(timestamp)
         return web3.eth.blockNumber
 
     @internal

--- a/tests/network/state/test_blocks.py
+++ b/tests/network/state/test_blocks.py
@@ -17,6 +17,17 @@ def test_length_after_revert(devnetwork, chain):
     assert len(chain) == 5
 
 
+def test_timestamp(devnetwork, chain):
+    chain.mine()
+    assert chain[-2].timestamp <= chain[-1].timestamp
+
+
+def test_timestamp_multiple_blocks(devnetwork, chain):
+    chain.mine(5)
+    for i in range(1, len(chain)):
+        assert chain[i - 1].timestamp <= chain[i].timestamp
+
+
 def test_getitem_negative_index(devnetwork, accounts, chain, web3):
     block = chain[-1]
     assert block == web3.eth.getBlock("latest")


### PR DESCRIPTION
### What I did
Fix a bug in `chain.mine` that was introduced in `v1.14.0`, where if no timestamp was explicitly given all blocks were mined with a timestamp of `1`.

### How I did it
Correctly handle default args. Oopsie.

### How to verify it
Run the tests.  I added some coverage for this case.
