### PR TITLE
fix: moves brownie.utils.color to brownie._color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/eth-brownie/brownie)
+### Fixed
+- Moves `brownie.utils.color` to `brownie._colors` to fix circular import loop.
+
 
 ## [1.14.3](https://github.com/eth-brownie/brownie/tree/v1.14.3) - 2021-03-27
 ### Added

--- a/brownie/_cli/__main__.py
+++ b/brownie/_cli/__main__.py
@@ -5,9 +5,9 @@ import sys
 from pathlib import Path
 
 from brownie import network
+from brownie._colors import color, notify
 from brownie._config import CONFIG, __version__
 from brownie.exceptions import ProjectNotFound
-from brownie.utils import color, notify
 from brownie.utils.docopt import docopt, levenshtein_norm
 
 __doc__ = """Usage:  brownie <command> [<args>...] [options <args>]

--- a/brownie/_cli/accounts.py
+++ b/brownie/_cli/accounts.py
@@ -6,9 +6,9 @@ import sys
 from pathlib import Path
 
 from brownie import accounts
+from brownie._colors import color, notify
 from brownie._config import _get_data_folder
 from brownie.convert import to_address
-from brownie.utils import color, notify
 from brownie.utils.docopt import docopt
 
 __doc__ = """Usage: brownie accounts <command> [<arguments> ...] [options]

--- a/brownie/_cli/analyze.py
+++ b/brownie/_cli/analyze.py
@@ -13,6 +13,7 @@ from pythx import Client, ValidationError
 from pythx.middleware import ClientToolNameMiddleware, GroupDataMiddleware
 
 from brownie import project
