### PR TITLE
fix: add `no_call_coverage` as custom marker

### DIFF
--- a/brownie/test/managers/base.py
+++ b/brownie/test/managers/base.py
@@ -100,6 +100,9 @@ class PytestBrownieBase:
         config.addinivalue_line(
             "markers", "skip_coverage: skips a test when coverage evaluation is active"
         )
+        config.addinivalue_line(
+            "markers", "no_call_coverage: do not evaluate coverage for calls made during a test"
+        )
 
         for key in ("coverage", "always_transact"):
             CONFIG.argv[key] = config.getoption("--coverage")


### PR DESCRIPTION
### What I did
Add `no_call_coverage` as custom marker to fix a warning when running tests.