### PR TITLE
Remove `__ret_value__` prior to writing to console

### DIFF
--- a/brownie/_cli/console.py
+++ b/brownie/_cli/console.py
@@ -248,8 +248,8 @@ class Console(code.InteractiveConsole):
             pass
         self.runcode(code)
         if "__ret_value__" in self.locals and self.locals["__ret_value__"] is not None:
-            self._console_write(self.locals["__ret_value__"])
-            del self.locals["__ret_value__"]
+            return_value = self.locals.pop("__ret_value__")
+            self._console_write(return_value)
         return False
 
     def paste_event(self, event):


### PR DESCRIPTION
### What I did
Fix a recursion error within the console when attempting to print the output of `globals()` or `locals()`.

Fixes #1014 

### How I did it
The bug was due to how console output is generated - under the hood, `globals()` is mutated to `__ret_value__ = globals()` and then `__ret_value__` is printed.  However, because the return value _contains_ `__ret_value__` we end up dying recursion death as we try to format dict-inside-dict-inside-dict.

The fix is simply to remove `__ret_value__` from locals prior to generating the console output.

### How to verify it
Open the console and type `locals()` or `globals()`.

