### PR TITLE
feat: add support for EIP-712 message signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add polygon network integration ([#1119](https://github.com/eth-brownie/brownie/pull/1119))
 - Fixed subcalls to empty accounts not appearing in the subcalls property of TransactionReceipts ([#1106](https://github.com/eth-brownie/brownie/pull/1106))
 
+### Added
+- Added `LocalAccount.sign_message` method to sign `EIP712Message` objects ([#1097](https://github.com/eth-brownie/brownie/pull/1097))
+
 ## [1.14.6](https://github.com/eth-brownie/brownie/tree/v1.14.5) - 2021-04-20
 ### Changed
 - Upgraded web3 dependency to version 5.18.0 ([#1064](https://github.com/eth-brownie/brownie/pull/1064))

--- a/docs/account-management.rst
+++ b/docs/account-management.rst
@@ -94,6 +94,30 @@ To do so, add the account to the ``unlock`` setting in a project's :ref:`configu
 The unlocked accounts are automatically added to the :func:`Accounts <brownie.network.account.Accounts>` container.
 Note that you might need to fund the unlocked accounts manually.
 
+Signing Messages
+================
+
+To sign an `EIP712Message <https://pypi.org/project/eip712/>`_, use the :func:`LocalAccount.sign_message <brownie.network.account.LocalAccount.sign_message>` method to produce an ``eth_account`` `SignableMessage <https://eth-account.readthedocs.io/en/stable/eth_account.html#eth_account.messages.SignableMessage>`_ object:
+
+.. code-block:: python
+
+    >>> from eip712.messages import EIP712Message, EIP712Type
+    >>> local = accounts.add(private_key="0x416b8a7d9290502f5661da81f0cf43893e3d19cb9aea3c426cfb36e8186e9c09")
+    >>> class TestSubType(EIP712Type):
+    ...     inner: "uint256"
+    ...
+    >>> class TestMessage(EIP712Message):
+    ...     _name_: "string" = "Brownie Test Message"
+    ...     outer: "uint256"
+    ...     sub: TestSubType
+    ...
+    >>> msg = TestMessage(outer=1, sub=TestSubType(inner=2))
+    >>> signed = local.sign_message(msg)
+    >>> type(signed)
+    <class 'eth_account.datastructures.SignedMessage'>
+    >>> signed.messageHash.hex()
+    '0x2a180b353c317ae903c063141592ec360b25be9f75c60ae16ca19f5578f70a50'
+
 Using a Hardware Wallet
 =======================
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,5 @@
 black==20.8b1
+eip712<0.2.0
 eth-abi<3
 eth-account<1
 eth-event>=1.2.1,<2

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,9 +31,14 @@ cytoolz==0.11.0
     # via
     #   eth-keyfile
     #   eth-utils
+dataclassy==0.10.2
+    # via eip712
+eip712==0.1.0
+    # via -r requirements.in
 eth-abi==2.1.1
     # via
     #   -r requirements.in
+    #   eip712
     #   eth-account
     #   eth-event
     #   web3
@@ -59,6 +64,7 @@ eth-rlp==0.2.1
     # via eth-account
 eth-typing==2.2.2
     # via
+    #   eip712
     #   eth-abi
     #   eth-keys
     #   eth-utils
@@ -66,6 +72,7 @@ eth-typing==2.2.2
 eth-utils==1.10.0
     # via
     #   -r requirements.in
+    #   eip712
     #   eth-abi
     #   eth-account
     #   eth-event
@@ -80,6 +87,7 @@ execnet==1.8.0
 hexbytes==0.2.1
     # via
     #   -r requirements.in
+    #   eip712
     #   eth-account
     #   eth-event
     #   eth-rlp
@@ -135,6 +143,7 @@ py==1.10.0
     #   pytest-forked
 pycryptodome==3.10.1
     # via
+    #   eip712
     #   eth-hash
     #   eth-keyfile
     #   vyper

--- a/tests/network/account/test_accounts.py
+++ b/tests/network/account/test_accounts.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
-
 import pytest
+from eip712.messages import EIP712Message, EIP712Type
+from eth_account.datastructures import SignedMessage
 
 from brownie.exceptions import UnknownAccount
 from brownie.network.account import LocalAccount
@@ -131,3 +132,23 @@ def test_mnemonic_offset_multiple(accounts):
         "0x44302d4c1e535b4FB77bc390e3053586ecA411b0",
         "0x1F413d7E7B85E557D9997E6714479C7848A9Ea07",
     ]
+
+
+def test_sign_message(accounts):
+    class TestSubType(EIP712Type):
+        inner: "uint256"  # type: ignore # noqa: F821
+
+    class TestMessage(EIP712Message):
+        _name_: "string" = "Brownie Tests"  # type: ignore # noqa: F821
+        value: "uint256"  # type: ignore # noqa: F821
+        default_value: "address" = "0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF"  # type: ignore # noqa: F821,E501
+        sub: TestSubType
+
+    local = accounts.add(priv_key)
+    msg = TestMessage(value=1, sub=TestSubType(inner=2))
+    signed = local.sign_message(msg)
+    assert isinstance(signed, SignedMessage)
+    assert (
+        signed.messageHash.hex()
+        == "0x131c497d4b815213752a2a00564dcf667c3bf3f85a410ef8cb50050b51959c26"
+    )


### PR DESCRIPTION
This change adds a dependency for the `eip712` package and uses it to implement a new `LocalAccount.sign_message` method.

### What I did

Related issue: https://github.com/ApeWorX/eip712/issues/4

### How I did it

Added the `eip712` dependency to `requirements.in`, used `pip-compile` to update `requirements.txt`, used that new package to implement the `LocalAccount.sign_message` method, wrote a new test that defines an `EIP712Message` and signs it using a local account with a private key loaded, verified the test result, ran lint & other pre-commit steps, added docs, added entry in the changelog.

### How to verify it

I wrote a new test alongside the existing `LocalAccount` tests in `test_accounts.py`

```
$ pytest -k test_sign_message 
...
== 1 passed in 12.87s ==
```

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [x] I have updated the documentation
- [x] I have added an entry to the changelog
