### PR TITLE
fix: balance contract member override

### DIFF
--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -778,9 +778,10 @@ class _DeployedContractBase(_ContractBase):
         if name == "balance":
             warnings.warn(
                 f"'{self._name}' defines a 'balance' function, "
-                f"'{self._name}.balance' is unavailable",
+                f"'{self._name}.balance' is available as {self._name}.wei_balance",
                 BrownieEnvironmentWarning,
             )
+            setattr(self, "wei_balance", self.balance)
         elif hasattr(self, name):
             warnings.warn(
                 "Namespace collision between contract function and "
@@ -788,8 +789,8 @@ class _DeployedContractBase(_ContractBase):
                 f"The {name} function will not be available when interacting with {self._name}",
                 BrownieEnvironmentWarning,
             )
-        else:
-            setattr(self, name, obj)
+            return
+        setattr(self, name, obj)
 
     def __hash__(self) -> int:
         return hash(f"{self._name}{self.address}{self._project}")


### PR DESCRIPTION
### What I did

Fixed a regression introduced [here](https://github.com/eth-brownie/brownie/commit/ed7adacd008d2a633c47c701ccf905954fe66a40#diff-9d15ba572e3097f4a9461dc8fe0a0dfc6d7f6015e935930526ebfb4ba0fa0cefL781).

Related issue: #

### How I did it

Reverted an erroneous refactor to its previous state.

Also added renaming `balance` Contract class member to `wei_balance` on name clash instead of rendering it inaccessible.

### How to verify it

`Contract('0x5dbcF33D8c2E976c6b560249878e6F1491Bca25c').balance()` on mainnet should be non-zero.

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
