### PR TITLE
Add missing import in test

### DIFF
--- a/docs/tests-hypothesis-property.rst
+++ b/docs/tests-hypothesis-property.rst
@@ -354,7 +354,7 @@ The mechanism for doing this is the :py:class:`hypothesis.settings <hypothesis.s
 .. code-block:: python
 
     from brownie.test import given
-    from hypothesis settings
+    from hypothesis import settings
 
     @given(strategy('uint256'))
     @settings(max_examples=500)


### PR DESCRIPTION
### What I did

Adds a missing `import` in a test example.
### Checklist

- [Y] I have confirmed that my PR passes all linting checks
- [N/A] I have included test cases
- [Y] I have updated the documentation
- [N/A ] I have added an entry to the changelog
