### PR TITLE
Fixed allow_revert error message syntax

### DIFF
--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -402,7 +402,7 @@ class _PrivateKeyAccount(PublicKeyAccount):
             msg = exc.args[0]["message"] if isinstance(exc.args[0], dict) else str(exc)
             raise ValueError(
                 f"Execution reverted during call: '{msg}'. This transaction will likely revert. "
-                "If you wish to broadcast, include `allow_revert=True` as a transaction parameter.",
+                "If you wish to broadcast, include `allow_revert:True` as a transaction parameter.",
             ) from None
 
     def deploy(


### PR DESCRIPTION
### What I did
Fixed allow_revert error message syntax to be consistent with actual transaction parameter syntax.


