### PR TITLE
fix: add libraries for linkage with solc in verification info

### DIFF
--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -275,9 +275,13 @@ class ContractContainer(_ContractBase):
                         compiler._get_solc_remappings(config["solc"]["remappings"]),
                     )
                 )
+                libs = {lib.strip("_") for lib in re.findall("_{1,}[^_]*_{1,}", self.bytecode)}
                 compiler_settings = {
                     "evmVersion": self._build["compiler"]["evm_version"],
                     "optimizer": config["solc"]["optimizer"],
+                    "libraries": {
+                        Path(source_fp).name: {lib: self._project[lib][-1].address for lib in libs}
+                    },
                 }
                 self._flattener = Flattener(source_fp, self._name, remaps, compiler_settings)
 


### PR DESCRIPTION
### What I did

Fix contract verification for contracts with linked libraries (as opposed to embedded libraries).

Fixes: #1317 

### How I did it

Add all libraries w/ there deployment addresses to the dictionary of compiler settings

### How to verify it

Check #1317 can be compiled with solc using the standard json input from `get_verification_info()`

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
