### PR TITLE
fixed 2 critical bugs on windows 

### DIFF
--- a/brownie/_config.py
+++ b/brownie/_config.py
@@ -179,7 +179,7 @@ def _load_config(project_path: Path) -> Dict:
 
     with path.open() as fp:
         if path.suffix in (".yaml", ".yml"):
-            return yaml.safe_load(fp)
+            return yaml.safe_load(fp) or {}
         raw_json = fp.read()
     valid_json = re.sub(r'\/\/[^"]*?(?=\n|$)', "", raw_json)
     return json.loads(valid_json)

--- a/brownie/project/scripts.py
+++ b/brownie/project/scripts.py
@@ -5,6 +5,7 @@ import importlib
 import sys
 import warnings
 from hashlib import sha1
+from importlib.machinery import SourceFileLoader
 from pathlib import Path, WindowsPath
 from types import FunctionType, ModuleType
 from typing import Any, Dict, List, Optional, Tuple
@@ -48,7 +49,7 @@ def run(
     # modify sys.path to ensure script can be imported
     if type(script) == WindowsPath:
         # far from elegant but just works
-        root_path = Path(".").resolve()
+        root_path = str(Path(".").resolve())
         script = script.relative_to(Path("..").resolve())
     else:
         root_path = Path(".").resolve().root
@@ -80,7 +81,8 @@ def run(
 
         # first, we extract the source code from the function and parse it to an AST
         # we generate the AST from the entire module to preserve line numbers
-        source = module.__loader__.get_source(module.__name__)
+        assert isinstance(module.__loader__, SourceFileLoader)
+        source = module.__loader__.get_source(module.__name__) or ""
         func_ast = ast.parse(source)
 
         # use the last function with the correct name, consistent with how python handles

--- a/brownie/project/scripts.py
+++ b/brownie/project/scripts.py
@@ -5,7 +5,7 @@ import importlib
 import sys
 import warnings
 from hashlib import sha1
-from pathlib import Path
+from pathlib import Path, WindowsPath
 from types import FunctionType, ModuleType
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -46,7 +46,13 @@ def run(
         project._add_to_main_namespace()
 
     # modify sys.path to ensure script can be imported
-    root_path = Path(".").resolve().root
+    if type(script) == WindowsPath:
+        # far from elegant but just works
+        root_path = Path(".").resolve()
+        script = script.relative_to(Path("..").resolve())
+    else:
+        root_path = Path(".").resolve().root
+
     sys.path.insert(0, root_path)
 
     try:
@@ -74,8 +80,7 @@ def run(
 
         # first, we extract the source code from the function and parse it to an AST
         # we generate the AST from the entire module to preserve line numbers
-        with Path(module.__file__).open() as fp:
-            source = fp.read()
+        source = module.__loader__.get_source(module.__name__)
         func_ast = ast.parse(source)
 
         # use the last function with the correct name, consistent with how python handles


### PR DESCRIPTION
Fixed 3 bugs:

1. failed to load python scripts on windows when running "brownie run xxx.py".

```
  File "C:\Users\guli\Anaconda3\envs\ethereum\lib\site-packages\brownie\_cli\run.py", line 50, in main
    return_value, frame = run(
  File "C:\Users\guli\Anaconda3\envs\ethereum\lib\site-packages\brownie\project\scripts.py", line 53, in run
    module = _import_from_path(script)
  File "C:\Users\guli\Anaconda3\envs\ethereum\lib\site-packages\brownie\project\scripts.py", line 149, in _import_from_path
    _import_cache[import_str] = importlib.import_module(import_str)
  File "C:\Users\guli\Anaconda3\envs\ethereum\lib\importlib\__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
```

2. if OS default encoding is different from the script's file encoding, "brownie run xxx.py" will throws an UnicodeDecodeError exception . 

For example, the script's file encoding is "utf-8" but the OS default encoding is "GBK".

3. exception when loading empty config file (brownie-config.yaml) 

