### PR TITLE
Recursively kill all RPC child processes on exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/eth-brownie/brownie)
+### Fixed
+- Recursively kill all RPC child processes on exit ([#1200](https://github.com/eth-brownie/brownie/pull/1200))
 
 ## [1.16.0](https://github.com/eth-brownie/brownie/tree/v1.16.0) - 2021-08-08
 ### Added

--- a/brownie/data/network-config.yaml
+++ b/brownie/data/network-config.yaml
@@ -121,6 +121,7 @@ development:
     id: hardhat-fork
     cmd: npx hardhat node
     host: http://127.0.0.1
+    timeout: 120
     cmd_settings:
       port: 8545
       fork: mainnet

--- a/brownie/network/rpc/__init__.py
+++ b/brownie/network/rpc/__init__.py
@@ -138,7 +138,7 @@ class Rpc(metaclass=_Singleton):
             print("Terminating local RPC client...")
         except ValueError:
             pass
-        for child in self.process.children():
+        for child in self.process.children(recursive=True):
             try:
                 child.kill()
             except psutil.NoSuchProcess:


### PR DESCRIPTION
### What I did
Modified the RPC `kill()` function to recursively kill all child processes. This ensures that hardhat terminates properly on exit.

Also changed timeout of `hardhat-fork` to 120s to match other forknets.

Related issue: #1199

### How to verify it
```
# Launch brownie. This should launch a new hardhat instance
brownie console --network hardhat
# Terminate brownie. This should kill the active hardhat instance
quit()

# Relaunch brownie. Verify that it launches a new hardhat instance
brownie console --network hardhat
```

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have added an entry to the changelog
