### PR TITLE
Improved project load

### DIFF
--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -747,15 +747,11 @@ def load(
             raise BadProjectName("Project must start with an alphabetic character")
         name = "".join(i for i in name.title() if i.isalnum())
 
-    already_loaded_project: Optional[Project] = None
     for loaded_project in _loaded_projects:
         if loaded_project._name == name:
-            already_loaded_project = loaded_project
-
-    if already_loaded_project is not None:
-        if raise_if_loaded:
-            raise ProjectAlreadyLoaded("There is already a project loaded with this name")
-        return already_loaded_project
+            if raise_if_loaded:
+                raise ProjectAlreadyLoaded("There is already a project loaded with this name")
+            return loaded_project
 
     # paths
     _create_folders(project_path)

--- a/tests/project/main/test_main_project.py
+++ b/tests/project/main/test_main_project.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 from brownie.exceptions import ProjectAlreadyLoaded, ProjectNotFound
-from brownie.project.main import Project, TempProject, _ProjectBase
+from brownie.project.main import Project, TempProject, _ProjectBase, load, new
 
 
 def test_object(newproject):
@@ -47,7 +47,8 @@ def test_load_raises_already_loaded(project, newproject):
 
 def test_load_does_not_raise_when_raise_if_loaded_is_false(project, newproject):
     newproject.load()
-    project.load(newproject._path, "NewProject", raise_if_loaded=False)
+    loaded_project = project.load(newproject._path, "NewProject", raise_if_loaded=False)
+    assert loaded_project is newproject
     newproject.load(raise_if_loaded=False)
 
 

--- a/tests/project/main/test_main_project.py
+++ b/tests/project/main/test_main_project.py
@@ -45,6 +45,12 @@ def test_load_raises_already_loaded(project, newproject):
         newproject.load()
 
 
+def test_load_does_not_raise_when_raise_if_loaded_is_false(project, newproject):
+    newproject.load()
+    project.load(newproject._path, "NewProject", raise_if_loaded=False)
+    newproject.load(raise_if_loaded=False)
+
+
 def test_load_raises_cannot_find(project, tmp_path):
     with pytest.raises(ProjectNotFound):
         x = project.load(tmp_path)


### PR DESCRIPTION
### What I did

Related issue: #1368 

### How I did it

Introduces the `raise_if_loaded` boolean argument, which is `True` by default. Default behaviour is the previous behaviour of `brownie`, but if `raise_if_loaded=False` them the loaders do not raise a `ProjectAlreadyLoaded` error when a caller tries to load a previously loaded project.

`project.load` quietly returns the previously loaded `Project` instance, and `project.main.Project.load` short-circuits (returning `None`).

### How to verify it
```bash
pytest tests/project/main/test_main_project.py::test_load_does_not_raise_when_raise_if_loaded_is_false
```

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
