### PR TITLE
fix: do not assume last nonce == highest nonce

### DIFF
--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -334,7 +334,7 @@ class _PrivateKeyAccount(PublicKeyAccount):
         super().__init__(addr)
 
     def _pending_nonce(self) -> int:
-        tx_from_sender = history.from_sender(self.address)
+        tx_from_sender = sorted(history.from_sender(self.address), key=lambda k: k.nonce)
         if len(tx_from_sender) == 0:
             return self.nonce
 


### PR DESCRIPTION
### What I did
Fix an issue where an incorrect nonce can be used when creating multiple tx's with gas strategies.

### How I did it
Instead of simply assuming the last tx within `history` is the highest nonce, actually sort by nonce to make sure the highest one is used.