### PR TITLE
pass solc version to get_abi from compiler config file

### DIFF
--- a/brownie/project/compiler/__init__.py
+++ b/brownie/project/compiler/__init__.py
@@ -377,6 +377,7 @@ def _sources_dict(original: Dict, language: str) -> Dict:
 
 def get_abi(
     contract_sources: Dict[str, str],
+    solc_version: Optional[str] = None,
     allow_paths: Optional[str] = None,
     remappings: Optional[list] = None,
     silent: bool = True,
@@ -388,6 +389,7 @@ def get_abi(
     ---------
     contract_sources : dict
         a dictionary in the form of {'path': "source code"}
+    solc_version: solc version to compile with (use None to set via pragmas)
     allow_paths : str, optional
         Compiler allowed filesystem import path
     remappings : list, optional
@@ -438,7 +440,10 @@ def get_abi(
     if not solc_sources:
         return final_output
 
-    compiler_targets = find_solc_versions(solc_sources, install_needed=True, silent=silent)
+    if solc_version:
+        compiler_targets = {solc_version: list(solc_sources)}
+    else:
+        compiler_targets = find_solc_versions(solc_sources, install_needed=True, silent=silent)
 
     for version, path_list in compiler_targets.items():
         to_compile = {k: v for k, v in contract_sources.items() if k in path_list}

--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -315,6 +315,7 @@ class Project(_ProjectBase):
         changed_sources = {i: self._sources.get(i) for i in changed_paths}
         abi_json = compiler.get_abi(
             changed_sources,
+            solc_version=self._compiler_config["solc"].get("version", None),
             allow_paths=self._path.as_posix(),
             remappings=self._compiler_config["solc"].get("remappings", []),
         )


### PR DESCRIPTION
### What I did

Related issue: #1242 

### How I did it

by adding a `solc_version` parameter to `get_abi`

### How to verify it

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog

not necessarily a draft, but would like some feedback before moving on to including a test case, updating the docs and/or adding an entry to the changelog.

if none of that is needed for a small fix such as this one, i guess it can directly be merged :)