+from brownie._colors import color, notify
 from brownie._config import (
     CONFIG,
     __version__,
@@ -20,7 +21,6 @@ from brownie._config import (
     _update_argv_from_docopt,
 )
 from brownie.exceptions import ProjectNotFound
-from brownie.utils import color, notify
 from brownie.utils.docopt import docopt
 
 __doc__ = """Usage: brownie analyze [options] [--async | --interval=<sec>]

--- a/brownie/_cli/bake.py
+++ b/brownie/_cli/bake.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
 from brownie import project
-from brownie.utils import notify
+from brownie._colors import notify
 from brownie.utils.docopt import docopt
 
 __doc__ = """Usage: brownie bake <mix> [<path>] [options]

--- a/brownie/_cli/compile.py
+++ b/brownie/_cli/compile.py
@@ -3,9 +3,9 @@
 import shutil
 
 from brownie import project
+from brownie._colors import color
 from brownie._config import _load_project_structure_config
 from brownie.exceptions import ProjectNotFound
-from brownie.utils import color
 from brownie.utils.docopt import docopt
 
 CODESIZE_COLORS = [(1, "bright red"), (0.8, "bright yellow")]

--- a/brownie/_cli/console.py
+++ b/brownie/_cli/console.py
@@ -23,8 +23,8 @@ from pygments.styles import get_style_by_name
 
 import brownie
 from brownie import network, project
+from brownie._colors import color
 from brownie._config import CONFIG, _get_data_folder, _update_argv_from_docopt
-from brownie.utils import color
 from brownie.utils.docopt import docopt
 
 __doc__ = f"""Usage: brownie console [options]

--- a/brownie/_cli/ethpm.py
+++ b/brownie/_cli/ethpm.py
@@ -7,10 +7,10 @@ import sys
 import yaml
 
 from brownie import accounts, network
+from brownie._colors import color, notify
 from brownie._config import BROWNIE_FOLDER, _get_data_folder
 from brownie.exceptions import ProjectNotFound, UnknownAccount
 from brownie.project import check_for_project, ethpm
-from brownie.utils import color, notify
 from brownie.utils.docopt import docopt
 
 __doc__ = """Usage: brownie ethpm <command> [<arguments> ...] [options]

--- a/brownie/_cli/init.py
+++ b/brownie/_cli/init.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
 from brownie import project
-from brownie.utils import notify
+from brownie._colors import notify
 from brownie.utils.docopt import docopt
 
 __doc__ = """Usage: brownie init [<path>] [options]

--- a/brownie/_cli/networks.py
+++ b/brownie/_cli/networks.py
@@ -6,8 +6,8 @@ from pathlib import Path
 
 import yaml
 
+from brownie._colors import color, notify
 from brownie._config import CONFIG, _get_data_folder
-from brownie.utils import color, notify
 from brownie.utils.docopt import docopt
 
 __doc__ = """Usage: brownie networks <command> [<arguments> ...] [options]

--- a/brownie/_cli/pm.py
+++ b/brownie/_cli/pm.py
@@ -5,8 +5,8 @@ import sys
 from pathlib import Path
 
 from brownie import project
+from brownie._colors import color, notify
 from brownie._config import _get_data_folder
-from brownie.utils import color, notify
 from brownie.utils.docopt import docopt
 
 __doc__ = """Usage: brownie pm <command> [<arguments> ...] [options]

--- a/brownie/_cli/run.py
+++ b/brownie/_cli/run.py
@@ -6,10 +6,10 @@ from pathlib import Path
 
 from brownie import network, project
 from brownie._cli.console import Console
+from brownie._colors import color
 from brownie._config import CONFIG, _update_argv_from_docopt
 from brownie.project.scripts import _get_path, run
 from brownie.test.output import _build_gas_profile_output
-from brownie.utils import color
 from brownie.utils.docopt import docopt
 
 __doc__ = f"""Usage: brownie run <filename> [<function>] [options]

--- a/brownie/_colors.py
+++ b/brownie/_colors.py
@@ -190,6 +190,9 @@ class Color:
         return pygments.highlight(text, lexer, formatter)
 
 
+color = Color()
+
+
 def notify(type_, msg):
     """Prepends a message with a colored tag and outputs it to the console."""
     color = Color()

--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -14,6 +14,7 @@ import rlp
 from eth_utils import keccak
 from hexbytes import HexBytes
 
+from brownie._colors import color
 from brownie._config import CONFIG, _get_data_folder
 from brownie._singleton import _Singleton
 from brownie.convert import EthAddress, Wei, to_address
@@ -23,7 +24,6 @@ from brownie.exceptions import (
     UnknownAccount,
     VirtualMachineError,
 )
-from brownie.utils import color
 
 from .gas.bases import GasABC
 from .rpc import Rpc

--- a/brownie/network/alert.py
+++ b/brownie/network/alert.py
@@ -4,7 +4,7 @@ import time as time
 from threading import Thread
 from typing import Callable, Dict, List, Tuple, Union
 
-from brownie.utils import color
+from brownie._colors import color
 
 __console_dir__ = ["Alert", "new", "show", "stop_all"]
 _instances = set()

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -21,6 +21,7 @@ from semantic_version import Version
 from vvm import get_installable_vyper_versions
 from vvm.utils.convert import to_vyper_version
 
+from brownie._colors import color
 from brownie._config import BROWNIE_FOLDER, CONFIG, REQUEST_HEADERS
 from brownie.convert.datatypes import Wei
 from brownie.convert.normalize import format_input, format_output
@@ -39,7 +40,6 @@ from brownie.exceptions import (
 )
 from brownie.project import compiler, ethpm
 from brownie.typing import AccountsType, TransactionReceiptType
-from brownie.utils import color
 from brownie.utils.toposort import toposort_flatten
 
 from . import accounts, chain

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -15,6 +15,7 @@ from eth_abi import decode_abi
 from hexbytes import HexBytes
 from web3.exceptions import TimeExhausted, TransactionNotFound
 
+from brownie._colors import color
 from brownie._config import CONFIG
 from brownie.convert import EthAddress, Wei
 from brownie.exceptions import RPCRequestError
@@ -23,7 +24,6 @@ from brownie.project import main as project_main
 from brownie.project.compiler.solidity import SOLIDITY_ERROR_CODES
 from brownie.project.sources import highlight_source
 from brownie.test import coverage
-from brownie.utils import color
 from brownie.utils.output import build_tree
 
 from . import state

--- a/brownie/network/web3.py
+++ b/brownie/network/web3.py
@@ -3,6 +3,7 @@
 import json
 import os
 import time
+import warnings
 from pathlib import Path
 from typing import Dict, Optional, Set
 
@@ -168,6 +169,11 @@ def _expand_environment_vars(uri: str) -> str:
     expanded = os.path.expandvars(uri)
     if uri != expanded:
         return expanded
+    if uri.endswith("WEB3_INFURA_PROJECT_ID"):
+        warnings.warn(
+            """Did you set WEB3_INFURA_PROJECT_ID? See
+            "https://eth-brownie.readthedocs.io/en/stable/network-management.html#using-infura"""
+        )
     raise ValueError(f"Unable to expand environment variable in host setting: '{uri}'")
 
 

--- a/brownie/project/compiler/__init__.py
+++ b/brownie/project/compiler/__init__.py
@@ -10,6 +10,7 @@ import solcast
 from eth_utils import remove_0x_prefix
 from semantic_version import Version
 
+from brownie._colors import notify
 from brownie._config import _get_data_folder
 from brownie.exceptions import UnsupportedLanguage
 from brownie.project import sources
@@ -21,7 +22,6 @@ from brownie.project.compiler.solidity import (  # NOQA: F401
 )
 from brownie.project.compiler.utils import _get_alias, merge_natspec
 from brownie.project.compiler.vyper import find_vyper_versions, set_vyper_version
-from brownie.utils import notify
 
 from . import solidity, vyper
 

--- a/brownie/project/ethpm.py
+++ b/brownie/project/ethpm.py
@@ -13,12 +13,12 @@ from ethpm._utils.ipfs import generate_file_hash
 from ethpm.backends.ipfs import InfuraIPFSBackend
 
 from brownie import network
+from brownie._colors import color
 from brownie._config import _get_data_folder
 from brownie.convert import to_address
 from brownie.exceptions import InvalidManifest
 from brownie.network.web3 import web3
 from brownie.typing import AccountsType, TransactionReceiptType
-from brownie.utils import color
 
 from . import compiler
 

--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -22,6 +22,7 @@ from solcx.exceptions import SolcNotInstalled
 from tqdm import tqdm
 from vvm.exceptions import VyperNotInstalled
 
+from brownie._colors import notify
 from brownie._config import (
     CONFIG,
     REQUEST_HEADERS,
@@ -50,7 +51,6 @@ from brownie.project import compiler, ethpm
 from brownie.project.build import BUILD_KEYS, INTERFACE_KEYS, Build
 from brownie.project.ethpm import get_deployment_addresses, get_manifest
 from brownie.project.sources import Sources, get_pragma_spec
-from brownie.utils import notify
 
 BUILD_FOLDERS = ["contracts", "deployments", "interfaces"]
 MIXES_URL = "https://github.com/brownie-mix/{}-mix/archive/{}.zip"

--- a/brownie/project/scripts.py
+++ b/brownie/project/scripts.py
@@ -9,9 +9,9 @@ from pathlib import Path
 from types import FunctionType, ModuleType
 from typing import Any, Dict, List, Optional, Tuple
 
+from brownie._colors import color
 from brownie.exceptions import ProjectNotFound
 from brownie.project.main import Project, check_for_project, get_loaded_projects
-from brownie.utils import color
 
 _import_cache: Dict = {}
 

--- a/brownie/project/sources.py
+++ b/brownie/project/sources.py
@@ -9,8 +9,8 @@ from typing import Dict, List, Optional, Tuple
 from semantic_version import NpmSpec
 from vvm.utils.convert import to_vyper_version
 
+from brownie._colors import color
 from brownie.exceptions import NamespaceCollision, PragmaError
-from brownie.utils import color
 
 
 class Sources:

--- a/brownie/test/managers/runner.py
+++ b/brownie/test/managers/runner.py
@@ -12,11 +12,11 @@ from _pytest._io import TerminalWriter
 
 import brownie
 from brownie._cli.console import Console
+from brownie._colors import color
 from brownie._config import CONFIG
 from brownie.exceptions import VirtualMachineError
 from brownie.network.state import _get_current_dependencies
 from brownie.test import coverage, output
-from brownie.utils import color
 
 from .base import PytestBrownieBase
 from .utils import convert_outcome

--- a/brownie/test/output.py
+++ b/brownie/test/output.py
@@ -4,11 +4,11 @@ import json
 import warnings
 from pathlib import Path
 
+from brownie._colors import color
 from brownie._config import CONFIG
 from brownie.exceptions import BrownieConfigWarning
 from brownie.network.state import TxHistory
 from brownie.project import get_loaded_projects
-from brownie.utils import color
 
 COVERAGE_COLORS = [(0.8, "bright red"), (0.9, "bright yellow"), (1, "bright green")]
 

--- a/brownie/test/plugin.py
+++ b/brownie/test/plugin.py
@@ -7,10 +7,10 @@ from typing import Optional
 import pytest
 
 from brownie import project
+from brownie._colors import color
 from brownie._config import CONFIG, _modify_hypothesis_settings
 from brownie.test.fixtures import PytestBrownieFixtures
 from brownie.test.managers import PytestBrownieMaster, PytestBrownieRunner, PytestBrownieXdistRunner
-from brownie.utils import color
 
 
 def _get_project_path() -> Optional[Path]:

--- a/brownie/test/stateful.py
+++ b/brownie/test/stateful.py
@@ -11,7 +11,7 @@ from hypothesis import stateful as sf
 from hypothesis.strategies import SearchStrategy
 
 import brownie
-from brownie.utils import color
+from brownie._colors import color
 
 sf.__tracebackhide__ = True
 

--- a/brownie/utils/__init__.py
+++ b/brownie/utils/__init__.py
@@ -1,5 +1,0 @@
-#!/usr/bin/python3
-
-from .color import Color, notify  # noqa 401
-
-color = Color()

--- a/docs/api-utils.rst
+++ b/docs/api-utils.rst
@@ -6,7 +6,7 @@ Utils API
 
 The ``utils`` package contains utility classes and methods that are used throughout Brownie.
 
-``brownie.utils.color``
+``brownie._color``
 =======================
 
 The ``color`` module contains the ``Color`` class, used for to apply color and formatting to text before printing.
@@ -14,15 +14,15 @@ The ``color`` module contains the ``Color`` class, used for to apply color and f
 Color
 -----
 
-.. py:class:: brownie.utils.color.Color
+.. py:class:: brownie._color.Color
 
-    The ``Color`` class is used to apply color and formatting to text before displaying it to the user. It is primarily used within the console. An instance of ``Color`` is available at ``brownie.utils.color``:
+    The ``Color`` class is used to apply color and formatting to text before displaying it to the user. It is primarily used within the console. An instance of ``Color`` is available at ``brownie._color``:
 
     .. code-block:: python
 
-        >>> from brownie.utils import color
+        >>> from brownie._colors import color
         >>> color
-        <brownie.utils.color.Color object at 0x7fa9ec851ba8>
+        <brownie._color.Color object at 0x7fa9ec851ba8>
 
     ``Color`` is designed for use in `formatted string literals <https://docs.python.org/3.6/reference/lexical_analysis.html#f-strings>`_. When called it returns an `ANSI escape code <https://en.wikipedia.org/wiki/ANSI_escape_code#Colors>`_ for the given color:
 

--- a/tests/utils/test_colors.py
+++ b/tests/utils/test_colors.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from brownie.utils import color
+from brownie._colors import color
 
 
 @pytest.fixture
@@ -10,8 +10,8 @@ def colorpatch(monkeypatch):
     def patched(*args):
         return ""
 
-    monkeypatch.setattr("brownie.utils.Color.__call__", patched)
-    monkeypatch.setattr("brownie.utils.Color.__str__", patched)
+    monkeypatch.setattr("brownie._colors.Color.__call__", patched)
+    monkeypatch.setattr("brownie._colors.Color.__str__", patched)
     yield
 
 


### PR DESCRIPTION
### What I did

While working on #1012, I ran into a circular dependency:

* `brownie._config` calls `brownie.utils.color`, and `brownie.utils.color` calls `brownie._config`
* This made it a bit hard to add new `utils`. 

* One design pattern we could follow for the future: core parts of the library can reference `brownie.utils`, but `brownie.utils` cannot reference core parts of the library.

Doing this right now would require refactoring how we do colors, so for now I think this is the 80/20 solution, which moves `brownie.utils.color` to `brownie._colors`. 

Another possible solution: keep `brownie.utils.color` where it is pull out the `CONFIG` calls from the module. We'd have to add an intermediate abstraction layer, but I could also see that solution working.  
 
I also added a helpful warning message related to #1031.

Related issue: #1012, #1031

### How I did it

### How to verify it

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [x] I have updated the documentation
- [x] I have added an entry to the changelog
