### PR TITLE
fix: add project to brownie namespace for console

### DIFF
--- a/brownie/_cli/console.py
+++ b/brownie/_cli/console.py
@@ -47,6 +47,7 @@ def main():
     if project.check_for_project():
         active_project = project.load()
         active_project.load_config()
+        active_project._add_to_main_namespace()
         print(f"{active_project._name} is the active project.")
     else:
         active_project = None


### PR DESCRIPTION
### What I did

Fixed an annoyance when firing up an interactive console in a project directory. It loads the project automatically, but it previously didn't inject contract and interfaces in a global namespace, which made the environment different from scripts or tests.

Related issue: #

### How I did it

### How to verify it

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
