### PR TITLE
fix: match against double/single quote paths

### DIFF
--- a/brownie/project/flattener.py
+++ b/brownie/project/flattener.py
@@ -7,7 +7,9 @@ from brownie.utils.toposort import toposort_flatten
 
 # Patten matching Solidity `import-directive`, capturing path component
 # https://docs.soliditylang.org/en/latest/grammar.html#a4.SolidityParser.importDirective
-IMPORT_PATTERN = re.compile(r"(?<=\n)?import(?P<prefix>.*)\"(?P<path>.*)\"(?P<suffix>.*)(?=\n)")
+IMPORT_PATTERN = re.compile(
+    r"(?<=\n)?import(?P<prefix>.*)(?P<quote>[\"'])(?P<path>.*)(?P=quote)(?P<suffix>.*)(?=\n)"
+)
 PRAGMA_PATTERN = re.compile(r"^pragma.*;$", re.MULTILINE)
 LICENSE_PATTERN = re.compile(r"^// SPDX-License-Identifier: (.*)$", re.MULTILINE)
 

--- a/tests/network/contract/test_verification.py
+++ b/tests/network/contract/test_verification.py
@@ -35,7 +35,7 @@ contract Baz {}
         "contracts/Bar.sol",
         """
 import {Foo as FooSomething} from "./Foo.sol";
-import "./Baz.sol";
+import './Baz.sol';
 
 struct Helper {
     address x;


### PR DESCRIPTION
### What I did

Fix regex to support paths with your single quotes along with double quotes when building verification info.

Fixes: #1322

### How I did it

Add a capture group for the quote used, and a backreference to the group for the closing quotes.

### How to verify it

Tests should still pass, (updated one to include single quotes in the import path).
