### PR TITLE
Support EIP1559 in `TransactionReceipt.replace`

### DIFF
--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -556,8 +556,9 @@ class TransactionReceipt:
             self.sender = EthAddress(tx["from"])
         self.receiver = EthAddress(tx["to"]) if tx["to"] else None
         self.value = Wei(tx["value"])
-        if "gasPrice" in tx:
-            self.gas_price = tx["gasPrice"]
+        self.gas_price = tx["gasPrice"]
+        self.max_fee = tx.get("maxFeePerGas")
+        self.priority_fee = tx.get("maxPriorityFeePerGas")
         self.gas_limit = tx["gas"]
         self.input = tx["input"]
         self.nonce = tx["nonce"]

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -312,9 +312,12 @@ class TransactionReceipt:
         ---------
         increment : float, optional
             Multiplier applied to the gas price of this transaction in order
-            to determine the new gas price
+            to determine the new gas price. For EIP1559 transactions the multiplier
+            is applied to the max_fee, the priority_fee is incremented by 1.1.
         gas_price : Wei, optional
-            Absolute gas price to use in the replacement transaction
+            Absolute gas price to use in the replacement transaction. For EIP1559
+            transactions this is the new max_fee, the priority_fee is incremented
+            by 1.1.
         silent : bool, optional
             Toggle console verbosity (default is same setting as this transaction)
 
@@ -332,6 +335,14 @@ class TransactionReceipt:
 
         if increment is not None:
             gas_price = Wei(self.gas_price * increment)
+        else:
+            gas_price = Wei(gas_price)
+
+        max_fee, priority_fee = None, None
+        if self.max_fee is not None and self.priority_fee is not None:
+            max_fee = gas_price
+            priority_fee = Wei(self.priority_fee * 1.1)
+            gas_price = None
 
         if silent is None:
             silent = self._silent
@@ -351,7 +362,9 @@ class TransactionReceipt:
             self.receiver,
             self.value,
             gas_limit=self.gas_limit,
-            gas_price=Wei(gas_price),
+            gas_price=gas_price,
+            max_fee=max_fee,
+            priority_fee=priority_fee,
             data=self.input,
             nonce=self.nonce,
             required_confs=0,

--- a/docs/api-network.rst
+++ b/docs/api-network.rst
@@ -2693,6 +2693,8 @@ TransactionReceipt Methods
     * ``increment``: Multiplier applied to the gas price of the current transaction in order to determine a new gas price
     * ``gas_price``: Absolute gas price to use in the replacement transaction
 
+    For EIP-1559 transactions, the modification is applied to ``max_fee``. The ``priority_fee`` is always multiplied by 1.1 (the minimum increase required to be accepted by a node).
+
     Returns a :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>` object.
 
     .. code-block:: python


### PR DESCRIPTION
### What I did
When replacing an EIP1559 transaction, create another EIP1559 transaction.

### How I did it
* The max fee is modified according to the given modifier or new absolute value.
* The priority fee is always multiplied by 1.1, which seems to be the minimum required by Geth.

### How to verify it
Try it.
