### PR TITLE
Fix: Subcalls to empty accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/eth-brownie/brownie)
 - Add polygon network integration ([#1119](https://github.com/eth-brownie/brownie/pull/1119))
+- Fixed subcalls to empty accounts not appearing in the subcalls property of TransactionReceipts ([#1106](https://github.com/eth-brownie/brownie/pull/1106))
+
 ## [1.14.6](https://github.com/eth-brownie/brownie/tree/v1.14.5) - 2021-04-20
 ### Changed
 - Upgraded web3 dependency to version 5.18.0 ([#1064](https://github.com/eth-brownie/brownie/pull/1064))

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -781,6 +781,7 @@ class TransactionReceipt:
         last_map = {0: _get_last_map(self.receiver, self.input[:10])}  # type: ignore
         coverage_eval: Dict = {last_map[0]["name"]: {}}
 
+        datacopy_precompile = "0x0000000000000000000000000000000000000004"
         call_opcodes = ("CALL", "STATICCALL", "DELEGATECALL")
         for i in range(len(trace)):
             # if depth has increased, tx has called into a different contract
@@ -823,6 +824,10 @@ class TransactionReceipt:
                         self._subcalls[-1]["calldata"] = calldata.hex()
                 elif calldata:
                     self._subcalls[-1]["calldata"] = calldata.hex()
+
+                if str(self._subcalls[-1]["from"]) == datacopy_precompile:
+                    caller = self._subcalls.pop(-2)["from"]
+                    self._subcalls[-1]["from"] = caller
 
             # update trace from last_map
             last = last_map[trace[i]["depth"]]

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -271,7 +271,8 @@ class TransactionReceipt:
     def subcalls(self) -> Optional[List]:
         if self._subcalls is None:
             self._expand_trace()
-        return self._subcalls
+        subcalls = filter(lambda s: not _is_call_to_data_copy(s), self._subcalls)  # type: ignore
+        return list(subcalls)
 
     @trace_property
     def trace(self) -> Optional[List]:
@@ -785,7 +786,9 @@ class TransactionReceipt:
         call_opcodes = ("CALL", "STATICCALL", "DELEGATECALL")
         for i in range(len(trace)):
             # if depth has increased, tx has called into a different contract
-            if trace[i]["depth"] > trace[i - 1]["depth"] or trace[i - 1]["op"] in call_opcodes:
+            is_depth_increase = trace[i]["depth"] > trace[i - 1]["depth"]
+            is_subcall = trace[i - 1]["op"] in call_opcodes
+            if is_depth_increase or is_subcall:
                 step = trace[i - 1]
                 if step["op"] in ("CREATE", "CREATE2"):
                     # creating a new contract
@@ -805,15 +808,16 @@ class TransactionReceipt:
                     sig = calldata[:4].hex()
                     address = step["stack"][-2][-40:]
 
-                last_map[trace[i]["depth"]] = _get_last_map(address, sig)
-                coverage_eval.setdefault(last_map[trace[i]["depth"]]["name"], {})
+                if is_depth_increase:
+                    last_map[trace[i]["depth"]] = _get_last_map(address, sig)
+                    coverage_eval.setdefault(last_map[trace[i]["depth"]]["name"], {})
 
                 self._subcalls.append(
                     {"from": step["address"], "to": EthAddress(address), "op": step["op"]}
                 )
                 if step["op"] in ("CALL", "CALLCODE"):
                     self._subcalls[-1]["value"] = int(step["stack"][-3], 16)
-                if calldata and last_map[trace[i]["depth"]].get("function"):
+                if is_depth_increase and calldata and last_map[trace[i]["depth"]].get("function"):
                     fn = last_map[trace[i]["depth"]]["function"]
                     self._subcalls[-1]["function"] = fn._input_sig
                     try:
@@ -822,8 +826,8 @@ class TransactionReceipt:
                         self._subcalls[-1]["inputs"] = inputs
                     except Exception:
                         self._subcalls[-1]["calldata"] = calldata.hex()
-                elif calldata:
-                    self._subcalls[-1]["calldata"] = calldata.hex()
+                elif calldata or is_subcall:
+                    self._subcalls[-1]["calldata"] = calldata.hex()  # type: ignore
 
                 if str(self._subcalls[-1]["from"]) == datacopy_precompile:
                     caller = self._subcalls.pop(-2)["from"]
@@ -1359,3 +1363,7 @@ def _get_last_map(address: EthAddress, sig: str) -> Dict:
         last_map.update(contract=None, internal_calls=[f"<UnknownContract>.{sig}"], pc_map=None)
 
     return last_map
+
+
+def _is_call_to_data_copy(subcall: dict) -> bool:
+    return str(subcall["to"]) == "0x0000000000000000000000000000000000000004"

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -781,9 +781,10 @@ class TransactionReceipt:
         last_map = {0: _get_last_map(self.receiver, self.input[:10])}  # type: ignore
         coverage_eval: Dict = {last_map[0]["name"]: {}}
 
+        call_opcodes = ("CALL", "STATICCALL", "DELEGATECALL")
         for i in range(len(trace)):
             # if depth has increased, tx has called into a different contract
-            if trace[i]["depth"] > trace[i - 1]["depth"]:
+            if trace[i]["depth"] > trace[i - 1]["depth"] or trace[i - 1]["op"] in call_opcodes:
                 step = trace[i - 1]
                 if step["op"] in ("CREATE", "CREATE2"):
                     # creating a new contract

--- a/tests/network/transaction/test_subcalls.py
+++ b/tests/network/transaction/test_subcalls.py
@@ -48,7 +48,7 @@ def foo_delegatecall():
 
 @pytest.fixture()
 def solidity_contract(accounts):
-    container = compile_source(solidity_source, solc_version="0.6.12")
+    container = compile_source(solidity_source)
     return container.Foo.deploy({"from": accounts[0]})
 
 

--- a/tests/network/transaction/test_subcalls.py
+++ b/tests/network/transaction/test_subcalls.py
@@ -1,0 +1,83 @@
+import pytest
+
+from brownie import compile_source
+
+solidity_source = """
+pragma solidity >=0.6.0;
+
+contract Foo {
+    address constant TARGET = 0xD0660cD418a64a1d44E9214ad8e459324D8157f1;
+
+    function foo_call() external {
+        TARGET.call(abi.encodeWithSignature("bar()"));
+    }
+
+    function foo_staticcall() external {
+        TARGET.staticcall(abi.encodeWithSignature("bar()"));
+    }
+
+    function foo_delegatecall() external {
+        TARGET.delegatecall(abi.encodeWithSignature("bar()"));
+    }
+}
+"""
+
+
+vyper_source = """
+# @version 0.2.12
+
+
+TARGET: constant(address) = 0xD0660cD418a64a1d44E9214ad8e459324D8157f1
+
+
+@external
+def foo_call():
+    raw_call(TARGET, method_id("bar()"))
+
+
+@external
+def foo_staticcall():
+    raw_call(TARGET, method_id("bar()"), is_static_call=True)
+
+
+@external
+def foo_delegatecall():
+    raw_call(TARGET, method_id("bar()"), is_delegate_call=True)
+"""
+
+
+@pytest.fixture()
+def solidity_contract(accounts):
+    container = compile_source(solidity_source, solc_version="0.6.12")
+    return container.Foo.deploy({"from": accounts[0]})
+
+
+@pytest.fixture()
+def vyper_contract(accounts):
+    container = compile_source(vyper_source, vyper_version="0.2.12").Vyper
+    return container.deploy({"from": accounts[0]})
+
+
+@pytest.fixture(params=[True, False], ids=["SolFoo", "VyFoo"])
+def foo_contract(request, solidity_contract, vyper_contract):
+    return solidity_contract if request.param else vyper_contract
+
+
+@pytest.mark.parametrize("low_level_method", ["call", "staticcall", "delegatecall"])
+def test_calls_to_empty_accounts(foo_contract, low_level_method):
+    method = f"foo_{low_level_method}"
+    tx = getattr(foo_contract, method).transact()
+
+    expected_dict = {
+        "from": foo_contract.address,
+        "to": "0xD0660cD418a64a1d44E9214ad8e459324D8157f1",
+        "op": low_level_method.upper(),
+        "calldata": "0xfebb0f7e",  # keccak256("bar()")[:4]
+    }
+
+    # call opcode transmits value as well
+    if low_level_method == "call":
+        expected_dict["value"] = 0
+
+    assert len(tx.subcalls) == 1
+    assert tx.subcalls[-1] == expected_dict


### PR DESCRIPTION
### What I did

Minor patch of the logic in transactions.py to handle direct calls/staticcalls/delegatecalls to empty accounts. 

Fixes #1105 

### How I did it

Added to the if statement that determines whether a call is being made to a contract, and handled calls to the datacopy address from vyper.

### How to verify it

There is a parameterized test verifying functionality in both solidity and vyper contracts.

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [x] I have added an entry to the changelog
