### PR TITLE
feat: XDai support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for `POLYGONSCAN_TOKEN` env var ([#1135](https://github.com/eth-brownie/brownie/pull/1135))
 - Add Multicall context manager ([#1125](https://github.com/eth-brownie/brownie/pull/1125))
 - Add initial support for Solidity 0.8's typed errors ([#1110](https://github.com/eth-brownie/brownie/pull/1110))
+- Add xdai network integration ([#1136](https://github.com/eth-brownie/brownie/pull/1136))
 
 ### Added
 - Added `LocalAccount.sign_message` method to sign `EIP712Message` objects ([#1097](https://github.com/eth-brownie/brownie/pull/1097))

--- a/brownie/data/network-config.yaml
+++ b/brownie/data/network-config.yaml
@@ -81,6 +81,18 @@ live:
         host: https://polygon-mumbai.infura.io/v3/$WEB3_INFURA_PROJECT_ID
         explorer: https://api-testnet.polygonscan.com/api
         multicall2: "0x6842E0412AC1c00464dc48961330156a07268d14"
+  - name: XDai
+    networks:
+      - name: Mainnet
+        chainid: 100
+        id: xdai-main
+        host: https://xdai.poanetwork.dev
+        explorer: https://blockscout.com/xdai/mainnet/api
+      - name: Testnet
+        chainid: 77
+        id: xdai-test
+        host: https://sokol.poa.network
+        explorer: https://blockscout.com/poa/sokol/api
 
 development:
   - name: Ganache-CLI
@@ -147,3 +159,15 @@ development:
       evm_version: istanbul
       mnemonic: brownie
       fork: polygon-main
+  - name: Ganache-CLI (XDai-Mainnet Fork)
+    id: xdai-main-fork
+    cmd: ganache-cli
+    host: http://127.0.0.1
+    timeout: 120
+    cmd_settings:
+      port: 8545
+      gas_limit: 20000000
+      accounts: 10
+      evm_version: istanbul
+      mnemonic: brownie
+      fork: xdai-main

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -113,11 +113,12 @@ class _ContractBase:
         if not isinstance(calldata, HexBytes):
             calldata = HexBytes(calldata)
 
+        fn_selector = calldata[:4].hex()  # type: ignore
         abi = next(
             (
                 i
                 for i in self.abi
-                if i["type"] == "function" and build_function_selector(i) == calldata[:4].hex()
+                if i["type"] == "function" and build_function_selector(i) == fn_selector
             ),
             None,
         )
@@ -713,11 +714,12 @@ class InterfaceConstructor:
         if not isinstance(calldata, HexBytes):
             calldata = HexBytes(calldata)
 
+        fn_selector = calldata[:4].hex()  # type: ignore
         abi = next(
             (
                 i
                 for i in self.abi
-                if i["type"] == "function" and build_function_selector(i) == calldata[:4].hex()
+                if i["type"] == "function" and build_function_selector(i) == fn_selector
             ),
             None,
         )
@@ -1893,7 +1895,6 @@ def _fetch_from_explorer(address: str, action: str, silent: bool) -> Dict:
                 "as the environment variable $POLYGONSCAN_TOKEN",
                 BrownieEnvironmentWarning,
             )
-
     if not silent:
         print(
             f"Fetching source of {color('bright blue')}{address}{color} "

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -1176,6 +1176,14 @@ class Contract(_DeployedContractBase):
                     BrownieCompilerWarning,
                 )
             return cls.from_abi(name, address, abi, owner)
+        elif data["result"][0]["OptimizationUsed"] in ("true", "false"):
+            if not silent:
+                warnings.warn(
+                    f"Blockscout explorer API has limited support by Brownie. "  # noqa
+                    "Some debugging functionality will not be available.",
+                    BrownieCompilerWarning,
+                )
+            return cls.from_abi(name, address, abi, owner)
 
         optimizer = {
             "enabled": bool(int(data["result"][0]["OptimizationUsed"])),

--- a/docs/network-management.rst
+++ b/docs/network-management.rst
@@ -235,6 +235,7 @@ Brownie natively supports the following collection of EVM-compatible chains:
 * Binance Smart Chain
 * Fantom Opera
 * Polygon Network
+* XDai Network
 
 In order to enable native support for an EVM-compatible chain, there are 2 requirements. The chain must have a JSON-RPC endpoint which is publicly accessible (free in cost, sign-up may be required), and it should have a block explorer with API support for fetching contract sources and ABIs.
 

--- a/tests/cli/test_cli_networks.py
+++ b/tests/cli/test_cli_networks.py
@@ -158,6 +158,7 @@ def test_delete_development():
         "bsc-main-fork",
         "ftm-main-fork",
         "polygon-main-fork",
+        "xdai-main-fork",
         "geth-dev",
     ):
         cli_networks._delete(network_name)


### PR DESCRIPTION
### What I did

Added Xdai to network config.
Enabled fetching ABI from blockscout api

Note: Although the blockscout api tries to be similar to etherscan, there are a few dis-similarities (mainly in naming conventions and return values)

Related issue: #934 

### How I did it

Handled the case when the explorer api is set to blockscout, easy to identify due to naming conventions and url

### How to verify it

Drop into a brownie console and try fetching the source of a contract. here is one: [0x22Bd2A732b39dACe37AE7E8f50A186f3D9702e87](https://blockscout.com/xdai/mainnet/address/0x22Bd2A732b39dACe37AE7E8f50A186f3D9702e87)

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have updated the documentation
- [x] I have added an entry to the changelog
