### PR TITLE
give txs time to complete before killing rpc

### DIFF
--- a/brownie/network/rpc/__init__.py
+++ b/brownie/network/rpc/__init__.py
@@ -138,6 +138,7 @@ class Rpc(metaclass=_Singleton):
             print("Terminating local RPC client...")
         except ValueError:
             pass
+        time.sleep(1)
         for child in self.process.children(recursive=True):
             try:
                 child.kill()


### PR DESCRIPTION
### What I did

add 1 second of sleep before RPC killing

related issue: #1375 

this fixed it in my particular case. 1 second obviously is arbitrary, there might be better ways to solve this.

### How I did it

### How to verify it

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] ~~I have included test cases~~
- [x] ~~I have updated the documentation~~
- [x] ~~I have added an entry to the changelog~~