### PR TITLE
bump `py-solc-ast`

### DIFF
--- a/requirements-windows.txt
+++ b/requirements-windows.txt
@@ -207,7 +207,7 @@ protobuf==3.17.3
     #   web3
 psutil==5.8.0
     # via -r requirements.txt
-py-solc-ast==1.2.8
+py-solc-ast==1.2.9
     # via -r requirements.txt
 py-solc-x==1.1.0
     # via -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -145,7 +145,7 @@ protobuf==3.17.3
     # via web3
 psutil==5.8.0
     # via -r requirements.in
-py-solc-ast==1.2.8
+py-solc-ast==1.2.9
     # via -r requirements.in
 py-solc-x==1.1.0
     # via -r requirements.in


### PR DESCRIPTION
### What I did
Bump `py-solc-ast` to `v1.2.9` which fixes an AST issue for `solc >=0.8.3`.

This _might_ solve one of more of the following issues: #1127, #1114, #1087, #1076
