### PR TITLE
don't crash on solidity 0.8.4 typed errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed subcalls to empty accounts not appearing in the subcalls property of TransactionReceipts ([#1106](https://github.com/eth-brownie/brownie/pull/1106))
 - Add support for `POLYGONSCAN_TOKEN` env var ([#1135](https://github.com/eth-brownie/brownie/pull/1135))
 - Add Multicall context manager ([#1125](https://github.com/eth-brownie/brownie/pull/1125))
+- Add initial support for Solidity 0.8's typed errors ([#1110](https://github.com/eth-brownie/brownie/pull/1110))
 
 ### Added
 - Added `LocalAccount.sign_message` method to sign `EIP712Message` objects ([#1097](https://github.com/eth-brownie/brownie/pull/1097))

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -661,7 +661,7 @@ class TransactionReceipt:
                         self._revert_msg = SOLIDITY_ERROR_CODES[error_code]
                     else:
                         self._revert_msg = f"Panic (error code: {error_code})"
-                elif selector == "0x08c379a0":
+                elif selector == "0x08c379a0":  # keccak of Error(string)
                     self._revert_msg = decode_abi(["string"], data[4:])[0]
                 else:
                     # TODO: actually parse the data


### PR DESCRIPTION
### What I did

Solidity now has typed errors. This keeps parsing them from crashing brownie.

We can figure  out actually parsing them in this PR or merge this and do that later.

### How I did it

Check for the string selector before trying to parse as a string

### How to verify it

revert with the new typed errors.

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [ ] I have updated the documentation
- [x] I have added an entry to the changelog
