### PR TITLE
CLI flag for run command to raise exceptions to the caller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/eth-brownie/brownie)
 ### Changed
 - Force files to be opened as UTF-8
+- Add cli flag `-r` for raising exceptions to the caller instead of doing a system exit.
 
 ## [1.17.2](https://github.com/eth-brownie/brownie/tree/v1.17.2) - 2021-12-04
 ### Changed

--- a/brownie/_cli/__main__.py
+++ b/brownie/_cli/__main__.py
@@ -66,4 +66,7 @@ def main():
         notify("ERROR", "Brownie environment has not been initiated for this folder.")
         sys.exit("Type 'brownie init' to create the file structure.")
     except Exception as e:
-        sys.exit(color.format_tb(e))
+        if "-r" in sys.argv:
+            raise e
+        else:
+            sys.exit(color.format_tb(e))

--- a/brownie/_cli/run.py
+++ b/brownie/_cli/run.py
@@ -23,6 +23,7 @@ Options:
   --network [name]        Use a specific network (default {CONFIG.settings['networks']['default']})
   --silent                Suppress console output for transactions
   --interactive -I        Open an interactive console when the script completes or raises
+  --raise -r              Raise exceptions occured in the script to the caller
   --gas -g                Display gas profile for function calls
   --tb -t                 Show entire python traceback on exceptions
   --help -h               Display this message
@@ -55,7 +56,11 @@ def main():
         )
         exit_code = 0
     except Exception as e:
+        if args["--raise"]:
+            raise e
+
         print(color.format_tb(e))
+
         frame = next(
             (i.frame for i in inspect.trace()[::-1] if Path(i.filename).as_posix() == path_str),
             None,

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -108,6 +108,20 @@ def test_cli_run_with_missing_file(cli_tester):
     assert cli_tester.mock_subroutines.call_count == 1
 
 
+def test_cli_run_with_raise_flag(cli_tester):
+    cli_tester.monkeypatch.setattr("brownie.run", cli_tester.mock_subroutines)
+
+    subtargets = ("brownie.network.connect",)
+    for target in subtargets:
+        cli_tester.monkeypatch.setattr(target, cli_tester.mock_subroutines)
+
+    with pytest.raises(FileNotFoundError):
+        cli_tester.run_and_test_parameters("run testfile -r", parameters=None)
+
+    assert cli_tester.mock_subroutines.called is True
+    assert cli_tester.mock_subroutines.call_count == 1
+
+
 def test_cli_ethpm(cli_tester, testproject):
     cli_tester.monkeypatch.setattr("brownie._cli.ethpm._list", cli_tester.mock_subroutines)
 


### PR DESCRIPTION
### What I did
I've added a `-r` cli flag for the `brownie run` cli command which raises any exceptions to the caller instead of doing a system exit. I've noticed a system exit breaks the auto-capturing of exceptions with sentry because the excepthooks are not triggered at all.

With this addition I could verify that running a brownie script with the current [sentry_sdk](https://github.com/getsentry/sentry-python) works and automatically captures any unhandled exceptions like expected.

### How I did it
I've just modified the `except` blocks slightly to check for the flag and preserve the existing logic if it's not present.

### How to verify it
```
$ echo "1/0" > scripts/fail.py
$ brownie run fail -r
Traceback (most recent call last):
  File "/usr/local/bin/brownie", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.9/site-packages/brownie/_cli/__main__.py", line 70, in main
    raise e
  File "/usr/local/lib/python3.9/site-packages/brownie/_cli/__main__.py", line 64, in main
    importlib.import_module(f"brownie._cli.{cmd}").main()
  File "/usr/local/lib/python3.9/site-packages/brownie/_cli/run.py", line 60, in main
    raise e
  File "/usr/local/lib/python3.9/site-packages/brownie/_cli/run.py", line 51, in main
    return_value, frame = run(
  File "/usr/local/lib/python3.9/site-packages/brownie/project/scripts.py", line 53, in run
    module = _import_from_path(script)
  File "/usr/local/lib/python3.9/site-packages/brownie/project/scripts.py", line 149, in _import_from_path
    _import_cache[import_str] = importlib.import_module(import_str)
  File "/usr/local/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/app/scripts/fail.py", line 1, in <module>
    1/0
ZeroDivisionError: division by zero
```
### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [ ] I have updated the documentation
- [x] I have added an entry to the changelog
