### PR TITLE
Adding support for dotted paths

### DIFF
--- a/brownie/project/scripts.py
+++ b/brownie/project/scripts.py
@@ -141,12 +141,18 @@ def _get_path(path_str: str) -> Tuple[Path, Optional[Project]]:
 
 
 def _import_from_path(path: Path) -> ModuleType:
-    # Imports a module from the given path
-    import_str = ".".join(path.parts[1:-1] + (path.stem,))
+    import_str = str(path)
+
     if import_str in _import_cache:
         importlib.reload(_import_cache[import_str])
     else:
-        _import_cache[import_str] = importlib.import_module(import_str)
+        moduleName = path.stem
+        spec = importlib.util.spec_from_file_location(moduleName, path)
+        module = importlib.util.module_from_spec(spec)
+        _import_cache[import_str] = module
+        sys.modules[moduleName] = module
+        spec.loader.exec_module(module)
+
     return _import_cache[import_str]
 
 


### PR DESCRIPTION
### What I did
Fixed brownie script execution failure when project path includes dotted filepath (e.g. `/User/John.Doe/Documents/brownie`). 

```
(venv) kelvin.bonilla@kelvin token % brownie run token
Brownie v1.14.6 - Python development framework for Ethereum

TokenProject is the active project.

Launching 'ganache-cli --port 8545 --gasLimit 12000000 --accounts 10 --hardfork istanbul --mnemonic brownie'...
  File "/Users/kelvin.bonilla/Documents/brownie/brownie/_cli/run.py", line 50, in main
    args["<filename>"], method_name=args["<function>"] or "main", _include_frame=True
  File "/Users/kelvin.bonilla/Documents/brownie/brownie/project/scripts.py", line 53, in run
    module = _import_from_path(script)
  File "/Users/kelvin.bonilla/Documents/brownie/brownie/project/scripts.py", line 149, in _import_from_path
    _import_cache[import_str] = importlib.import_module(import_str)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen, line line, in in
  File "<frozen, line line, in in
  File "<frozen, line line, in in
  File "<frozen, line line, in in
  File "<frozen, line line, in in
  File "<frozen, line line, in in
  File "<frozen, line line, in in
  File "<frozen, line line, in in
  File "<frozen, line line, in in
  File "<frozen, line line, in in
  File "<frozen, line line, in in
  File "<frozen, line line, in in
  File "<frozen, line line, in in
  File "<frozen, line line, in in
  File "<frozen, line line, in in
  File "<frozen, line line, in in
  File "<frozen, line line, in in
  File "<frozen, line line, in in
  File "<frozen, line line, in in
  File "<frozen, line line, in in
  File "<frozen, line line, in in
  File "<frozen, line line, in in
  File "<frozen, line line, in in
ModuleNotFoundError: No module named 'Users.kelvin'
Terminating local RPC client...
```

You can see this case happening to user users:
- https://ethereum.stackexchange.com/questions/96331/how-to-run-chainlink-project-using-eth-brownie-python

The issue originates from feeding a dot-separated path during import from path. This creates a misinterpretation for [importlib.import_module()](https://docs.python.org/3/library/importlib.html#importlib.import_module):

- https://stackoverflow.com/questions/27189044/import-with-dot-name-in-python
- https://stackoverflow.com/questions/25296219/import-py-files-with-punctuation-before-extension

Instead of using the classic approach, I opted for using importlib utitlities instead:
https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly


Related issue: #
https://github.com/eth-brownie/brownie/issues/143

### How I did it
With lots of patience. And prints.
![image](https://user-images.githubusercontent.com/1028926/115785538-72a6cd00-a374-11eb-80fb-af42c2d1fdc8.png)

### How to verify it
(Only tested in OSX 10.15.7, Brownie v1.14.6, Python 3.6.8)
1. [Clone brownie for development](https://github.com/eth-brownie/brownie#for-development) to a dotted path: `/Users/John.Doe/brownie`
2. Grab token mix: `$ brownie bake token`
3. `$ brownie compile`
4. `$ brownie run token`
5. Observe similar trailing error: `ModuleNotFoundError: No module named 'Users.John'`
![image](https://user-images.githubusercontent.com/1028926/115787921-c5ce4f00-a377-11eb-83ba-03661c2b37ea.png)


6. Checkout pull request into locally cloned brownie repo.
7. retry step 4
8. Observe successful transaction:
![image](https://user-images.githubusercontent.com/1028926/115787848-ad5e3480-a377-11eb-8223-f7e7aaa47fb0.png)


### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog

### Notes
I'm unable to successfully initiate linting tests. I don't understand what I am missing:
![image](https://user-images.githubusercontent.com/1028926/115786214-5bb4aa80-a375-11eb-9811-d9183dfd95d3.png)

