### PR TITLE
fix: update fantom rpc to new rpc

### DIFF
--- a/brownie/data/network-config.yaml
+++ b/brownie/data/network-config.yaml
@@ -84,7 +84,7 @@ live:
       - name: Mainnet
         chainid: 250
         id: ftm-main
-        host: https://rpcapi.fantom.network
+        host: https://rpc.ftm.tools
         explorer: https://api.ftmscan.com/api
   - name: Harmony
     networks:


### PR DESCRIPTION
### What I did
- Changed rpc url of fantom mainnet to the new rpc gateway recommended by fantom
Related issue: #

### How I did it
- edited network-config.yml
### How to verify it
- Try running brownie in ftm-main-fork network and it should work now,while previously it didnt
### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
