### PR TITLE
Add `no_vm_errors_on_rpc_response` ganache-cli flag

### DIFF
--- a/brownie/network/rpc/ganache.py
+++ b/brownie/network/rpc/ganache.py
@@ -29,6 +29,7 @@ CLI_FLAGS = {
     "unlock": "--unlock",
     "network_id": "--networkId",
     "chain_id": "--chainId",
+    "no_vm_errors_on_rpc_response": "--noVMErrorsOnRPCResponse",
 }
 
 EVM_VERSIONS = ["byzantium", "constantinople", "petersburg", "istanbul"]
@@ -51,7 +52,9 @@ def launch(cmd: str, **kwargs: Dict) -> None:
         kwargs["evm_version"] = EVM_EQUIVALENTS[kwargs["evm_version"]]  # type: ignore
     kwargs = _validate_cmd_settings(kwargs)
     for key, value in [(k, v) for k, v in kwargs.items() if v]:
-        if key == "unlock":
+        if key == "no_vm_errors_on_rpc_response" and value:
+            cmd_list.append(CLI_FLAGS[key])
+        elif key == "unlock":
             if not isinstance(value, list):
                 value = [value]  # type: ignore
             for address in value:

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -130,6 +130,7 @@ Networks
                     default_balance: 100
                     time: 2020-05-08T14:54:08+0000
                     unlock: null
+                    no_vm_errors_on_rpc_response: true
 
 .. py:attribute:: networks.live
 

--- a/docs/network-management.rst
+++ b/docs/network-management.rst
@@ -105,6 +105,7 @@ The following optional fields may be given for development networks, which are p
     * ``default_balance``: The starting balance for all unlocked accounts. Can be given as unit string like "1000 ether" or "50 gwei" or as an number **in Ether**. Will default to 100 ether.
     * ``time``: Date (ISO 8601) that the first block should start. Use this feature, along with :func:`Chain.sleep <Chain.sleep>` to test time-dependent code. Defaults to the current time.
     * ``unlock``: A single address or a list of addresses to unlock. These accounts are added to the :func:`Accounts <brownie.network.account.Accounts>` container and can be used as if the private key is known. Also works in combination with ``fork`` to send transactions from any account.
+    * ``no_vm_errors_on_rpc_response``: Do not transmit transaction failures as RPC errors. Enable this flag for error reporting behaviour which is compatible with other clients such as Geth and OpenEthereum.
 
 .. note::
     These optional commandline fields can also be specified on a project level in the project's ``brownie-config.yaml`` file. See the :ref:`configuration files<config>`.


### PR DESCRIPTION
### What I did

Sometimes it's really useful to get error messages like real nodes
instead of the js VM stacktrace of ganache-cli

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
