### PR TITLE
Fix alert message bug

### DIFF
--- a/brownie/network/alert.py
+++ b/brownie/network/alert.py
@@ -83,8 +83,8 @@ class Alert:
                 if value == start_value:
                     continue
                 if msg:
-                    msg = msg.format(start_value, value)
-                    print(f"{color('bright red')}ALERT{color}: {msg}")
+                    fmt_msg = msg.format(start_value, value)
+                    print(f"{color('bright red')}ALERT{color}: {fmt_msg}")
                 if callback:
                     callback(start_value, value)
                 start_value = value


### PR DESCRIPTION
### What I did
Fixed alert message bug
Closes #939 

Full disclosure: This change was made in-browser, so I haven't run tests locally. It's just a variable name change though, so I don't expect it to be controversial.

### How I did it
msg variable was reset, causing the bug: I created a new variable for printing the message

### How to verify it
Create an alert with repeat != False, verify that the message updates accordingly

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
