### PR TITLE
fix: support eip1559 in undo buffer

### DIFF
--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -535,6 +535,8 @@ class _PrivateKeyAccount(PublicKeyAccount):
                         "gas_limit": gas_limit,
                         "gas_buffer": gas_buffer,
                         "gas_price": gas_price,
+                        "max_fee": max_fee,
+                        "priority_fee": priority_fee,
                     },
                 ),
                 daemon=True,
@@ -658,8 +660,17 @@ class _PrivateKeyAccount(PublicKeyAccount):
                 args=(
                     receipt,
                     self.transfer,
-                    (to, amount, gas_limit, gas_buffer, gas_price, data, None),
-                    {},
+                    [],
+                    {
+                        "to": to,
+                        "amount": amount,
+                        "gas_limit": gas_limit,
+                        "gas_buffer": gas_buffer,
+                        "gas_price": gas_price,
+                        "max_fee": max_fee,
+                        "priority_fee": priority_fee,
+                        "data": data,
+                    },
                 ),
                 daemon=True,
             )


### PR DESCRIPTION
### What I did
Fix a bug introduced in #1179 related to the undo buffer - incorrect args were being passed which broke `chain.redo` and the failing test went unnoticed because I'm a pleb.