### PR TITLE
Add floor division to Wei

### DIFF
--- a/brownie/convert/datatypes.py
+++ b/brownie/convert/datatypes.py
@@ -74,6 +74,15 @@ class Wei(int):
     def __sub__(self, other: Any) -> "Wei":
         return Wei(super().__sub__(_to_wei(other)))
 
+    def __floordiv__(self, other: Any) -> "Wei":
+        return Wei(super().__floordiv__(_to_wei(other)))
+
+    def __truediv__(self, other: Any) -> "Wei":
+        return self // _to_wei(other)
+
+    def __mul__(self, other: Any) -> "Wei":
+        return Wei(super().__mul__(_to_wei(other)))
+
     def to(self, unit: str) -> "Fixed":
         """
         Returns a converted denomination of the stored wei value.
@@ -84,7 +93,7 @@ class Wei(int):
         :return: A 'Fixed' type number in the specified denomination
         """
         try:
-            return Fixed(self * Fixed(10) ** -UNITS[unit])
+            return Fixed(Fixed(self) * Fixed(10) ** -UNITS[unit])
         except KeyError:
             raise TypeError(f'Cannot convert wei to unknown unit: "{unit}". ') from None
 

--- a/tests/convert/test_wei.py
+++ b/tests/convert/test_wei.py
@@ -67,6 +67,11 @@ def test_ge():
     assert Wei("2 ether") >= "2 ether"
 
 
+def test_div():
+    assert Wei("3 wei") / Wei("2 wei") == "1 wei"
+    assert Wei("3 wei") // Wei("2 wei") == "1 wei"
+
+
 @pytest.mark.parametrize(
     "conversion_tuples",
     (


### PR DESCRIPTION
### What I did:
I added floor division to the Wei datatype in order to better match Solidity.

Related issue: #1224 

### What's the problem
Brownie `Wei` class rounds differently from solidity because it uses true division (as inherited from python3.x `int`). Solidity uses floor division.

### Example (From #1224)
```python
# python
from brownie.convert import Wei

x = 2200094942857964307
y = 1000000
z = 100000000
out = Wei(Wei(x) * Wei(y) / Wei(z)) 
# 22000949428579644

# Essentially the same as:
out = Wei(int(x * y / z))
                  # ^ True division
```

```solidity
// solidity
contract MyContract{
    function division_testing() external view returns (uint out) {
        uint x = 2200094942857964307;
        uint y = 1000000;
        uint z = 100000000;
        out = x * y / z;
        // 22000949428579643
    }
}
```
----

### Thoughts

After playing with this for a bit and writing this up, I had some thoughts:

#### Overriding `__mul__` in this way causes all `Wei` calculations to be integers.

As I understand it, there aren't decimals in solidity, so while the below is "true", it may not be intuitive. 
```python
# (New code)
Wei(10) * 0.1 == 0
```
One thought would be throwing a `TypeError: can't multiply Wei by decimal`, but then `Wei(1) * 0.1` would fail and `0.1 * Wei(1)` would succeed, which is also confusing.

----

#### Use `//` operator instead
Could just opt to use the `//` (floor division or `__floordiv__`) instead. This would solve the original rounding problem above and none of the changes in this PR would be required.

----

Not sure where we want to go with this, and I'm very new to Brownie, so I don't have a deep understanding of where/how `Wei` is used.

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
