### PR TITLE
fix: handle function outside contract

### DIFF
--- a/brownie/project/compiler/solidity.py
+++ b/brownie/project/compiler/solidity.py
@@ -593,6 +593,12 @@ def _get_active_fn(source_node: NodeBase, offset: Tuple[int, int]) -> Tuple[Node
             name = "<constructor>"
         else:
             name = "<fallback>"
+
+    parent = fn_node.parent()
+    if parent.nodeType == "SourceUnit":
+        # the function exists outside a contract
+        return fn_node, name
+
     return fn_node, f"{fn_node.parent().name}.{name}"
 
 


### PR DESCRIPTION
### What I did
When generating the `pcMap`, correctly handle branches occuring in a function outside of a contract.

Fixes #1198 

### How I did it
Check if the parent of the function node is a `SourceUnit` and if yes, do not include a contract name.

### How to verify it
From inside the console:

```python
Contract.from_explorer('0xBA12222222228d8Ba445958a75a0704d566BF2C8')
```
