### PR TITLE
Fix: `eth_call` revert check with eip1559 tx's

### DIFF
--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -457,9 +457,10 @@ class _PrivateKeyAccount(PublicKeyAccount):
 
     def _check_for_revert(self, tx: Dict) -> None:
         try:
-            # remove `gasPrice` to avoid issues post-EIP1559
+            # remove gas price related values to avoid issues post-EIP1559
             # https://github.com/ethereum/go-ethereum/pull/23027
-            web3.eth.call(dict((k, v) for k, v in tx.items() if k != "gasPrice" and v))
+            skip_keys = {"gasPrice", "maxFeePerGas", "maxPriorityFeePerGas"}
+            web3.eth.call({k: v for k, v in tx.items() if k not in skip_keys and v})
         except ValueError as exc:
             msg = exc.args[0]["message"] if isinstance(exc.args[0], dict) else str(exc)
             raise ValueError(


### PR DESCRIPTION
### What I did
Filter `maxFeePerGas` and `maxPriorityFeePerGas` when making a call to check if an eip-1559 tx will revert. This is necessary to allow transactions where the max fee is set below the current base fee.