### PR TITLE
docs: fix typo in quickstart section

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -4,7 +4,7 @@
 Quickstart
 ==========
 
-This page provides a quick overview of how to use Brownie. It relies mostly on examples and assumes a level of familiarity with Python and smart contract dvelopment. For more in-depth content, you should read the documentation sections under "Getting Started" in the table of contents.
+This page provides a quick overview of how to use Brownie. It relies mostly on examples and assumes a level of familiarity with Python and smart contract development. For more in-depth content, you should read the documentation sections under "Getting Started" in the table of contents.
 
 If you have any questions about how to use Brownie, feel free to ask on `Ethereum StackExchange <https://ethereum.stackexchange.com/>`_ or join us on `Gitter <https://gitter.im/eth-brownie/community>`_.
 


### PR DESCRIPTION
### What I did

Fixess a small typo in the Quickstart section of the `docs`

Related issue: #

### How I did it

Simply changed the text.

### How to verify it

Navigate to `https://eth-brownie.readthedocs.io/en/stable/quickstart.html` to check the typo.

### Checklist

- [X] I have confirmed that my PR passes all linting checks
- [X] I have included test cases
- [X] I have updated the documentation
- [X] I have added an entry to the changelog
