### PR TITLE
Improvements to gas reporting

### DIFF
--- a/brownie/data/default-config.yaml
+++ b/brownie/data/default-config.yaml
@@ -50,6 +50,7 @@ console:
 reports:
     exclude_paths: null
     exclude_contracts: null
+    only_include_project: true
 
 hypothesis:
     deadline: null

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -540,7 +540,7 @@ class TransactionReceipt:
         self.coverage_hash = sha1(base.encode()).hexdigest()
 
         if self.fn_name:
-            state.TxHistory()._gas(self._full_name(), receipt["gasUsed"])
+            state.TxHistory()._gas(self._full_name(), receipt["gasUsed"], self.status == Status(1))
 
     def _confirm_output(self) -> str:
         status = ""

--- a/brownie/test/output.py
+++ b/brownie/test/output.py
@@ -108,8 +108,8 @@ def _build_gas_profile_output():
             values["avg"] = int(values["avg"])
             values = {k: str(v).rjust(padding[k]) for k, v in values.items()}
             lines.append(
-                f"   {prefix} {fn_name} -  avg: {values['avg']}"
-                f"  low: {values['low']}  high: {values['high']}"
+                f"   {prefix} {fn_name} -  avg: {values['avg']}  avg (confirmed):"
+                f" {values['avg_success']}  low: {values['low']}  high: {values['high']}"
             )
 
     return lines + [""]

--- a/brownie/test/output.py
+++ b/brownie/test/output.py
@@ -74,6 +74,7 @@ def _build_gas_profile_output():
 
     lines = [""]
 
+    only_include_project = CONFIG.settings["reports"]["only_include_project"]
     for full_name, values in sorted_gas:
         contract, function = full_name.split(".", 1)
 
@@ -82,7 +83,8 @@ def _build_gas_profile_output():
                 continue
         except (AttributeError, KeyError):
             # filters contracts that are not part of the project
-            continue
+            if only_include_project:
+                continue
         if contract in exclude_contracts:
             continue
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -267,6 +267,12 @@ Settings related to reports such as coverage data and gas profiles.
                 - SafeMath
                 - Owned
 
+.. py:attribute:: only_include_project
+
+    If ``false``, reports also include contracts imported from outside the active project (such as those compiled via :func:`compile_source <main.compile_source>`).
+
+    default value: ``true``
+
 .. _config-hypothesis:
 
 Hypothesis


### PR DESCRIPTION
### What I did
* Add `reports.only_include_project` as a config setting, to disable filtering non-project contracts from gas report
* Add a new `avg (confirmed)` column to the gas report, for the average transaction cost only on tx's that did not revert
