### PR TITLE
Handle contracts not found during revert check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/eth-brownie/brownie)
 
+### Fixed
+- Issue with testing reverted contracts not found in deployment map ([#1195](https://github.com/eth-brownie/brownie/pull/1195))
+
 ## [1.16.0](https://github.com/eth-brownie/brownie/tree/v1.16.0) - 2021-08-08
 ### Added
 - Initial support for [Hardhat Network](https://hardhat.org/hardhat-network/) as an alternative to Ganache ([#1043](https://github.com/eth-brownie/brownie/pull/1043))

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -397,10 +397,11 @@ class TransactionReceipt:
         else:
             source = self._error_string(1)
             contract = state._find_contract(self.receiver)
-            marker = "//" if contract._build["language"] == "Solidity" else "#"
-            line = self._traceback_string().split("\n")[-1]
-            if marker + " dev: " in line:
-                self._dev_revert_msg = line[line.index(marker) + len(marker) : -5].strip()
+            if contract:
+                marker = "//" if contract._build["language"] == "Solidity" else "#"
+                line = self._traceback_string().split("\n")[-1]
+                if marker + " dev: " in line:
+                    self._dev_revert_msg = line[line.index(marker) + len(marker) : -5].strip()
 
         raise exc._with_attr(
             source=source, revert_msg=self._revert_msg, dev_revert_msg=self._dev_revert_msg


### PR DESCRIPTION
### What I did

Added a check in `_raise_if_reverted` to skip the dev_revert_string lookup if the contract is not found. This can happen if the contract is deployed via another contract (or somehow otherwise not logged in the deployment map).

### How I did it

I added an if statement.

### How to verify it

Deploy a contract from inside a contract and check if it reverts. A test like this should pass:

```
with brownie.reverts():
    contract.transactionWillRevert()
```

### Checklist

- [YES?] I have confirmed that my PR passes all linting checks
- [NO] I have included test cases
- [N/A] I have updated the documentation
- [YES] I have added an entry to the changelog
