### PR TITLE
Support hardhat revert strings

### DIFF
--- a/brownie/test/managers/runner.py
+++ b/brownie/test/managers/runner.py
@@ -95,11 +95,21 @@ class RevertContextManager:
                 ) from None
 
         if self.revert_msg or self.revert_pattern:
-            actual = exc_value.revert_msg
+            actual = exc_value if exc_value.revert_msg is None else exc_value.revert_msg
             if (
                 actual is None
                 or (self.revert_pattern and not re.fullmatch(self.revert_pattern, actual))
-                or (self.revert_msg and self.revert_msg != actual)
+                or (
+                    self.revert_msg
+                    and (
+                        self.revert_msg != actual
+                        and f"{actual}"
+                        != (
+                            "VM Exception while processing transaction:"
+                            f" reverted with reason string '{self.revert_msg}'"
+                        )
+                    )
+                )
             ):
                 raise AssertionError(
                     f"Unexpected revert string '{actual}'\n{exc_value.source}"


### PR DESCRIPTION
Solves #1201 for me, I'm not really a python dev so not sure if this is how to solve the issue "properly"

`tox -e lint` fails because of something in `brownie/convert/datatypes.py`