### PR TITLE
fix: support subpath in remappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/eth-brownie/brownie)
+- Add support remapping with a sub-folder (like OpenZeppelin/openzeppelin-contracts-upgradeable, ref: [#1137](https://github.com/eth-brownie/brownie/issues/1137))
 - Add polygon network integration ([#1119](https://github.com/eth-brownie/brownie/pull/1119))
 - Fixed subcalls to empty accounts not appearing in the subcalls property of TransactionReceipts ([#1106](https://github.com/eth-brownie/brownie/pull/1106))
 - Add support for `POLYGONSCAN_TOKEN` env var ([#1135](https://github.com/eth-brownie/brownie/pull/1135))

--- a/brownie/project/compiler/__init__.py
+++ b/brownie/project/compiler/__init__.py
@@ -206,15 +206,19 @@ def _get_solc_remappings(remappings: Optional[list]) -> list:
         remap_dict = dict([remappings.split("=")])
     else:
         remap_dict = dict(i.split("=") for i in remappings)
-
-    for path in _get_data_folder().joinpath("packages").iterdir():
+    remapped_dict = {}
+    packages = _get_data_folder().joinpath("packages")
+    for path in packages.iterdir():
         key = next((k for k, v in remap_dict.items() if v.startswith(path.name)), None)
         if key:
-            remap_dict[key] = path.parent.joinpath(remap_dict[key]).as_posix()
+            remapped_dict[key] = path.parent.joinpath(remap_dict.pop(key)).as_posix()
         else:
-            remap_dict[path.name] = path.as_posix()
+            remapped_dict[path.name] = path.as_posix()
+    for (k, v) in remap_dict.items():
+        if packages.joinpath(v).exists():
+            remapped_dict[k] = packages.joinpath(v).as_posix()
 
-    return [f"{k}={v}" for k, v in remap_dict.items()]
+    return [f"{k}={v}" for k, v in dict(remap_dict, **remapped_dict).items()]
 
 
 def _get_allow_paths(allow_paths: Optional[str], remappings: list) -> str:


### PR DESCRIPTION
### What I did

Fixes #1137

### How I did it

Add support for mappings to subfolders

### How to verify it

```yaml
compiler:
    solc:
        version: null
        optimizer:
            enabled: true
            runs: 31337
        remappings:
            - "@openzeppelin=OpenZeppelin/openzeppelin-contracts@3.4.0"
            - "@openzeppelin/contracts-upgradeable=OpenZeppelin/openzeppelin-contracts-upgradeable@3.4.0/contracts"
```

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [x] I have added an entry to the changelog
