### PR TITLE
Prevent brownie from crashing when skipping tests with -s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/eth-brownie/brownie)
+- Prevent brownie from crashing when skipping tests with -s ([#1220](https://github.com/eth-brownie/brownie/pull/1220))
 
 ## [1.16.2](https://github.com/eth-brownie/brownie/tree/v1.16.2) - 2021-08-24
 ### Added

--- a/brownie/test/managers/base.py
+++ b/brownie/test/managers/base.py
@@ -187,6 +187,7 @@ class PytestBrownieBase:
                 path, test_id = self._test_id(report.nodeid)
                 idx = self.node_map[path].index(test_id)
                 report.outcome = convert_outcome(self.results[path][idx])
+                report.longrepr = (path, None, "Skipped")  # File path, line no., reason
                 return "skipped", "s", "SKIPPED"
             return "", "", ""
         if hasattr(report, "wasxfail"):


### PR DESCRIPTION
### What I did
Added a hotfix to prevent `brownie test -s` from crashing when skipping tests 

Related issue: Fixes #1215 

### How I did it
Added missing `report.longrepr` tuple. Ideally, it should contain the reason written in `@pytest.mark.skip(reason=...)`, but I couldn't figure out a way to do that with the existing flow

### How to verify it
Add `@pytest.mark.skip()` or `@pytest.mark.require_network("dummy")` to a test and run `brownie test -s`

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [x] I have added an entry to the changelog
