### PR TITLE
Docs: typo: Etherem => Ethereum

### DIFF
--- a/docs/deploy.rst
+++ b/docs/deploy.rst
@@ -4,7 +4,7 @@
 Deployment Basics
 =================
 
-Once your project is ready to be deployed to a persistent chain (such as the Etherem mainnet or a testnet), Brownie can be used to handle the deployments.
+Once your project is ready to be deployed to a persistent chain (such as the Ethereum mainnet or a testnet), Brownie can be used to handle the deployments.
 
 It is important to remember that blockchains are `permanent` and `immutable`. Once your project has been deployed there is no going back. For this reason, we highly recommend the following process when deploying to the mainnet:
 


### PR DESCRIPTION
### What I did
Fixed a typo in documentation

Related issue: #

### How I did it

### How to verify it

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
