### PR TITLE
Modify hardhat config to support london ruleset

### DIFF
--- a/brownie/network/rpc/hardhat.py
+++ b/brownie/network/rpc/hardhat.py
@@ -21,7 +21,10 @@ HARDHAT_CONFIG = """
 module.exports = {
     networks: {
         hardhat: {
-            hardfork: "berlin",
+            hardfork: "london",
+            // base fee of 0 allows use of 0 gas price when testing
+            initialBaseFeePerGas: 0,
+            // brownie expects calls and transactions to throw on revert
             throwOnTransactionFailures: true,
             throwOnCallFailures: true
        }


### PR DESCRIPTION
### What I did
Modify hardhat config to support london ruleset.

### How I did it
Set `initialBaseFeePerGas` to 0 within the default config. This allows for a gas price of 0 when testing, so that hardhat can be used within existing test suites without breaking anything.