### PR TITLE
Add the interfaces compilation artifacts into build/contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/eth-brownie/brownie)
 ### Changed
 - Force files to be opened as UTF-8
+- Add the interfaces compilation artifacts into build/contracts ([#941](https://github.com/eth-brownie/brownie/issues/941))
 
 ## [1.17.2](https://github.com/eth-brownie/brownie/tree/v1.17.2) - 2021-12-04
 ### Changed

--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -108,8 +108,7 @@ class _ProjectBase:
             os.chdir(cwd)
 
         for alias, data in build_json.items():
-            if self._build_path is not None and not data["sourcePath"].startswith("interface"):
-                # interfaces should generate artifact in /build/interfaces/ not /build/contracts/
+            if self._build_path is not None:
                 if alias == data["contractName"]:
                     # if the alias == contract name, this is a part of the core project
                     path = self._build_path.joinpath(f"contracts/{alias}.json")


### PR DESCRIPTION
### What I did
Add the interfaces compilation artifacts into build/contracts

See #941 for more details

### How I did it
I removed the original restrictions.

### How to verify it

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [X] I have added an entry to the changelog
