### PR TITLE
feat: eip1559 transactions support

### DIFF
--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -677,7 +677,7 @@ class _PrivateKeyAccount(PublicKeyAccount):
         gas_price: Optional[int],
         max_fee: Optional[int],
         priority_fee: Optional[int],
-        data: Optional[str],
+        data: str,
         nonce: Optional[int],
         fn_name: str,
         required_confs: int,
@@ -943,7 +943,7 @@ def _apply_fee_to_tx(
     gas_price: Optional[int] = None,
     max_fee: Optional[int] = None,
     priority_fee: Optional[int] = None,
-):
+) -> Dict:
     tx = tx.copy()
 
     if gas_price is not None:

--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -952,11 +952,14 @@ def _apply_fee_to_tx(
 
     if priority_fee is None:
         raise InvalidTransaction("priority_fee must be defined")
+    priority_fee = Wei(priority_fee)
 
     # no max_fee specified, infer from base_fee
     if max_fee is None:
         base_fee = Chain().base_fee
         max_fee = base_fee * 2 + priority_fee
+    else:
+        max_fee = Wei(max_fee)
 
     if priority_fee > max_fee:
         raise InvalidTransaction("priority_fee must not exceed max_fee")

--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -457,7 +457,9 @@ class _PrivateKeyAccount(PublicKeyAccount):
 
     def _check_for_revert(self, tx: Dict) -> None:
         try:
-            web3.eth.call(dict((k, v) for k, v in tx.items() if v))
+            # remove `gasPrice` to avoid issues post-EIP1559
+            # https://github.com/ethereum/go-ethereum/pull/23027
+            web3.eth.call(dict((k, v) for k, v in tx.items() if k != "gasPrice" and v))
         except ValueError as exc:
             msg = exc.args[0]["message"] if isinstance(exc.args[0], dict) else str(exc)
             raise ValueError(

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -38,7 +38,6 @@ from brownie.exceptions import (
     UndeployedLibrary,
     VirtualMachineError,
 )
-from brownie.network.account import _apply_fee_to_tx
 from brownie.project import compiler, ethpm
 from brownie.typing import AccountsType, TransactionReceiptType
 from brownie.utils import color
@@ -602,7 +601,7 @@ class ContractConstructor:
             *args,
             amount=tx["value"],
             gas_limit=tx["gas"],
-            gas_price=tx.get("gasPrice"),
+            gas_price=tx.get("gas_price"),
             max_fee=tx.get("max_fee"),
             priority_fee=tx.get("priority_fee"),
             nonce=tx["nonce"],
@@ -1568,7 +1567,7 @@ class _ContractMethod:
             tx["value"],
             gas_limit=tx["gas"],
             gas_buffer=tx.get("gas_buffer"),
-            gas_price=tx.get("gasPrice"),
+            gas_price=tx.get("gas_price"),
             max_fee=tx.get("max_fee"),
             priority_fee=tx.get("priority_fee"),
             nonce=tx["nonce"],
@@ -1771,12 +1770,10 @@ def _get_tx(owner: Optional[AccountsType], args: Tuple) -> Tuple:
     if args and isinstance(args[-1], dict):
         tx.update(args[-1])
         args = args[:-1]
-        for key, target in [("amount", "value"), ("gas_limit", "gas")]:
+        # key substitution to provide compatibility with web3.py
+        for key, target in [("amount", "value"), ("gas_limit", "gas"), ("gas_price", "gasPrice")]:
             if key in tx:
                 tx[target] = tx[key]
-        tx = _apply_fee_to_tx(
-            tx, tx.get("gas_price"), tx.get("max_fee"), tx.get("priority_fee")  # type: ignore
-        )
 
     # enable the magic of ganache's `evm_unlockUnknownAccount`
     if isinstance(tx["from"], str):

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -38,6 +38,7 @@ from brownie.exceptions import (
     UndeployedLibrary,
     VirtualMachineError,
 )
+from brownie.network.account import _apply_fee_to_tx
 from brownie.project import compiler, ethpm
 from brownie.typing import AccountsType, TransactionReceiptType
 from brownie.utils import color
@@ -601,7 +602,9 @@ class ContractConstructor:
             *args,
             amount=tx["value"],
             gas_limit=tx["gas"],
-            gas_price=tx["gasPrice"],
+            gas_price=tx.get("gasPrice"),
+            max_fee=tx.get("max_fee"),
+            priority_fee=tx.get("priority_fee"),
             nonce=tx["nonce"],
             required_confs=tx["required_confs"],
             publish_source=publish_source,
@@ -652,9 +655,7 @@ class ContractConstructor:
                 "includes a `from` field specifying the sender of the transaction"
             )
 
-        return tx["from"].estimate_gas(
-            amount=tx["value"], gas_price=tx["gasPrice"], data=self.encode_input(*args)
-        )
+        return tx["from"].estimate_gas(amount=tx["value"], data=self.encode_input(*args))
 
 
 class InterfaceContainer:
@@ -1566,8 +1567,10 @@ class _ContractMethod:
             self._address,
             tx["value"],
             gas_limit=tx["gas"],
-            gas_buffer=tx["gas_buffer"],
-            gas_price=tx["gasPrice"],
+            gas_buffer=tx.get("gas_buffer"),
+            gas_price=tx.get("gasPrice"),
+            max_fee=tx.get("max_fee"),
+            priority_fee=tx.get("priority_fee"),
             nonce=tx["nonce"],
             required_confs=tx["required_confs"],
             data=self.encode_input(*args),
@@ -1655,7 +1658,6 @@ class _ContractMethod:
         return tx["from"].estimate_gas(
             to=self._address,
             amount=tx["value"],
-            gas_price=tx["gasPrice"],
             data=self.encode_input(*args),
         )
 
@@ -1762,7 +1764,6 @@ def _get_tx(owner: Optional[AccountsType], args: Tuple) -> Tuple:
         "value": 0,
         "gas": None,
         "gas_buffer": None,
-        "gasPrice": None,
         "nonce": None,
         "required_confs": 1,
         "allow_revert": None,
@@ -1770,9 +1771,12 @@ def _get_tx(owner: Optional[AccountsType], args: Tuple) -> Tuple:
     if args and isinstance(args[-1], dict):
         tx.update(args[-1])
         args = args[:-1]
-        for key, target in [("amount", "value"), ("gas_limit", "gas"), ("gas_price", "gasPrice")]:
+        for key, target in [("amount", "value"), ("gas_limit", "gas")]:
             if key in tx:
                 tx[target] = tx[key]
+        tx = _apply_fee_to_tx(
+            tx, tx.get("gas_price"), tx.get("max_fee"), tx.get("priority_fee")  # type: ignore
+        )
 
     # enable the magic of ganache's `evm_unlockUnknownAccount`
     if isinstance(tx["from"], str):

--- a/brownie/network/state.py
+++ b/brownie/network/state.py
@@ -284,6 +284,11 @@ class Chain(metaclass=_Singleton):
             self._block_gas_time = block["timestamp"]
         return Wei(self._block_gas_limit)
 
+    @property
+    def base_fee(self) -> Wei:
+        block = web3.eth.get_block("latest")
+        return Wei(block.baseFeePerGas)
+
     def _revert(self, id_: int) -> int:
         rpc_client = rpc.Rpc()
         if web3.isConnected() and not web3.eth.block_number and not self._time_offset:

--- a/requirements-windows.txt
+++ b/requirements-windows.txt
@@ -35,7 +35,7 @@ bitarray==1.2.2
     # via
     #   -r requirements.txt
     #   eth-account
-black>=21.7b0
+black==21.7b0
     # via -r requirements.txt
 certifi==2021.5.30
     # via
@@ -73,7 +73,7 @@ eth-abi==2.1.1
     #   eth-account
     #   eth-event
     #   web3
-eth-account==0.5.4
+eth-account==0.5.5
     # via
     #   -r requirements.txt
     #   web3
@@ -334,7 +334,7 @@ wcwidth==0.2.5
     # via
     #   -r requirements.txt
     #   prompt-toolkit
-web3==5.21.0
+web3==5.22.0
     # via -r requirements.txt
 websockets==9.1
     # via

--- a/requirements.in
+++ b/requirements.in
@@ -26,5 +26,5 @@ semantic-version<3
 tqdm<5
 vvm>=0.1.0,<1
 vyper>=0.2.11,<1
-web3<6
+web3>=5.22.0,<6
 wrapt>=1.12.1,<2

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ base58==2.1.0
     # via multiaddr
 bitarray==1.2.2
     # via eth-account
-black>=21.7b0
+black==21.7b0
     # via -r requirements.in
 certifi==2021.5.30
     # via requests
@@ -47,7 +47,7 @@ eth-abi==2.1.1
     #   eth-account
     #   eth-event
     #   web3
-eth-account==0.5.4
+eth-account==0.5.5
     # via
     #   -r requirements.in
     #   web3
@@ -243,7 +243,7 @@ vyper==0.2.15
     # via -r requirements.in
 wcwidth==0.2.5
     # via prompt-toolkit
-web3==5.21.0
+web3==5.22.0
     # via -r requirements.in
 websockets==9.1
     # via web3


### PR DESCRIPTION
### What I did

Add support for specifying EIP-1559 style transactions.

### How I did it

`transact` method not accepts `max_fee` and `priority_fee` arguments which are mutually exclusive with legacy `gas_price` argument. I went for shorter names instead of `max_fee_per_gas` and `max_priority_fee_per_gas` to keep Brownie users' sanity.

It also adds `chain.base_fee` to look up the base fee of the latest block. It it used when a user only specifies `priority_fee`, in which case `max_fee` is inferred as `base_fee * 2 + priority_fee`, which should be enough to get the transaction through within 6 blocks of raising base fee (actually 1.125⁶ is needed, explore if that would be a better constant here).

### How to verify it

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
