### PR TITLE
Find console frame based on project path

### DIFF
--- a/brownie/test/managers/runner.py
+++ b/brownie/test/managers/runner.py
@@ -434,12 +434,15 @@ class PytestBrownieRunner(PytestBrownieBase):
             tw = TerminalWriter()
             report.longrepr.toterminal(tw)
 
-            # find last traceback frame within the active test
-            excinfo = call.excinfo
-            traceback = next(
-                (i for i in excinfo.traceback[::-1] if Path(i.path).as_posix().endswith(location)),
-                excinfo.traceback[-1],
-            )
+            # find the last traceback frame within the active project
+            traceback = call.excinfo.traceback[-1]
+            for tb_frame in call.excinfo.traceback[::-1]:
+                try:
+                    Path(tb_frame.path).relative_to(self.project_path)
+                    traceback = tb_frame
+                    break
+                except ValueError:
+                    pass
 
             # get global namespace
             globals_dict = traceback.frame.f_globals


### PR DESCRIPTION
### What I did
When opening a console during pytest interactive debugging, find the local frame based on the project path rather than the test path. This ensures the correct namespace when a test fails during logic imported from another file, such as an inherited class.

### How I did it
Tweaks to `pytest_exception_interact`

