### PR TITLE
Bind GUI report dropdowns to currently displayed contract

### DIFF
--- a/brownie/_gui/report.py
+++ b/brownie/_gui/report.py
@@ -1,19 +1,41 @@
 #!/usr/bin/python3
 
 import warnings
+from pathlib import Path
 
 from .bases import SelectBox
 
 
 class ReportSelect(SelectBox):
     def __init__(self, parent):
-        super().__init__(parent, "(No Reports)", [])
+        super().__init__(parent, "", [])
+
+    def show(self):
+        self.grid()
+
+    def hide(self):
+        self.grid_remove()
+
+    def set_values(self, contract):
         reports = self._root().reports
-        if not reports:
+        values = []
+        for report in sorted(reports):
+            if contract in reports[report][report]:
+                values.append(report)
+
+        if not values:
+            self.set("(No Reports)")
             self.config(state="disabled")
+            self.root.toolbar.highlight_select.hide()
             return
-        self["values"] = ["None"] + sorted(reports)
-        self.set("Select Report")
+
+        self["values"] = ["None"] + values
+        self.config(state="readonly")
+        if self.root.report_key:
+            self.set(self.root.report_key)
+            self.root.toolbar.highlight_select.show()
+        else:
+            self.set("Select Report")
 
     def _select(self, event):
         value = super()._select()
@@ -53,7 +75,7 @@ class HighlightSelect(SelectBox):
             self.set("Report Type")
             return
         self.root.highlight_key = value
-        contract = self.root.get_active_contract()
+        contract = Path(self.root.main.note.active_frame()._label).stem.strip()
         if contract not in self.root.active_report[value]:
             return
         report = self.root.active_report[value][contract]

--- a/brownie/_gui/report.py
+++ b/brownie/_gui/report.py
@@ -34,6 +34,8 @@ class ReportSelect(SelectBox):
         if self.root.report_key:
             self.set(self.root.report_key)
             self.root.toolbar.highlight_select.show()
+            if self.root.highlight_key:
+                self.root.toolbar.highlight_select.update_highlights(self.root.highlight_key)
         else:
             self.set("Select Report")
 
@@ -70,6 +72,9 @@ class HighlightSelect(SelectBox):
 
     def _select(self, event):
         value = super()._select()
+        self.update_highlights(value)
+
+    def update_highlights(self, value):
         self.toggle_off()
         if value == "None":
             self.set("Report Type")

--- a/brownie/_gui/root.py
+++ b/brownie/_gui/root.py
@@ -63,9 +63,6 @@ class Root(tk.Tk):
     def active_report(self):
         return self.reports[self.report_key]["highlights"]
 
-    def get_active_contract(self):
-        return self.toolbar.combo.get()
-
     def set_active_contract(self, contract_name):
         build_json = self.active_project._build.get(contract_name)
         self.main.note.set_visible(sorted(build_json["allSourcePaths"].values()))
@@ -76,6 +73,8 @@ class Root(tk.Tk):
         for value in (v for v in self.pcMap.values() if "path" in v):
             if value["path"] not in self.pathMap:
                 value["path"] = self.pathMap[value["path"]]
+        self.toolbar.report.show()
+        self.toolbar.report.set_values(contract_name)
 
     def destroy(self):
         super().destroy()
@@ -131,6 +130,7 @@ class ToolbarFrame(ttk.Frame):
 
         self.report = ReportSelect(self)
         self.report.grid(row=0, column=9, sticky="nsew", padx=10)
+        self.report.hide()
         ToolTip(self.report, "Select a report to overlay onto the source code")
 
         # contract selection

--- a/brownie/_gui/root.py
+++ b/brownie/_gui/root.py
@@ -74,7 +74,8 @@ class Root(tk.Tk):
         self.pcMap = dict((str(k), v) for k, v in build_json["pcMap"].items())
         self.pathMap = build_json["allSourcePaths"]
         for value in (v for v in self.pcMap.values() if "path" in v):
-            value["path"] = self.pathMap[value["path"]]
+            if value["path"] not in self.pathMap:
+                value["path"] = self.pathMap[value["path"]]
 
     def destroy(self):
         super().destroy()

--- a/brownie/_gui/source.py
+++ b/brownie/_gui/source.py
@@ -29,6 +29,7 @@ class SourceNoteBook(ttk.Notebook):
             if path.suffix in (".sol", ".vy"):
                 self.add(path)
         self.set_visible([])
+        self.bind("<<NotebookTabChanged>>", self.on_tab_change)
 
     def add(self, path):
         path = Path(path)
@@ -61,6 +62,11 @@ class SourceNoteBook(ttk.Notebook):
             return
         frame._visible = True
         super().add(frame, text=f"   {label}   ")
+
+    def on_tab_change(self, event):
+        if self.select():
+            tab = event.widget.tab("current")["text"]
+            self.root.toolbar.report.set_values(Path(tab).stem.strip())
 
     def set_visible(self, labels):
         labels = [Path(i).name for i in labels]


### PR DESCRIPTION
Currently, the values of the report dropdowns in the brownie GUI are loaded once on startup and remain static afterwards. The values can be changed by the user, but neither the values nor the highlights are updated when another contract is selected - even if that contract has no corresponding report.

This can become inconvenient in different ways: 
- If someone is just starting to write tests or only running a specific subset of tests, when checking for coverage of branches or statements through the GUI, if no highlights are available for the selected contract it is not clear whether that is due to the absence of a report or to the tests failing to cover any part of the contract for that report type. 
- When switching between contracts, the report and report type dropdowns retain their previous values but the highlights themselves are cleared. One needs to reselect a report type (even if it is the same) to get the proper highlights for the current contract. This can likewise create confusion as it can easily appear that a specific report type has been selected and that tests have failed to cover any of the code in the contract.
- More of a cosmetic issue, but upon startup, one can select a report and highlight options without having selected a contract.

### What I did

I tied the report and report type values to the active tab of the tkinter notebook where the contract code is displayed. If no reports are available for the currently displayed contract, it is made explicit: the report dropdown displays "(No Report)" and becomes disabled. When one switches between tabs or contract, the dropdown values are updated depending on the availability of a report for said contract. When switching between two contracts that both have reports available, the user's selection of report type is retained but the highlights in the notebook are updated to those of the newly selected contract.

### How I did it

Made some modification to the dropdown's code to check that the currently displayed contract has a corresponding report. Linked the values to the active tab in the notebook in `source.py` rather than to the `get_active_contract()` method from the root.

### How to verify it

Run only a subset of a project's test suite so as not to cover all available contracts. Open brownie gui and navigate between the different contracts.

### Known issues

No tests (there are currently no tests for the gui)

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
