### PR TITLE
feat: add arbitrum to network config

### DIFF
--- a/brownie/data/network-config.yaml
+++ b/brownie/data/network-config.yaml
@@ -43,6 +43,13 @@ live:
         id: kotti
         host: https://www.ethercluster.com/kotti
         explorer: https://blockscout.com/etc/kotti/api
+  - name: Arbitrum
+    networks:
+      - name: Mainnet
+        chainid: 42161
+        id: arbitrum-main
+        host: https://arb1.arbitrum.io/rpc
+        explorer:  https://api.arbiscan.io/api
   - name: Binance Smart Chain
     networks:
       - name: Testnet


### PR DESCRIPTION
### What I did
Add `arbitrum-main` to the default network config.

Closes #1230 

### How I did it
Followed the instructions at https://arbitrum.io/bridge-tutorial/

### How to verify it
Try it.
