### PR TITLE
#1138 fix: stop reading solidity version within comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/eth-brownie/brownie)
+### Fixed
+- Ignore commented-out solidity versions
 
 ## [1.17.0](https://github.com/eth-brownie/brownie/tree/v1.17.0) - 2021-10-13
 ### Added

--- a/brownie/project/sources.py
+++ b/brownie/project/sources.py
@@ -211,7 +211,7 @@ def get_pragma_spec(source: str, path: Optional[str] = None) -> NpmSpec:
     Returns: NpmSpec object
     """
 
-    pragma_match = next(re.finditer(r"pragma +solidity([^;]*);", source), None)
+    pragma_match = next(re.finditer(r"(?:\n|^)pragma +solidity([^;]*);", source), None)
     if pragma_match is not None:
         pragma_string = pragma_match.groups()[0]
         pragma_string = " ".join(pragma_string.split())


### PR DESCRIPTION
### What I did
Updated the relevant regex expression to ignore comments

Related issue: #1138 

### How I did it
Updated the relevant regex expression to ignore comments

### How to verify it
![image](https://user-images.githubusercontent.com/70677534/139541322-15ce227a-e130-4eb0-8c66-1c09fbf7715f.png)


### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [x] I have updated the documentation (doesn't seem relevant for this minor fix, didn't do this but did check box)
- [x] I have added an entry to the changelog
