### PR TITLE
GH-#1168: add .env to .gitignore after brownie init

### DIFF
--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -58,6 +58,7 @@ BUILD_FOLDERS = ["contracts", "deployments", "interfaces"]
 MIXES_URL = "https://github.com/brownie-mix/{}-mix/archive/{}.zip"
 
 GITIGNORE = """__pycache__
+.env
 .history
 .hypothesis/
 build/


### PR DESCRIPTION
Fixed #1168

I don't think adding a specific test case nor a changelog entry is needed for a such modification

### What I did

Related issue: #1168

### How I did it

### How to verify it

.env entry is present in generated .gitignore file after brownie init

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
