### PR TITLE
Modifications to tx flow

### DIFF
--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -422,7 +422,7 @@ class TransactionReceipt:
                         self.status = Status(-2)
                         return
                 if not self._silent:
-                    sys.stdout.write(f"\r  Awaiting transaction in the mempool... {_marker[0]}")
+                    sys.stdout.write(f"  Awaiting transaction in the mempool... {_marker[0]}\r")
                     sys.stdout.flush()
                     _marker.rotate(1)
                 time.sleep(1)
@@ -431,7 +431,7 @@ class TransactionReceipt:
 
         if not self._silent:
             print(
-                f"\r  Gas price: {color('bright blue')}{self.gas_price / 10 ** 9}{color} gwei"
+                f"  Gas price: {color('bright blue')}{self.gas_price / 10 ** 9}{color} gwei"
                 f"   Gas limit: {color('bright blue')}{self.gas_limit}{color}"
                 f"   Nonce: {color('bright blue')}{self.nonce}{color}"
             )
@@ -477,15 +477,21 @@ class TransactionReceipt:
 
             if not block_number and not self._silent and required_confs > 0:
                 if required_confs == 1:
-                    sys.stdout.write(f"\rWaiting for confirmation... {_marker[0]}")
+                    sys.stdout.write(f"  Waiting for confirmation... {_marker[0]}\r")
                 else:
                     sys.stdout.write(
-                        f"\rRequired confirmations: {color('bright yellow')}0/"
-                        f"{required_confs}{color}   {_marker[0]}"
+                        f"  Required confirmations: {color('bright yellow')}0/"
+                        f"{required_confs}{color}   {_marker[0]}\r"
                     )
                 _marker.rotate(1)
                 sys.stdout.flush()
                 time.sleep(1)
+
+        # silence other dropped tx's immediately after confirmation to avoid output weirdness
+        for dropped_tx in state.TxHistory().filter(
+            sender=self.sender, nonce=self.nonce, key=lambda k: k != self
+        ):
+            dropped_tx._silent = True
 
         self.block_number = receipt["blockNumber"]
         # wait for more confirmations if required and handle uncle blocks

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -5,6 +5,7 @@ import re
 import sys
 import threading
 import time
+from collections import deque
 from enum import IntEnum
 from hashlib import sha1
 from pathlib import Path
@@ -14,7 +15,7 @@ import black
 import requests
 from eth_abi import decode_abi
 from hexbytes import HexBytes
-from web3.exceptions import TimeExhausted, TransactionNotFound
+from web3.exceptions import TransactionNotFound
 
 from brownie._config import CONFIG
 from brownie.convert import EthAddress, Wei
@@ -30,6 +31,8 @@ from brownie.utils.output import build_tree
 from . import state
 from .event import EventDict, _decode_logs, _decode_trace
 from .web3 import web3
+
+_marker = deque("-/|\\-/|\\")
 
 
 def trace_property(fn: Callable) -> Any:
@@ -418,13 +421,17 @@ class TransactionReceipt:
                     if sender_nonce > self.nonce:
                         self.status = Status(-2)
                         return
+                if not self._silent:
+                    sys.stdout.write(f"\r  Awaiting transaction in the mempool... {_marker[0]}")
+                    sys.stdout.flush()
+                    _marker.rotate(1)
                 time.sleep(1)
 
         self._set_from_tx(tx)
 
         if not self._silent:
             print(
-                f"  Gas price: {color('bright blue')}{self.gas_price / 10 ** 9}{color} gwei"
+                f"\r  Gas price: {color('bright blue')}{self.gas_price / 10 ** 9}{color} gwei"
                 f"   Gas limit: {color('bright blue')}{self.gas_limit}{color}"
                 f"   Nonce: {color('bright blue')}{self.nonce}{color}"
             )
@@ -439,32 +446,40 @@ class TransactionReceipt:
             confirm_thread.join()
 
     def _await_confirmation(self, block_number: int = None, required_confs: int = 1) -> None:
-        block_number = block_number or self.block_number
-        if not block_number and not self._silent and required_confs > 0:
-            if required_confs == 1:
-                sys.stdout.write("\rWaiting for confirmation... ")
-            else:
-                sys.stdout.write(
-                    f"\rRequired confirmations: {color('bright yellow')}0/{required_confs}{color}"
-                )
-            sys.stdout.flush()
-
         # await first confirmation
+        nonce_time = 0
+        block_number = block_number or self.block_number
         while True:
-            # if sender nonce is greater than tx nonce, the tx should be confirmed
-            sender_nonce = web3.eth.get_transaction_count(str(self.sender))
-            expect_confirmed = bool(sender_nonce > self.nonce)  # type: ignore
             try:
-                receipt = web3.eth.wait_for_transaction_receipt(
-                    HexBytes(self.txid), timeout=15, poll_latency=1
-                )
+                receipt = web3.eth.get_transaction_receipt(HexBytes(self.txid))
+            except TransactionNotFound:
+                receipt = None
+            # the null blockHash check is required for older versions of Parity
+            # taken from `web3._utils.transactions.wait_for_transaction_receipt`
+            if receipt is not None and receipt["blockHash"] is not None:
                 break
-            except TimeExhausted:
-                if expect_confirmed:
-                    # if we expected confirmation based on the nonce, tx likely dropped
+
+            # every 15 seconds check if the nonce increased without a confirmation of
+            # this specific transaction. if this happens, the tx has likely dropped
+            # and we should stop waiting.
+            if time.time() - nonce_time > 15:
+                sender_nonce = web3.eth.get_transaction_count(str(self.sender))
+                if sender_nonce > self.nonce:
                     self.status = Status(-2)
                     self._confirmed.set()
                     return
+
+            if not block_number and not self._silent and required_confs > 0:
+                if required_confs == 1:
+                    sys.stdout.write(f"\rWaiting for confirmation... {_marker[0]}")
+                else:
+                    sys.stdout.write(
+                        f"\rRequired confirmations: {color('bright yellow')}0/"
+                        f"{required_confs}{color}   {_marker[0]}"
+                    )
+                _marker.rotate(1)
+                sys.stdout.flush()
+                time.sleep(1)
 
         self.block_number = receipt["blockNumber"]
         # wait for more confirmations if required and handle uncle blocks


### PR DESCRIPTION
### What I did
Adjust the flow of logic around making a new transaction to reduce the likelihood of a threadlock. Also improves the verbosity with a tx to show when things are still working (particularly when the tx was broadcast but has not yet shown in the mempool).

### How I did it
The main thing happening here is removing the use of web3.py's `wait_for_transaction_receipt` and applying similar logic directly in brownie.  This gives us some more control over how everything is handled and allows the improved verbosity.

For the locks, I reduced the amount of logic inside the lock to only broadcasting the actual transaction.