### PR TITLE
feat: allow users to overwrite 'host' and 'explorer' in network settings

### DIFF
--- a/brownie/_config.py
+++ b/brownie/_config.py
@@ -94,6 +94,19 @@ class ConfigContainer:
 
             network["cmd_settings"]["fork"] = os.path.expandvars(network["cmd_settings"]["fork"])
 
+        if (
+            key == "live"
+            and id_ in self.settings["networks"]
+        ):
+            overwrite_settings = self.settings["networks"][id_]
+
+            if "host" in overwrite_settings:
+                # overwrite the host settings
+                network["host"] = overwrite_settings["host"]
+
+            if "explorer" in overwrite_settings:
+                network["explorer"] = overwrite_settings["explorer"]
+
         self._active_network = network
         return network
 


### PR DESCRIPTION
### What I did
I'd like to have a setting for mainnet. Infura is not the only option here. I can specify "host" with another eth RPC provider.
similar to etherscan, I'd like to have another url, as the original one is blocked here.

### How I did it
I add the code in _config.py

### How to verify it

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
