### PR TITLE
feat: adding a use_latest_patch option to solc compiler config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/eth-brownie/brownie)
 ### Changed
 - Force files to be opened as UTF-8
+- Added a new solidity compiler setting `use_latest_patch` in brownie-config.yaml to use the latest patch version of a compiler based on the pragma version of the contract.
 
 ## [1.17.2](https://github.com/eth-brownie/brownie/tree/v1.17.2) - 2021-12-04
 ### Changed

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -1091,11 +1091,13 @@ class Contract(_DeployedContractBase):
                 version = Version(compiler_str.lstrip("v")).truncate()
                 compiler_config = _load_project_compiler_config(Path(os.getcwd()))
                 solc_config = compiler_config["solc"]
-                if "use_latest_patch" in solc_config and solc_config["use_latest_patch"] is True:
-                    versions = [Version(str(i)) for i in solcx.get_installable_solc_versions()]
-                    for v in filter(lambda l: l < version.next_minor(), versions):
-                        if v > version:
-                            version = v
+                if "use_latest_patch" in solc_config:
+                    use_latest_patch = solc_config["use_latest_patch"]
+                    if use_latest_patch is True or address in use_latest_patch:
+                        versions = [Version(str(i)) for i in solcx.get_installable_solc_versions()]
+                        for v in filter(lambda l: l < version.next_minor(), versions):
+                            if v > version:
+                                version = v
 
                 is_compilable = (
                     version >= Version("0.4.22")

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -1194,7 +1194,13 @@ class Contract(_DeployedContractBase):
         solc_config = compiler_config["solc"]
         if "use_latest_patch" in solc_config:
             use_latest_patch = solc_config["use_latest_patch"]
-            if use_latest_patch is True or address in use_latest_patch:
+            needs_patch_version = False
+            if isinstance(use_latest_patch, bool):
+                needs_patch_version = use_latest_patch
+            elif isinstance(use_latest_patch, list):
+                needs_patch_version = address in use_latest_patch
+
+            if needs_patch_version:
                 versions = [Version(str(i)) for i in solcx.get_installable_solc_versions()]
                 for v in filter(lambda l: l < version.next_minor(), versions):
                     if v > version:

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -222,6 +222,10 @@ Compiler settings. See :ref:`compiler settings<compile_settings>` for more infor
               - zeppelin=/usr/local/lib/open-zeppelin/contracts/
               - github.com/ethereum/dapp-bin/=/usr/local/lib/dapp-bin/
 
+    .. py:attribute:: use_latest_patch
+
+        Optional boolean to use the latest patch semver compiler version. E.g. the if the contract has pragma version `0.4.16` and the latest available patch for `0.4` is `0.4.22` it will use this instead for compilations.
+
 .. py:attribute:: compiler.vyper
 
     Settings specific to the Vyper compiler.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -224,7 +224,20 @@ Compiler settings. See :ref:`compiler settings<compile_settings>` for more infor
 
     .. py:attribute:: use_latest_patch
 
-        Optional boolean to use the latest patch semver compiler version. E.g. the if the contract has pragma version `0.4.16` and the latest available patch for `0.4` is `0.4.22` it will use this instead for compilations.
+        Optional boolean or array contract list to use the latest patch semver compiler version. E.g. the if the contract has pragma version `0.4.16` and the latest available patch for `0.4` is `0.4.22` it will use this instead for compilations.
+
+        Enable for all contracts:
+        .. code-block:: yaml
+            compiler:
+                solc:
+                    use_latest_patch: true
+
+        Enable for only specific contracts:
+        .. code-block:: yaml
+            compiler:
+                solc:
+                    use_latest_patch:
+                        - '0x514910771AF9Ca656af840dff83E8264EcF986CA'
 
 .. py:attribute:: compiler.vyper
 

--- a/tests/network/contract/test_contract.py
+++ b/tests/network/contract/test_contract.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 import pytest
 import requests
 import yaml
+from semantic_version import Version
 
 from brownie import Wei
 from brownie.exceptions import BrownieCompilerWarning, BrownieEnvironmentWarning, ContractNotFound
@@ -315,11 +316,9 @@ def test_solc_use_latest_patch_true(testproject, network):
     with testproject._path.joinpath("brownie-config.yaml").open("w") as fp:
         yaml.dump(solc_config, fp)
 
-    # chainlink contract specifies version pragma ^0.4.16 which doesn't support overloaded
-    # events (>= 0.4.17)
-    c = Contract.from_explorer("0x514910771AF9Ca656af840dff83E8264EcF986CA")
-    transfer_events = list(filter(lambda l: "name" in l and l["name"] == "Transfer", c.abi))
-    assert len(transfer_events) == 2
+    assert Contract.get_solc_version(
+        "v0.4.16", "0x514910771AF9Ca656af840dff83E8264EcF986CA"
+    ) == Version("0.4.26")
 
 
 def test_solc_use_latest_patch_false(testproject, network):
@@ -328,11 +327,9 @@ def test_solc_use_latest_patch_false(testproject, network):
     with testproject._path.joinpath("brownie-config.yaml").open("w") as fp:
         yaml.dump(solc_config, fp)
 
-    # chainlink contract specifies version pragma ^0.4.16 which doesn't support overloaded
-    # events (>= 0.4.17)
-    c = Contract.from_explorer("0x514910771AF9Ca656af840dff83E8264EcF986CA")
-    transfer_events = list(filter(lambda l: "name" in l and l["name"] == "Transfer", c.abi))
-    assert len(transfer_events) == 1
+    assert Contract.get_solc_version(
+        "v0.4.16", "0x514910771AF9Ca656af840dff83E8264EcF986CA"
+    ) == Version("0.4.16")
 
 
 def test_solc_use_latest_patch_missing(testproject, network):
@@ -341,11 +338,9 @@ def test_solc_use_latest_patch_missing(testproject, network):
     with testproject._path.joinpath("brownie-config.yaml").open("w") as fp:
         yaml.dump(solc_config, fp)
 
-    # chainlink contract specifies version pragma ^0.4.16 which doesn't support overloaded
-    # events (>= 0.4.17)
-    c = Contract.from_explorer("0x514910771AF9Ca656af840dff83E8264EcF986CA")
-    transfer_events = list(filter(lambda l: "name" in l and l["name"] == "Transfer", c.abi))
-    assert len(transfer_events) == 1
+    assert Contract.get_solc_version(
+        "v0.4.16", "0x514910771AF9Ca656af840dff83E8264EcF986CA"
+    ) == Version("0.4.16")
 
 
 def test_solc_use_latest_patch_specific_not_included(testproject, network):
@@ -356,11 +351,9 @@ def test_solc_use_latest_patch_specific_not_included(testproject, network):
     with testproject._path.joinpath("brownie-config.yaml").open("w") as fp:
         yaml.dump(solc_config, fp)
 
-    # chainlink contract specifies version pragma ^0.4.16 which doesn't support overloaded
-    # events (>= 0.4.17)
-    c = Contract.from_explorer("0x514910771AF9Ca656af840dff83E8264EcF986CA")
-    transfer_events = list(filter(lambda l: "name" in l and l["name"] == "Transfer", c.abi))
-    assert len(transfer_events) == 1
+    assert Contract.get_solc_version(
+        "v0.4.16", "0x514910771AF9Ca656af840dff83E8264EcF986CA"
+    ) == Version("0.4.16")
 
 
 def test_solc_use_latest_patch_specific_included(testproject, network):
@@ -371,11 +364,9 @@ def test_solc_use_latest_patch_specific_included(testproject, network):
     with testproject._path.joinpath("brownie-config.yaml").open("w") as fp:
         yaml.dump(solc_config, fp)
 
-    # chainlink contract specifies version pragma ^0.4.16 which doesn't support overloaded
-    # events (>= 0.4.17)
-    c = Contract.from_explorer("0x514910771AF9Ca656af840dff83E8264EcF986CA")
-    transfer_events = list(filter(lambda l: "name" in l and l["name"] == "Transfer", c.abi))
-    assert len(transfer_events) == 2
+    assert Contract.get_solc_version(
+        "v0.4.16", "0x514910771AF9Ca656af840dff83E8264EcF986CA"
+    ) == Version("0.4.26")
 
 
 # @pytest.mark.parametrize(

--- a/tests/network/contract/test_contract.py
+++ b/tests/network/contract/test_contract.py
@@ -348,6 +348,36 @@ def test_solc_use_latest_patch_missing(testproject, network):
     assert len(transfer_events) == 1
 
 
+def test_solc_use_latest_patch_specific_not_included(testproject, network):
+    network.connect("mainnet")
+    solc_config = {
+        "compiler": {"solc": {"use_latest_patch": ["0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e"]}}
+    }
+    with testproject._path.joinpath("brownie-config.yaml").open("w") as fp:
+        yaml.dump(solc_config, fp)
+
+    # chainlink contract specifies version pragma ^0.4.16 which doesn't support overloaded
+    # events (>= 0.4.17)
+    c = Contract.from_explorer("0x514910771AF9Ca656af840dff83E8264EcF986CA")
+    transfer_events = list(filter(lambda l: "name" in l and l["name"] == "Transfer", c.abi))
+    assert len(transfer_events) == 1
+
+
+def test_solc_use_latest_patch_specific_included(testproject, network):
+    network.connect("mainnet")
+    solc_config = {
+        "compiler": {"solc": {"use_latest_patch": ["0x514910771AF9Ca656af840dff83E8264EcF986CA"]}}
+    }
+    with testproject._path.joinpath("brownie-config.yaml").open("w") as fp:
+        yaml.dump(solc_config, fp)
+
+    # chainlink contract specifies version pragma ^0.4.16 which doesn't support overloaded
+    # events (>= 0.4.17)
+    c = Contract.from_explorer("0x514910771AF9Ca656af840dff83E8264EcF986CA")
+    transfer_events = list(filter(lambda l: "name" in l and l["name"] == "Transfer", c.abi))
+    assert len(transfer_events) == 2
+
+
 # @pytest.mark.parametrize(
 #     "original",
 #     [


### PR DESCRIPTION
### What I did

I've noticed that there's an issue with the chainlink contract `0x514910771AF9Ca656af840dff83E8264EcF986CA` wrt. to overloaded events. This contract is both `ERC-20` and `ERC-677` based and so it emits both types of events which have a different signature and can't be matched properly with log filters. AFAIS, overloaded events have been fixed in solidity compiler version `0.4.17`, the contract defines `0.4.16` in its pragma version. The fact that brownie doesn't compile solidity contracts with version `<0.4.22` causes it to use the given abi from the explorer etherscan which is also incomplete in terms of overloaded events. To overcome this issue and generate a more complete abi I've added a solc compiler setting that enables the download of the latest patch version of a given compiler based on the contract's version pragma.

### How I did it
In this change, I've implemented a solidity compiler config flag called `use_latest_patch`.
It can be turned on for all contracts by setting the value `true`:
```
compiler:
    solc:
        use_latest_patch: true
```

Alternatively, specific contracts can be added as a string list:
```
compiler:
    solc:
        use_latest_patch:
            - '0x514910771AF9Ca656af840dff83E8264EcF986CA'
```

In both cases the latest semver patch version of the solc compiler is downloaded and if it's >= 0.4.22 this causes local re-compilation of the contract with the latest compiler instead of the one which is hard-coded in the contract sources. 

For the chainlink contract, this fixes the issue that the abi contained only a single Transfer event definition and now includes both event definitions as the re-compilation is done locally.

### How to verify it
The contract 0x514910771AF9Ca656af840dff83E8264EcF986CA specifies the compiler version `0.4.16` in its source code.
The latest patch semver version for solidity is therefore `0.4.26`

If the flag is set to either true or if the contract is contained in the list, the `0.4.26` version will be used, otherwise the `0.4.16` will be used.

```
# with use_latest_patch = true
>>> Contract.get_solc_version("v0.4.16", "0x514910771AF9Ca656af840dff83E8264EcF986CA")
Version('0.4.26')

# with use_latest_patch = false
>>> Contract.get_solc_version("v0.4.16", "0x514910771AF9Ca656af840dff83E8264EcF986CA")
Version('0.4.16')
```
### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [x] I have updated the documentation
- [x] I have added an entry to the changelog
