### PR TITLE
Support for clef as an account signer

### DIFF
--- a/docs/account-management.rst
+++ b/docs/account-management.rst
@@ -93,3 +93,22 @@ To do so, add the account to the ``unlock`` setting in a project's :ref:`configu
 
 The unlocked accounts are automatically added to the :func:`Accounts <brownie.network.account.Accounts>` container.
 Note that you might need to fund the unlocked accounts manually.
+
+Using a Hardware Wallet
+=======================
+
+Brownie allows the use of hardware wallets via `Clef <https://geth.ethereum.org/docs/clef/tutorial>`_, an account management tool included within `Geth <https://geth.ethereum.org/>`_.
+
+To use a hardware wallet in Brownie, start by `installing Geth <https://geth.ethereum.org/docs/install-and-build/installing-geth>`_. Once finished, type the following command and follow the on-screen prompts to set of Clef:
+
+    ::
+
+        clef init
+
+Once Clef is configured, run Brownie in one command prompt and Clef in another. From within Brownie:
+
+    .. code-block:: python
+
+        >>> accounts.connect_to_clef()
+
+Again, follow the prompts in Clef to unlock the accounts in Brownie. You can now use the unlocked accounts as you would any other account.  Note that you will have to authorize each transaction made with a :func:`ClefAccount <brownie.network.account.ClefAccount>` from within clef.

--- a/docs/account-management.rst
+++ b/docs/account-management.rst
@@ -10,18 +10,18 @@ When we use the term `local` it implies that the account exists locally on your 
 
 You can manage your locally available accounts via the commandline:
 
-::
+    ::
 
-    $ brownie accounts
+        $ brownie accounts
 
 Generating a New Account
 ========================
 
 To generate a new account using the command line:
 
-::
+    ::
 
-    $ brownie accounts generate <id>
+        $ brownie accounts generate <id>
 
 You will be asked to choose a password for the account. Brownie will then generate a random private key, and make the account available as ``<id>``.
 
@@ -30,9 +30,9 @@ Importing from a Private Key
 
 To add a new account via private key:
 
-::
+    ::
 
-    $ brownie accounts new <id>
+        $ brownie accounts new <id>
 
 You will be asked to input the private key, and to choose a password. The account will then be available as ``<id>``.
 
@@ -41,9 +41,9 @@ Importing from a Keystore
 
 You can import an existing JSON keystore into Brownie using the commandline:
 
-::
+    ::
 
-    $ brownie accounts import <id> <path>
+        $ brownie accounts import <id> <path>
 
 Once imported the account is available as ``<id>``.
 
@@ -52,9 +52,9 @@ Exporting a Keystore
 
 To export an existing account as a JSON keystore file:
 
-::
+    ::
 
-    $ brownie accounts export <id> <path>
+        $ brownie accounts export <id> <path>
 
 The exported account will be saved at ``<path>``.
 
@@ -63,16 +63,16 @@ Unlocking Accounts
 
 In order to access a local account from a script or console, you must first unlock it. This is done via the :func:`Accounts.load <Accounts.load>` method:
 
-.. code-block:: python
+    .. code-block:: python
 
-    >>> accounts
-    []
-    >>> accounts.load(id)
-    >>> accounts.load('my_account')
-    Enter the password for this account:
-    <LocalAccount object '0xa9c2DD830DfFE8934fEb0A93BAbcb6e823e1FF05'>
-    >>> accounts
-    [<LocalAccount object '0xa9c2DD830DfFE8934fEb0A93BAbcb6e823e1FF05'>]
+        >>> accounts
+        []
+        >>> accounts.load(id)
+        >>> accounts.load('my_account')
+        Enter the password for this account:
+        <LocalAccount object '0xa9c2DD830DfFE8934fEb0A93BAbcb6e823e1FF05'>
+        >>> accounts
+        [<LocalAccount object '0xa9c2DD830DfFE8934fEb0A93BAbcb6e823e1FF05'>]
 
 Once the account is unlocked it will be available for use within the :func:`Accounts <brownie.network.account.Accounts>` container.
 
