### PR TITLE
fix: do not remove contract from coverage report if a function is missing statements or branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/eth-brownie/brownie)
 ### Fixed
 - Recursively kill all RPC child processes on exit ([#1200](https://github.com/eth-brownie/brownie/pull/1200))
-
-### Fixed
 - Issue with testing reverted contracts not found in deployment map ([#1195](https://github.com/eth-brownie/brownie/pull/1195))
+- Fix issue with missing contracts in coverage report ([#1178](https://github.com/eth-brownie/brownie/pull/1178))
 
 ## [1.16.0](https://github.com/eth-brownie/brownie/tree/v1.16.0) - 2021-08-08
 ### Added


### PR DESCRIPTION
### What I did

The previous behavior expects all functions to have a report for both
statements and branches. If not, it removes the whole contract from the
coverage report.
While the assumption seems reasonable, some functions seem to only have
either one of statements or branches, ending up in removing contracts
that would otherwise contain useful coverage information.

This is related to #1087 and should at least be a partial fix to it

### How I did it

Avoid excluding the contract when one of the functions in the contract was missing coverage information 

### How to verify it

Run the coverage report

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases - slightly tedious to recreate this in test but could be doable if needed
- [ ] I have updated the documentation - nothing to document here
- [x] I have added an entry to the changelog
