### PR TITLE
Force files to be opened as UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/eth-brownie/brownie)
+### Changed
+- Force files to be opened as UTF-8
 
 ## [1.17.2](https://github.com/eth-brownie/brownie/tree/v1.17.2) - 2021-12-04
 ### Changed

--- a/brownie/project/compiler/__init__.py
+++ b/brownie/project/compiler/__init__.py
@@ -294,7 +294,7 @@ def generate_build_json(
         if path_str in input_json["sources"]:
             source = input_json["sources"][path_str]["content"]
         else:
-            with Path(path_str).open() as fp:
+            with Path(path_str).open(encoding="utf-8") as fp:
                 source = fp.read()
             contract_alias = _get_alias(contract_name, path_str)
 


### PR DESCRIPTION
### What I did

This forces files in a project to be opened as UTF-8.
On Windows, the default seems to be CP-1252 which led to some error while decoding files in some project.
Since UTF-8 is already the default on Linux and macOS, I think it might make more sense to enforce it on Windows too. 
