### PR TITLE
Do not cache `eth_newBlockFilter`

### DIFF
--- a/brownie/network/middlewares/caching.py
+++ b/brownie/network/middlewares/caching.py
@@ -170,7 +170,12 @@ class RequestCachingMiddleware(BrownieMiddlewareABC):
     def process_request(self, make_request: Callable, method: str, params: List) -> Dict:
         # do not apply this middleware to filter updates or we'll die recursion death
         # clientVersion is used to check connectivity so we also don't cache that
-        if method in ("eth_getFilterChanges", "eth_uninstallFilter", "web3_clientVersion"):
+        if method in (
+            "eth_getFilterChanges",
+            "eth_newBlockFilter",
+            "eth_uninstallFilter",
+            "web3_clientVersion",
+        ):
             return make_request(method, params)
 
         # try to return a cached value


### PR DESCRIPTION
### What I did
Avoid caching requests to create a new block filter.  This fixes an issue causing brownie to freeze when the RPC client normally allows filters, but drops them frequently due to network congestion (looking at you, Binance Smart Chain).

### How I did it
Add `eth_newBlockFilter` to the list of RPC endpoints that should never be cached.

### How to verify it
Spend some time using BSC.