@@ -82,14 +82,14 @@ Unlocking Accounts on Development Networks
 On a local or forked development network you can unlock and use any account, even if you don't have the corresponding private key.
 To do so, add the account to the ``unlock`` setting in a project's :ref:`configuration file<config>`:
 
-.. code-block:: yaml
+    .. code-block:: yaml
 
-        networks:
-            development:
-                cmd_settings:
-                    unlock:
-                        - 0x7E1E3334130355799F833ffec2D731BCa3E68aF6
-                        - 0x0063046686E46Dc6F15918b61AE2B121458534a5
+            networks:
+                development:
+                    cmd_settings:
+                        unlock:
+                            - 0x7E1E3334130355799F833ffec2D731BCa3E68aF6
+                            - 0x0063046686E46Dc6F15918b61AE2B121458534a5
 
 The unlocked accounts are automatically added to the :func:`Accounts <brownie.network.account.Accounts>` container.
 Note that you might need to fund the unlocked accounts manually.

--- a/docs/api-network.rst
+++ b/docs/api-network.rst
@@ -228,6 +228,30 @@ Accounts Methods
 
         >>> accounts.remove('0xc1826925377b4103cC92DeeCDF6F96A03142F37a')
 
+.. py:classmethod:: Accounts.connect_to_clef(uri=None, timeout=120)
+
+    Connect to clef and add unlocked accounts to the container as :func:`ClefAccount <brownie.network.account.ClefAccount>` objects.
+
+    `Clef <https://geth.ethereum.org/docs/clef/tutorial>`_ is an account signing utility packaged with Geth, which can be used to interact with hardware wallets in Brownie. Before calling this function, Clef must be running and unlocked in another command prompt.
+
+    * ``uri``: IPC path or http url to use to connect to clef. If ``None``, uses clef's default IPC path on Unix systems or ``http://localhost:8550/`` on Windows.
+    * ``timeout``: The number of seconds to wait for clef to respond to a request before raising a ``TimeoutError``.
+
+    .. code-block:: python
+
+        >>> accounts
+        []
+        >>> accounts.connect_to_clef()
+        >>> accounts
+        [<ClefAccount object '0x716E8419F2926d6AcE07442675F476ace972C580'>]
+
+.. py:classmethod:: Accounts.disconnect_from_clef()
+
+    Disconnect from Clef.
+
+    Removes all :func:`ClefAccount <brownie.network.account.ClefAccount>` objects from the container.
+
+
 Accounts Internal Methods
 *************************
 
@@ -454,6 +478,21 @@ LocalAccount Methods
         >>> accounts[-1].save('~/my_account.json')
         Enter the password to encrypt this account with:
         /home/computer/my_account.json
+
+ClefAccount
+------------
+
+.. py:class:: brownie.network.account.ClefAccount
+
+    Functionally identical to :func:`Account <brownie.network.account.Account>`. A ``ClefAccount`` object is used for accounts that have been unlocked via `clef <https://geth.ethereum.org/docs/clef/tutorial>`_, and where signing of transactions is handled externally from brownie. This is useful for hardware wallets.
+
+    .. code-block:: python
+
+        >>> accounts
+        []
+        >>> accounts.connect_to_clef()
+        >>> accounts
+        [<ClefAccount object '0x716E8419F2926d6AcE07442675F476ace972C580'>]
 
 PublicKeyAccount
 ----------------


### PR DESCRIPTION
### What I did
Add support for [`clef`](https://geth.ethereum.org/docs/clef/tutorial) as an account signer.  This makes it possible to use hardware wallets in Brownie.

### How I did it
* added the `ClefAccount` class to handle interactions with `clef`.
* `Accounts.connect_to_clef` and `Accounts.disconnect_from_clef` for connection/disconnection
* updated docs

### How to verify it
Try it! I've tested manually a bunch.. not sure how to best write unit tests.
