### PR TITLE
fix: change lock acquire/release in multicall

### DIFF
--- a/brownie/network/multicall.py
+++ b/brownie/network/multicall.py
@@ -57,7 +57,7 @@ class Multicall:
         ContractCall.__call__.__code__ = self._proxy_call.__code__
 
     @property
-    def block_number(self):
+    def block_number(self) -> int:
         return self._block_number[get_ident()]
 
     def __call__(

--- a/brownie/network/multicall.py
+++ b/brownie/network/multicall.py
@@ -47,26 +47,29 @@ class Multicall:
 
     def __init__(self) -> None:
         self.address = None
-        self.block_number = None
+        self._block_number = defaultdict(lambda: None)  # type: ignore
         self._contract = None
-        self._pending_calls: List[Call] = []
+        self._pending_calls: Dict[int, List[Call]] = defaultdict(list)
 
         setattr(ContractCall, "__original_call_code", ContractCall.__call__.__code__)
         setattr(ContractCall, "__proxy_call_code", self._proxy_call.__code__)
         setattr(ContractCall, "__multicall", defaultdict(lambda: None))
         ContractCall.__call__.__code__ = self._proxy_call.__code__
 
+    @property
+    def block_number(self):
+        return self._block_number[get_ident()]
+
     def __call__(
         self, address: Optional[str] = None, block_identifier: Union[str, bytes, int, None] = None
     ) -> "Multicall":
         self.address = address  # type: ignore
-        self.block_number = block_identifier  # type: ignore
+        self._block_number[get_ident()] = block_identifier  # type: ignore
         return self
 
     def _flush(self, future_result: Result = None) -> Any:
-        with self._lock:
-            pending_calls = self._pending_calls
-            self._pending_calls = []
+        pending_calls = self._pending_calls[get_ident()]
+        self._pending_calls[get_ident()] = []
 
         if not pending_calls:
             # either all calls have already been made
@@ -77,7 +80,7 @@ class Multicall:
             results = self._contract.tryAggregate(  # type: ignore
                 False,
                 [_call.calldata for _call in pending_calls],
-                block_identifier=self.block_number,
+                block_identifier=self._block_number[get_ident()],
             )
             ContractCall.__call__.__code__ = getattr(ContractCall, "__proxy_call_code")
 
@@ -96,8 +99,7 @@ class Multicall:
         call_obj = Call(calldata, call.decode_output)  # type: ignore
         # future result
         result = Result(call_obj)
-        with self._lock:
-            self._pending_calls.append(result)
+        self._pending_calls[get_ident()].append(result)
 
         return LazyResult(lambda: self._flush(result))
 
@@ -125,9 +127,11 @@ class Multicall:
         elif "cmd" in active_network:
             deployment = self.deploy({"from": accounts[0]})
             self.address = deployment.address  # type: ignore
-            self.block_number = deployment.tx.block_number  # type: ignore
+            self._block_number[get_ident()] = deployment.tx.block_number  # type: ignore
 
-        self.block_number = self.block_number or web3.eth.get_block_number()
+        self._block_number[get_ident()] = (
+            self._block_number[get_ident()] or web3.eth.get_block_number()
+        )
 
         if self.address is None:
             raise ContractNotFound(

--- a/tests/network/test_mulitcall.py
+++ b/tests/network/test_mulitcall.py
@@ -38,9 +38,9 @@ def test_flush_mid_execution(accounts, tester):
 
     with brownie.multicall:
         tester.getTuple(addr)
-        assert len(brownie.multicall._pending_calls) == 1
+        assert len([x for v in brownie.multicall._pending_calls.values() for x in v]) == 1
         brownie.multicall.flush()
-        assert len(brownie.multicall._pending_calls) == 0
+        assert len([x for v in brownie.multicall._pending_calls.values() for x in v]) == 0
 
 
 def test_proxy_object_fetches_on_next_use(accounts, tester):
@@ -50,10 +50,10 @@ def test_proxy_object_fetches_on_next_use(accounts, tester):
 
     with brownie.multicall:
         ret_val = tester.getTuple(addr)
-        assert len(brownie.multicall._pending_calls) == 1
+        assert len([x for v in brownie.multicall._pending_calls.values() for x in v]) == 1
         # ret_val is now fetched
         assert ret_val == value
-        assert len(brownie.multicall._pending_calls) == 0
+        assert len([x for v in brownie.multicall._pending_calls.values() for x in v]) == 0
 
 
 def test_proxy_object_updates_on_exit(accounts, tester):


### PR DESCRIPTION
### What I did

Ended up testing 4 some different ways to handle this (some combinations as well).

- Lock enter/exit of context
- Lock pending calls access / bytecode swap
- Add dictionary with per-thread data (pending calls, block number)
- Add a separate thread for flushing

Easiest and quickest was just locking on enter/exit (we'd need to use a RLock to handle reentrancy within the same thread though, and then also handle more reentrancy issues (like maintaining a queue of block numbers). However, opting for locking on queue/bytecode access + per-thread dictionary was what I ended up going with. For now it gets the job done with the least amount of headache.

Will definitely need to revisit this along with reentrancy in the future.