### PR TITLE
Ensure node client supports filters before adding cache middleware

### DIFF
--- a/brownie/network/middlewares/caching.py
+++ b/brownie/network/middlewares/caching.py
@@ -111,6 +111,12 @@ class RequestCachingMiddleware(BrownieMiddlewareABC):
     @classmethod
     def get_layer(cls, w3: Web3, network_type: str) -> Optional[int]:
         if network_type == "live":
+            try:
+                # ensure that the node client supports filters
+                block_filter = w3.eth.filter("latest")
+                block_filter.get_new_entries()
+            except ValueError:
+                return None
             return 0
         else:
             return None


### PR DESCRIPTION
### What I did
Ensure the node client supports filters before adding the cache middleware.  Fixes #1008 

### How I did it
During `RequestCachingMiddleware.get_layer`, attempt to make and query a filter prior to returning a layer.

### How to verify it
Try it using the `bsc-main` network where filters are disabled.  CZ, if you're reading this, give us filters!
