### PR TITLE
Add support for `POLYGONSCAN_TOKEN` env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/eth-brownie/brownie)
 - Add polygon network integration ([#1119](https://github.com/eth-brownie/brownie/pull/1119))
 - Fixed subcalls to empty accounts not appearing in the subcalls property of TransactionReceipts ([#1106](https://github.com/eth-brownie/brownie/pull/1106))
+- Add support for `POLYGONSCAN_TOKEN` env var ([#1135](https://github.com/eth-brownie/brownie/pull/1135))
 
 ### Added
 - Added `LocalAccount.sign_message` method to sign `EIP712Message` objects ([#1097](https://github.com/eth-brownie/brownie/pull/1097))

--- a/brownie/data/network-config.yaml
+++ b/brownie/data/network-config.yaml
@@ -64,9 +64,9 @@ live:
         explorer: https://api.ftmscan.com/api
   - name: Polygon
     networks:
-      - name: Mainnet
+      - name: Mainnet (Infura)
         chainid: 137
-        id: polygon-main (Infura)
+        id: polygon-main
         host: https://polygon-mainnet.infura.io/v3/$WEB3_INFURA_PROJECT_ID
         explorer: https://api.polygonscan.com/api
       - name: Mumbai Testnet (Infura)

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -376,7 +376,11 @@ class ContractContainer(_ContractBase):
         """Flatten contract and publish source on the selected explorer"""
 
         # Check required conditions for verifying
-        explorer_tokens = {"etherscan": "ETHERSCAN_TOKEN", "bscscan": "BSCSCAN_TOKEN"}
+        explorer_tokens = {
+            "etherscan": "ETHERSCAN_TOKEN",
+            "bscscan": "BSCSCAN_TOKEN",
+            "polygonscan": "POLYGONSCAN_TOKEN",
+        }
         url = CONFIG.active_network.get("explorer")
         if url is None:
             raise ValueError("Explorer API not set for this network")
@@ -1876,6 +1880,16 @@ def _fetch_from_explorer(address: str, action: str, silent: bool) -> Dict:
                 "No BSCScan API token set. You may experience issues with rate limiting. "
                 "Visit https://bscscan.com/register to obtain a token, and then store it "
                 "as the environment variable $BSCSCAN_TOKEN",
+                BrownieEnvironmentWarning,
+            )
+    elif "polygonscan" in url:
+        if os.getenv("POLYGONSCAN_TOKEN"):
+            params["apiKey"] = os.getenv("POLYGONSCAN_TOKEN")
+        elif not silent:
+            warnings.warn(
+                "No PolygonScan API token set. You may experience issues with rate limiting. "
+                "Visit https://polygonscan.com/register to obtain a token, and then store it "
+                "as the environment variable $POLYGONSCAN_TOKEN",
                 BrownieEnvironmentWarning,
             )
 


### PR DESCRIPTION
### What I did
- Add support for `POLYGONSCAN_TOKEN` 
-  Fix `id` of Polygon Mainnet to make `polygon-main-fork` work

### How I did it
Copied code of etherscan/bscscan. Not sure if this could be made more elegant

### How to verify it
Launch `polygon-main-fork` network and fetch/call contracts.

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have added an entry to the changelog
