### PR TITLE
Check if re.findall actually matches

### DIFF
--- a/brownie/project/sources.py
+++ b/brownie/project/sources.py
@@ -191,11 +191,13 @@ def get_contract_names(full_source: str) -> List:
 
     contract_names = []
     for source in contracts:
-        type_, name, _ = re.findall(
+        matches = re.findall(
             r"(abstract contract|contract|library|interface)\s+(\S*)\s*(?:is\s+([\s\S]*?)|)(?:{)",
             source,
-        )[0]
-        contract_names.append((name, type_))
+        )
+        if matches:
+            type_, name, _ = matches[0]
+            contract_names.append((name, type_))
     return contract_names
 
 


### PR DESCRIPTION
### What I did

Result of `re.findall()` was not previously checked before use, which resulted in runtime exceptions for one of my contracts (compilable with solc).

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
