### PR TITLE
pre and post hook

### DIFF
--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -953,6 +953,9 @@ def _load_sources(project_path: Path, subfolder: str, allow_json: bool) -> Dict:
     if project_path.joinpath("brownie_hooks.py").exists():
         hooks = importlib.import_module("brownie_hooks")
 
+    if hasattr(hooks, "pre_hook"):
+        hooks.pre_hook()
+
     for path in project_path.glob(f"{subfolder}/**/*"):
         if path.suffix not in suffixes:
             continue
@@ -966,6 +969,10 @@ def _load_sources(project_path: Path, subfolder: str, allow_json: bool) -> Dict:
 
         path_str: str = path.relative_to(project_path).as_posix()
         contract_sources[path_str] = source
+
+    if hasattr(hooks, "post_hook"):
+        hooks.pre_hook()
+
     return contract_sources
 
 

--- a/docs/core-contracts.rst
+++ b/docs/core-contracts.rst
@@ -239,3 +239,19 @@ Alternatively, :func:`Contract.set_alias <Contract.set_alias>` allows you to cre
 
     >>> Contract('dai')
     <Dai Contract '0x6B175474E89094C44Da98b954EedeAC495271d0F'>
+
+Compilation hooks
+-------------------------------------
+
+A project can define additional compile steps in the file `brownie_hooks.py`. These functions will be called from brownie:
+
+```
+def pre_hook():
+# steps before compilation
+
+def post_hook():
+# steps after compilation
+
+def brownie_load_source(path, source):
+# this function will be called for each function
+```


### PR DESCRIPTION
### What I did

allow for pre and post hooks, so that the entire build process looks like this

1) pre compile hook. setup any files and needed utilities etc.
2) compile hook. run through each file and process it
3) post hook. final steps after compilation e.g. generate a flat file

this also allows to e.g. template contract code and other processing. an idea for the future would be a hooks.yaml which maps the custom config to the steps.

- [x ] I have confirmed that my PR passes all linting checks
- [-] I have included test cases
- [-] I have updated the documentation
- [-] I have added an entry to the changelog
