### PR TITLE
Apply auth error message to 404 responses too.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed a formatting issue on the new [environment variable section](https://eth-brownie.readthedocs.io/en/stable/config.html?highlight=POSIX-style#variable-expansion) ([#1038](https://github.com/eth-brownie/brownie/pull/1038))
+- Adjusted Github API token error message so that it correctly emits when auth failure occurs ([#1052](https://github.com/eth-brownie/brownie/pull/1052))
 
 ## [1.14.4](https://github.com/eth-brownie/brownie/tree/v1.14.4) - 2021-04-05
 ### Added

--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -824,9 +824,10 @@ def _install_from_github(package_id: str) -> str:
         msg = "Status {} when getting package versions from Github: '{}'".format(
             response.status_code, response.json()["message"]
         )
-        if response.status_code == 403:
+        if response.status_code in (403, 404):
             msg += (
-                "\n\nIf this issue persists, generate a Github API token and store"
+                "\n\nMissing or forbidden.\n"
+                "If this issue persists, generate a Github API token and store"
                 " it as the environment variable `GITHUB_TOKEN`:\n"
                 "https://github.blog/2013-05-16-personal-api-tokens/"
             )
@@ -996,10 +997,11 @@ def _get_mix_default_branch(mix_name: str) -> str:
     if r.status_code != 200:
         status, repo, message = r.status_code, f"brownie-mix/{mix_name}", r.json()["message"]
         msg = f"Status {status} when retrieving repo {repo} information from GHAPI: '{message}'"
-        if r.status_code == 403:
+        if r.status_code in (403, 404):
             msg_lines = (
                 msg,
-                "\n\nIf this issue persists, generate a Github API token and store",
+                "\n\nMissing or forbidden.\n",
+                "If this issue persists, generate a Github API token and store",
                 " it as the environment variable `GITHUB_TOKEN`:\n",
                 "https://github.blog/2013-05-16-personal-api-tokens/",
             )


### PR DESCRIPTION
### What I did

Adjusted error messages when interacting with the Github API.

Related issue:  Fixes #1051 

### How to verify it

Can try a failing auth request e.g. `brownie pm install org/some_private_repo@1.2.3`.
Pretty clear from inspection too

### Checklist

- [x] I have confirmed that my PR passes all linting checks (at least for files I modified)
- [ ] I have included test cases
- [ ] I have updated the documentation
- [x] I have added an entry to the changelog
