### PR TITLE
Catch NotImplementedError when trying to sleep with geth

### DIFF
--- a/brownie/network/state.py
+++ b/brownie/network/state.py
@@ -317,7 +317,10 @@ class Chain(metaclass=_Singleton):
                 self._redo_buffer.clear()
             self._current_id = rpc.Rpc().snapshot()
             # ensure the local time offset is correct, in case it was modified by the transaction
-            self.sleep(0)
+            try:
+                self.sleep(0)
+            except NotImplementedError:
+                pass
 
     def _network_connected(self) -> None:
         self._reset_id = None


### PR DESCRIPTION
### What I did

Related issue: 1227

### How I did it

In network/state.py, add a simple try / except block around the sleep statement in `_add_to_undo_buffer`, exactly as already present in `_revert`.

### How to verify it

Run geth v1.10.8
Then, in a separate terminal, run `brownie console` and test a simple transfer:

```
dev = accounts[0]
alice = accounts.add()
dev.transfer(to=alice, amount="1 ether")
```
This should not raise any errors, and `alice.balance()` should show that the Ether has been transferred. Unit tests in tests/network/state still pass.

### Checklist

- [x ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
