### PR TITLE
Remove gasPrice, gas  from ClefAccount formatters

### DIFF
--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -942,8 +942,6 @@ class ClefAccount(_PrivateKeyAccount):
 
         formatters = {
             "nonce": web3.toHex,
-            "gasPrice": web3.toHex,
-            "gas": web3.toHex,
             "value": web3.toHex,
             "chainId": web3.toHex,
             "data": web3.toHex,


### PR DESCRIPTION
### What I did

Remove `gasPrice` and `gas` from `ClefAccount` formatters, since it's already formatted before `_transact` are called.

Related issue: #1210 

### How I did it

Remove from the dict.

### How to verify it

2 lines removal :)

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
