### PR TITLE
Allow dependency [VERSION] tagged with ("@")

### DIFF
--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -817,7 +817,7 @@ def _maybe_retrieve_github_auth() -> Dict[str, str]:
 
 def _install_from_github(package_id: str) -> str:
     try:
-        path, version = package_id.split("@")
+        path, version = package_id.split("@", 1)
         org, repo = path.split("/")
     except ValueError:
         raise ValueError(


### PR DESCRIPTION
Some GitHub projects use the at-sign ("@") in release version tags.  For dependencies and remappings, only split the [ORG]/[REPO]@[VERSION] on the first occurrence of the at-sign ("@") since [VERSION] may also contain the at-sign ("@").

### What I did

Merely use 1 as the 2nd parameter to the split function.
