### PR TITLE
fix wsl with Ganache GUI and tested

### DIFF
--- a/brownie/network/rpc/__init__.py
+++ b/brownie/network/rpc/__init__.py
@@ -191,8 +191,8 @@ class Rpc(metaclass=_Singleton):
             # if no local RPC process could be found we can try to find a dockerized one
             if platform.system() == "Darwin":
                 return self._get_pid_from_docker_backend()
-            elif platform.system() == "Linux" and 'Microsoft' in platform.uname().release:
-                return
+            elif platform.system() == "Linux" and "Microsoft" in platform.uname().release:
+                return 0
             else:
                 return self._get_pid_from_net_connections(laddr)
 


### PR DESCRIPTION
### What I did

When I use brownie in Win WSL with Ganache GUI from Win

    brownie networks add Development dev cmd=ganache host=http://127.0.0.1:7545
    brownie console --network dev

![image](https://user-images.githubusercontent.com/64492/138030222-5b702a43-05b4-48f3-a5d7-521b56d0f75e.png)

Brownie tries to start the process instead of connecting.

### How I did it

I made changes to brownie/network/rpc/__init__.py and detect if brownie is running in WSL.
![image](https://user-images.githubusercontent.com/64492/138030807-894c586c-3d4b-4c9e-a5ea-558b1cb166dd.png)
return None to avoid starting ganache-cli.

### How to verify it

Locally I run 

   pip3 install brownie/
   brownie console --network dev

It works without the previous exception anymore.

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
