### PR TITLE
Fixes around caching

### DIFF
--- a/brownie/network/middlewares/caching.py
+++ b/brownie/network/middlewares/caching.py
@@ -168,13 +168,18 @@ class RequestCachingMiddleware(BrownieMiddlewareABC):
                 time.sleep(1)
 
     def process_request(self, make_request: Callable, method: str, params: List) -> Dict:
-        # do not apply this middleware to filter updates or we'll die recursion death
-        # clientVersion is used to check connectivity so we also don't cache that
         if method in (
+            # caching any of these means we die of recursion death so let's not do that
             "eth_getFilterChanges",
             "eth_newBlockFilter",
             "eth_uninstallFilter",
+            # used to check connectivity
             "web3_clientVersion",
+            # caching these causes weirdness with transaction replacement
+            "eth_sendTransaction",
+            "eth_sendRawTransaction",
+            "eth_sign",
+            "eth_signTransaction",
         ):
             return make_request(method, params)
 

--- a/brownie/network/middlewares/caching.py
+++ b/brownie/network/middlewares/caching.py
@@ -2,7 +2,7 @@ import json
 import threading
 import time
 from collections import OrderedDict
-from typing import Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from hexbytes import HexBytes
 from web3 import Web3
@@ -83,6 +83,16 @@ def is_cacheable_bytecode(web3: Web3, bytecode: HexBytes) -> bool:
     return True
 
 
+def _new_filter(w3: Web3) -> Any:
+    # returns a filter if the client is connected and supports filtering
+    try:
+        block_filter = w3.eth.filter("latest")
+        block_filter.get_new_entries()
+        return block_filter
+    except (AttributeError, ValueError):
+        return None
+
+
 class RequestCachingMiddleware(BrownieMiddlewareABC):
 
     """
@@ -110,13 +120,7 @@ class RequestCachingMiddleware(BrownieMiddlewareABC):
 
     @classmethod
     def get_layer(cls, w3: Web3, network_type: str) -> Optional[int]:
-        if network_type == "live":
-            try:
-                # ensure that the node client supports filters
-                block_filter = w3.eth.filter("latest")
-                block_filter.get_new_entries()
-            except ValueError:
-                return None
+        if network_type == "live" and _new_filter(w3) is not None:
             return 0
         else:
             return None
@@ -142,11 +146,12 @@ class RequestCachingMiddleware(BrownieMiddlewareABC):
                     new_blocks = self.block_filter.get_new_entries()
                 except (AttributeError, ValueError):
                     # web3 has disconnected, or the filter has expired from inactivity
-                    if self.w3.isConnected():
-                        self.block_filter = self.w3.eth.filter("latest")
-                        continue
-                    else:
+                    # some public nodes allow a filter initially, but block it several seconds later
+                    block_filter = _new_filter(self.w3)
+                    if block_filter is None:
                         return
+                    self.block_filter = block_filter
+                    continue
 
                 if new_blocks:
                     self.block_cache[new_blocks[-1]] = {}


### PR DESCRIPTION
### What I did
Fixes related to caching:

* do not cache `eth_sendTransaction` and `eth_sendRawTransaction` responses - when combined with tx replacement this can leave the main thread stuck on a loop forever, waiting for a lock to release. Maybe related - #1115 
* gracefully handle any exceptions raised when creating a filter _after the initial filter was created successfully_. In some cases (looking at you, BSC) public nodes allow a filter to be created and queried several times, then disable and rate limit that specific endpoint. Related - #1159 

### How to verify it
Do stuff, see what breaks.
