### PR TITLE
docs/quickstart.rst: fix wrong arg in constructor

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -133,7 +133,7 @@ Brownie provides a :func:`ContractContainer <brownie.network.contract.ContractCo
     >>> Token.deploy
     <ContractConstructor object 'Token.constructor(string _symbol, string _name, uint256 _decimals, uint256 _totalSupply)'>
 
-    >>> t = Token.deploy("Test Token", "TST", 18, 1e20, {'from': accounts[1]})
+    >>> t = Token.deploy("Test Token", "TST", 18, 1e21, {'from': accounts[1]})
 
     Transaction sent: 0x2e3cab83342edda14141714ced002e1326ecd8cded4cd0cf14b2f037b690b976
     Transaction confirmed - block: 1   gas spent: 594186


### PR DESCRIPTION
### What I did
Change the wrong argument passed to `Token` constructor in the example in `quickstart.rst`.

### How I did it
Change `1e20` to `1e21` in the quickstart doc.

### How to verify it
According to the example below, `_totalSupply` should be `1e21` so that `t.balanceOf(accounts[1]) == 1000000000000000000000`. Please let me know if there is anything wrong.

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [x] I have updated the documentation
- [ ] I have added an entry to the changelog
