### PR TITLE
added alchemy and provider support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Force files to be opened as UTF-8
 - Added a new solidity compiler setting `use_latest_patch` in brownie-config.yaml to use the latest patch version of a compiler based on the pragma version of the contract.
 - Add cli flag `-r` for raising exceptions to the caller instead of doing a system exit.
+- Added support for alchemy out of the box with a `WEB3_ALCHEMY_PROJECT_ID` after running `brownie networks set_provider alchemy`. 
 
 ## [1.17.2](https://github.com/eth-brownie/brownie/tree/v1.17.2) - 2021-12-04
 ### Changed

--- a/brownie/_config.py
+++ b/brownie/_config.py
@@ -333,6 +333,12 @@ def _make_data_folders(data_folder: Path) -> None:
             data_folder.joinpath("network-config.yaml"),
         )
 
+    if not data_folder.joinpath("providers-config.yaml").exists():
+        shutil.copyfile(
+            BROWNIE_FOLDER.joinpath("data/providers-config.yaml"),
+            data_folder.joinpath("providers-config.yaml"),
+        )
+
 
 warnings.filterwarnings("once", category=DeprecationWarning, module="brownie")
 

--- a/brownie/data/network-config.yaml
+++ b/brownie/data/network-config.yaml
@@ -98,6 +98,20 @@ live:
         host: https://api.harmony.one
         id: harmony-main
         multicall2: "0x3E01dD8a5E1fb3481F0F589056b428Fc308AF0Fb"
+  - name: Optimistic Ethereum
+    networks:
+      - name: Mainnet
+        chainid: 10
+        id: optimism-main
+        host: https://mainnet.optimism.io
+        explorer: https://api-optimistic.etherscan.io/api
+        multicall2: "0x2DC0E2aa608532Da689e89e237dF582B783E552C"
+      - name: Kovan
+        chainid: 69
+        id: optimism-test
+        host: https://kovan.optimism.io
+        explorer: https://api-kovan-optimistic.etherscan.io/api
+        multicall2: "0x2DC0E2aa608532Da689e89e237dF582B783E552C"
   - name: Polygon
     networks:
       - name: Mainnet (Infura)
@@ -124,106 +138,107 @@ live:
         id: xdai-test
         host: https://sokol.poa.network
         explorer: https://blockscout.com/poa/sokol/api
+
 development:
-    - name: Ganache-CLI
-      id: development
-      cmd: ganache-cli
-      host: http://127.0.0.1
-      cmd_settings:
-          port: 8545
-          gas_limit: 12000000
-          accounts: 10
-          evm_version: istanbul
-          mnemonic: brownie
-    - name: Geth Dev
-      id: geth-dev
-      cmd: ethnode
-      host: http://127.0.0.1
-      cmd_settings:
-          port: 8545
-    - name: Hardhat
-      id: hardhat
-      cmd: npx hardhat node
-      host: http://localhost
-      cmd_settings:
-          port: 8545
-    - name: Hardhat (Mainnet Fork)
-      id: hardhat-fork
-      cmd: npx hardhat node
-      host: http://localhost
-      timeout: 120
-      cmd_settings:
-          port: 8545
-          fork: mainnet
-    - name: Ganache-CLI (Mainnet Fork)
-      id: mainnet-fork
-      cmd: ganache-cli
-      host: http://127.0.0.1
-      timeout: 120
-      cmd_settings:
-          port: 8545
-          gas_limit: 12000000
-          accounts: 10
-          evm_version: istanbul
-          mnemonic: brownie
-          fork: mainnet
-    - name: Ganache-CLI (BSC-Mainnet Fork)
-      id: bsc-main-fork
-      cmd: ganache-cli
-      host: http://127.0.0.1
-      timeout: 120
-      cmd_settings:
-          port: 8545
-          gas_limit: 12000000
-          accounts: 10
-          evm_version: istanbul
-          mnemonic: brownie
-          fork: bsc-main
-    - name: Ganache-CLI (FTM-Mainnet Fork)
-      id: ftm-main-fork
-      cmd: ganache-cli
-      host: http://127.0.0.1
-      timeout: 120
-      cmd_settings:
-          port: 8545
-          gas_limit: 12000000
-          accounts: 10
-          evm_version: istanbul
-          mnemonic: brownie
-          fork: ftm-main
-    - name: Ganache-CLI (Polygon-Mainnet Fork)
-      id: polygon-main-fork
-      cmd: ganache-cli
-      host: http://127.0.0.1
-      timeout: 120
-      cmd_settings:
-          port: 8545
-          gas_limit: 20000000
-          accounts: 10
-          evm_version: istanbul
-          mnemonic: brownie
-          fork: polygon-main
-    - name: Ganache-CLI (XDai-Mainnet Fork)
-      id: xdai-main-fork
-      cmd: ganache-cli
-      host: http://127.0.0.1
-      timeout: 120
-      cmd_settings:
-          port: 8545
-          gas_limit: 20000000
-          accounts: 10
-          evm_version: istanbul
-          mnemonic: brownie
-          fork: xdai-main
-    - name: Ganache-CLI (Avax-Mainnet Fork)
-      id: avax-main-fork
-      cmd: ganache-cli
-      host: http://127.0.0.1
-      timeout: 120
-      cmd_settings:
-          port: 8545
-          gas_limit: 20000000
-          accounts: 10
-          evm_version: istanbul
-          mnemonic: brownie
-          fork: avax-main
+  - name: Ganache-CLI
+    id: development
+    cmd: ganache-cli
+    host: http://127.0.0.1
+    cmd_settings:
+      port: 8545
+      gas_limit: 12000000
+      accounts: 10
+      evm_version: istanbul
+      mnemonic: brownie
+  - name: Geth Dev
+    id: geth-dev
+    cmd: ethnode
+    host: http://127.0.0.1
+    cmd_settings:
+      port: 8545
+  - name: Hardhat
+    id: hardhat
+    cmd: npx hardhat node
+    host: http://localhost
+    cmd_settings:
+      port: 8545
+  - name: Hardhat (Mainnet Fork)
+    id: hardhat-fork
+    cmd: npx hardhat node
+    host: http://localhost
+    timeout: 120
+    cmd_settings:
+      port: 8545
+      fork: mainnet
+  - name: Ganache-CLI (Mainnet Fork)
+    id: mainnet-fork
+    cmd: ganache-cli
+    host: http://127.0.0.1
+    timeout: 120
+    cmd_settings:
+      port: 8545
+      gas_limit: 12000000
+      accounts: 10
+      evm_version: istanbul
+      mnemonic: brownie
+      fork: mainnet
+  - name: Ganache-CLI (BSC-Mainnet Fork)
+    id: bsc-main-fork
+    cmd: ganache-cli
+    host: http://127.0.0.1
+    timeout: 120
+    cmd_settings:
+      port: 8545
+      gas_limit: 12000000
+      accounts: 10
+      evm_version: istanbul
+      mnemonic: brownie
+      fork: bsc-main
+  - name: Ganache-CLI (FTM-Mainnet Fork)
+    id: ftm-main-fork
+    cmd: ganache-cli
+    host: http://127.0.0.1
+    timeout: 120
+    cmd_settings:
+      port: 8545
+      gas_limit: 12000000
+      accounts: 10
+      evm_version: istanbul
+      mnemonic: brownie
+      fork: ftm-main
+  - name: Ganache-CLI (Polygon-Mainnet Fork)
+    id: polygon-main-fork
+    cmd: ganache-cli
+    host: http://127.0.0.1
+    timeout: 120
+    cmd_settings:
+      port: 8545
+      gas_limit: 20000000
+      accounts: 10
+      evm_version: istanbul
+      mnemonic: brownie
+      fork: polygon-main
+  - name: Ganache-CLI (XDai-Mainnet Fork)
+    id: xdai-main-fork
+    cmd: ganache-cli
+    host: http://127.0.0.1
+    timeout: 120
+    cmd_settings:
+      port: 8545
+      gas_limit: 20000000
+      accounts: 10
+      evm_version: istanbul
+      mnemonic: brownie
+      fork: xdai-main
+  - name: Ganache-CLI (Avax-Mainnet Fork)
+    id: avax-main-fork
+    cmd: ganache-cli
+    host: http://127.0.0.1
+    timeout: 120
+    cmd_settings:
+      port: 8545
+      gas_limit: 20000000
+      accounts: 10
+      evm_version: istanbul
+      mnemonic: brownie
+      fork: avax-main

--- a/brownie/data/network-config.yaml
+++ b/brownie/data/network-config.yaml
@@ -1,239 +1,230 @@
 live:
-  - name: Ethereum
-    networks:
-      - name: Mainnet (Infura)
-        chainid: 1
-        id: mainnet
-        host: https://mainnet.infura.io/v3/$WEB3_INFURA_PROJECT_ID
-        explorer: https://api.etherscan.io/api
-        multicall2: "0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696"
-      - name: Ropsten (Infura)
-        chainid: 3
-        id: ropsten
-        host: https://ropsten.infura.io/v3/$WEB3_INFURA_PROJECT_ID
-        explorer: https://api-ropsten.etherscan.io/api
-        multicall2: "0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696"
-      - name: Rinkeby (Infura)
-        chainid: 4
-        id: rinkeby
-        host: https://rinkeby.infura.io/v3/$WEB3_INFURA_PROJECT_ID
-        explorer: https://api-rinkeby.etherscan.io/api
-        multicall2: "0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696"
-      - name: Goerli (Infura)
-        chainid: 5
-        id: goerli
-        host: https://goerli.infura.io/v3/$WEB3_INFURA_PROJECT_ID
-        explorer: https://api-goerli.etherscan.io/api
-        multicall2: "0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696"
-      - name: Kovan (Infura)
-        chainid: 42
-        id: kovan
-        host: https://kovan.infura.io/v3/$WEB3_INFURA_PROJECT_ID
-        explorer: https://api-kovan.etherscan.io/api
-        multicall2: "0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696"
-  - name: Ethereum Classic
-    networks:
-      - name: Mainnet
-        chainid: 61
-        id: etc
-        host: https://www.ethercluster.com/etc
-        explorer: https://blockscout.com/etc/mainnet/api
-      - name: Kotti
-        chainid: 6
-        id: kotti
-        host: https://www.ethercluster.com/kotti
-        explorer: https://blockscout.com/etc/kotti/api
-  - name: Arbitrum
-    networks:
-      - name: Mainnet
-        chainid: 42161
-        id: arbitrum-main
-        host: https://arb1.arbitrum.io/rpc
-        explorer: https://api.arbiscan.io/api
-        multicall2: "0x5B5CFE992AdAC0C9D48E05854B2d91C73a003858"
-  - name: Avalanche
-    networks:
-      - chainid: 43114
-        explorer:  https://api.snowtrace.io/api
-        host: https://api.avax.network/ext/bc/C/rpc
-        id: avax-main
-        name: Mainnet
-      - chainid: 43113
-        host: https://api.avax-test.network/ext/bc/C/rpc
-        id: avax-test
-        name: Testnet
-  - name: Binance Smart Chain
-    networks:
-      - name: Testnet
-        chainid: 97
-        id: bsc-test
-        host: https://data-seed-prebsc-1-s1.binance.org:8545
-        explorer: https://api-testnet.bscscan.com/api
-      - name: Mainnet
-        chainid: 56
-        id: bsc-main
-        host: https://bsc-dataseed.binance.org
-        explorer: https://api.bscscan.com/api
-  - name: Fantom Opera
-    networks:
-      - name: Testnet
-        chainid: 0xfa2
-        id: ftm-test
-        host: https://rpc.testnet.fantom.network
-        explorer: https://explorer.testnet.fantom.network
-      - name: Mainnet
-        chainid: 250
-        id: ftm-main
-        host: https://rpcapi.fantom.network
-        explorer: https://api.ftmscan.com/api
-  - name: Harmony
-    networks:
-      - name: Mainnet (Shard 0)
-        chainid: 1666600000
-        host: https://api.harmony.one
-        id: harmony-main
-        multicall2: "0x3E01dD8a5E1fb3481F0F589056b428Fc308AF0Fb"
-  - name: Optimistic Ethereum
-    networks:
-      - name: Mainnet
-        chainid: 10
-        id: optimism-main
-        host: https://mainnet.optimism.io
-        explorer: https://api-optimistic.etherscan.io/api
-        multicall2: "0x2DC0E2aa608532Da689e89e237dF582B783E552C"
-      - name: Kovan
-        chainid: 69
-        id: optimism-test
-        host: https://kovan.optimism.io
-        explorer: https://api-kovan-optimistic.etherscan.io/api
-        multicall2: "0x2DC0E2aa608532Da689e89e237dF582B783E552C"
-  - name: Polygon
-    networks:
-      - name: Mainnet (Infura)
-        chainid: 137
-        id: polygon-main
-        host: https://polygon-mainnet.infura.io/v3/$WEB3_INFURA_PROJECT_ID
-        explorer: https://api.polygonscan.com/api
-        multicall2: "0xc8E51042792d7405184DfCa245F2d27B94D013b6"
-      - name: Mumbai Testnet (Infura)
-        chainid: 80001
-        id: polygon-test
-        host: https://polygon-mumbai.infura.io/v3/$WEB3_INFURA_PROJECT_ID
-        explorer: https://api-testnet.polygonscan.com/api
-        multicall2: "0x6842E0412AC1c00464dc48961330156a07268d14"
-  - name: XDai
-    networks:
-      - name: Mainnet
-        chainid: 100
-        id: xdai-main
-        host: https://xdai.poanetwork.dev
-        explorer: https://blockscout.com/xdai/mainnet/api
-      - name: Testnet
-        chainid: 77
-        id: xdai-test
-        host: https://sokol.poa.network
-        explorer: https://blockscout.com/poa/sokol/api
+    - name: Ethereum
+      networks:
+          - name: Mainnet (Infura)
+            chainid: 1
+            id: mainnet
+            host: https://mainnet.infura.io/v3/$WEB3_INFURA_PROJECT_ID
+            explorer: https://api.etherscan.io/api
+            multicall2: "0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696"
+            provider: infura
+          - name: Ropsten (Infura)
+            chainid: 3
+            id: ropsten
+            host: https://ropsten.infura.io/v3/$WEB3_INFURA_PROJECT_ID
+            explorer: https://api-ropsten.etherscan.io/api
+            multicall2: "0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696"
+            provider: infura
+          - name: Rinkeby (Infura)
+            chainid: 4
+            id: rinkeby
+            host: https://rinkeby.infura.io/v3/$WEB3_INFURA_PROJECT_ID
+            explorer: https://api-rinkeby.etherscan.io/api
+            multicall2: "0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696"
+            provider: infura
+          - name: Goerli (Infura)
+            chainid: 5
+            id: goerli
+            host: https://goerli.infura.io/v3/$WEB3_INFURA_PROJECT_ID
+            explorer: https://api-goerli.etherscan.io/api
+            multicall2: "0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696"
+            provider: infura
+          - name: Kovan (Infura)
+            chainid: 42
+            id: kovan
+            host: https://kovan.infura.io/v3/$WEB3_INFURA_PROJECT_ID
+            explorer: https://api-kovan.etherscan.io/api
+            multicall2: "0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696"
+            provider: infura
+    - name: Ethereum Classic
+      networks:
+          - name: Mainnet
+            chainid: 61
+            id: etc
+            host: https://www.ethercluster.com/etc
+            explorer: https://blockscout.com/etc/mainnet/api
+          - name: Kotti
+            chainid: 6
+            id: kotti
+            host: https://www.ethercluster.com/kotti
+            explorer: https://blockscout.com/etc/kotti/api
+    - name: Arbitrum
+      networks:
+          - name: Mainnet
+            chainid: 42161
+            id: arbitrum-main
+            host: https://arb1.arbitrum.io/rpc
+            explorer: https://api.arbiscan.io/api
+            multicall2: "0x5B5CFE992AdAC0C9D48E05854B2d91C73a003858"
+    - name: Avalanche
+      networks:
+          - chainid: 43114
+            explorer: https://api.snowtrace.io/api
+            host: https://api.avax.network/ext/bc/C/rpc
+            id: avax-main
+            name: Mainnet
+          - chainid: 43113
+            host: https://api.avax-test.network/ext/bc/C/rpc
+            id: avax-test
+            name: Testnet
+    - name: Binance Smart Chain
+      networks:
+          - name: Testnet
+            chainid: 97
+            id: bsc-test
+            host: https://data-seed-prebsc-1-s1.binance.org:8545
+            explorer: https://api-testnet.bscscan.com/api
+          - name: Mainnet
+            chainid: 56
+            id: bsc-main
+            host: https://bsc-dataseed.binance.org
+            explorer: https://api.bscscan.com/api
+    - name: Fantom Opera
+      networks:
+          - name: Testnet
+            chainid: 0xfa2
+            id: ftm-test
+            host: https://rpc.testnet.fantom.network
+            explorer: https://explorer.testnet.fantom.network
+          - name: Mainnet
+            chainid: 250
+            id: ftm-main
+            host: https://rpcapi.fantom.network
+            explorer: https://api.ftmscan.com/api
+    - name: Harmony
+      networks:
+          - name: Mainnet (Shard 0)
+            chainid: 1666600000
+            host: https://api.harmony.one
+            id: harmony-main
+            multicall2: "0x3E01dD8a5E1fb3481F0F589056b428Fc308AF0Fb"
+    - name: Polygon
+      networks:
+          - name: Mainnet (Infura)
+            chainid: 137
+            id: polygon-main
+            host: https://polygon-mainnet.infura.io/v3/$WEB3_INFURA_PROJECT_ID
+            explorer: https://api.polygonscan.com/api
+            multicall2: "0xc8E51042792d7405184DfCa245F2d27B94D013b6"
+          - name: Mumbai Testnet (Infura)
+            chainid: 80001
+            id: polygon-test
+            host: https://polygon-mumbai.infura.io/v3/$WEB3_INFURA_PROJECT_ID
+            explorer: https://api-testnet.polygonscan.com/api
+            multicall2: "0x6842E0412AC1c00464dc48961330156a07268d14"
+    - name: XDai
+      networks:
+          - name: Mainnet
+            chainid: 100
+            id: xdai-main
+            host: https://xdai.poanetwork.dev
+            explorer: https://blockscout.com/xdai/mainnet/api
+          - name: Testnet
+            chainid: 77
+            id: xdai-test
+            host: https://sokol.poa.network
+            explorer: https://blockscout.com/poa/sokol/api
 
 development:
-  - name: Ganache-CLI
-    id: development
-    cmd: ganache-cli
-    host: http://127.0.0.1
-    cmd_settings:
-      port: 8545
-      gas_limit: 12000000
-      accounts: 10
-      evm_version: istanbul
-      mnemonic: brownie
-  - name: Geth Dev
-    id: geth-dev
-    cmd: ethnode
-    host: http://127.0.0.1
-    cmd_settings:
-      port: 8545
-  - name: Hardhat
-    id: hardhat
-    cmd: npx hardhat node
-    host: http://localhost
-    cmd_settings:
-      port: 8545
-  - name: Hardhat (Mainnet Fork)
-    id: hardhat-fork
-    cmd: npx hardhat node
-    host: http://localhost
-    timeout: 120
-    cmd_settings:
-      port: 8545
-      fork: mainnet
-  - name: Ganache-CLI (Mainnet Fork)
-    id: mainnet-fork
-    cmd: ganache-cli
-    host: http://127.0.0.1
-    timeout: 120
-    cmd_settings:
-      port: 8545
-      gas_limit: 12000000
-      accounts: 10
-      evm_version: istanbul
-      mnemonic: brownie
-      fork: mainnet
-  - name: Ganache-CLI (BSC-Mainnet Fork)
-    id: bsc-main-fork
-    cmd: ganache-cli
-    host: http://127.0.0.1
-    timeout: 120
-    cmd_settings:
-      port: 8545
-      gas_limit: 12000000
-      accounts: 10
-      evm_version: istanbul
-      mnemonic: brownie
-      fork: bsc-main
-  - name: Ganache-CLI (FTM-Mainnet Fork)
-    id: ftm-main-fork
-    cmd: ganache-cli
-    host: http://127.0.0.1
-    timeout: 120
-    cmd_settings:
-      port: 8545
-      gas_limit: 12000000
-      accounts: 10
-      evm_version: istanbul
-      mnemonic: brownie
-      fork: ftm-main
-  - name: Ganache-CLI (Polygon-Mainnet Fork)
-    id: polygon-main-fork
-    cmd: ganache-cli
-    host: http://127.0.0.1
-    timeout: 120
-    cmd_settings:
-      port: 8545
-      gas_limit: 20000000
-      accounts: 10
-      evm_version: istanbul
-      mnemonic: brownie
-      fork: polygon-main
-  - name: Ganache-CLI (XDai-Mainnet Fork)
-    id: xdai-main-fork
-    cmd: ganache-cli
-    host: http://127.0.0.1
-    timeout: 120
-    cmd_settings:
-      port: 8545
-      gas_limit: 20000000
-      accounts: 10
-      evm_version: istanbul
-      mnemonic: brownie
-      fork: xdai-main
-  - name: Ganache-CLI (Avax-Mainnet Fork)
-    id: avax-main-fork
-    cmd: ganache-cli
-    host: http://127.0.0.1
-    timeout: 120
-    cmd_settings:
-      port: 8545
-      gas_limit: 20000000
-      accounts: 10
-      evm_version: istanbul
-      mnemonic: brownie
-      fork: avax-main
+    - name: Ganache-CLI
+      id: development
+      cmd: ganache-cli
+      host: http://127.0.0.1
+      cmd_settings:
+          port: 8545
+          gas_limit: 12000000
+          accounts: 10
+          evm_version: istanbul
+          mnemonic: brownie
+    - name: Geth Dev
+      id: geth-dev
+      cmd: ethnode
+      host: http://127.0.0.1
+      cmd_settings:
+          port: 8545
+    - name: Hardhat
+      id: hardhat
+      cmd: npx hardhat node
+      host: http://localhost
+      cmd_settings:
+          port: 8545
+    - name: Hardhat (Mainnet Fork)
+      id: hardhat-fork
+      cmd: npx hardhat node
+      host: http://localhost
+      timeout: 120
+      cmd_settings:
+          port: 8545
+          fork: mainnet
+    - name: Ganache-CLI (Mainnet Fork)
+      id: mainnet-fork
+      cmd: ganache-cli
+      host: http://127.0.0.1
+      timeout: 120
+      cmd_settings:
+          port: 8545
+          gas_limit: 12000000
+          accounts: 10
+          evm_version: istanbul
+          mnemonic: brownie
+          fork: mainnet
+    - name: Ganache-CLI (BSC-Mainnet Fork)
+      id: bsc-main-fork
+      cmd: ganache-cli
+      host: http://127.0.0.1
+      timeout: 120
+      cmd_settings:
+          port: 8545
+          gas_limit: 12000000
+          accounts: 10
+          evm_version: istanbul
+          mnemonic: brownie
+          fork: bsc-main
+    - name: Ganache-CLI (FTM-Mainnet Fork)
+      id: ftm-main-fork
+      cmd: ganache-cli
+      host: http://127.0.0.1
+      timeout: 120
+      cmd_settings:
+          port: 8545
+          gas_limit: 12000000
+          accounts: 10
+          evm_version: istanbul
+          mnemonic: brownie
+          fork: ftm-main
+    - name: Ganache-CLI (Polygon-Mainnet Fork)
+      id: polygon-main-fork
+      cmd: ganache-cli
+      host: http://127.0.0.1
+      timeout: 120
+      cmd_settings:
+          port: 8545
+          gas_limit: 20000000
+          accounts: 10
+          evm_version: istanbul
+          mnemonic: brownie
+          fork: polygon-main
+    - name: Ganache-CLI (XDai-Mainnet Fork)
+      id: xdai-main-fork
+      cmd: ganache-cli
+      host: http://127.0.0.1
+      timeout: 120
+      cmd_settings:
+          port: 8545
+          gas_limit: 20000000
+          accounts: 10
+          evm_version: istanbul
+          mnemonic: brownie
+          fork: xdai-main
+    - name: Ganache-CLI (Avax-Mainnet Fork)
+      id: avax-main-fork
+      cmd: ganache-cli
+      host: http://127.0.0.1
+      timeout: 120
+      cmd_settings:
+          port: 8545
+          gas_limit: 20000000
+          accounts: 10
+          evm_version: istanbul
+          mnemonic: brownie
+          fork: avax-main

--- a/brownie/data/providers-config.yaml
+++ b/brownie/data/providers-config.yaml
@@ -1,0 +1,4 @@
+infura:
+    host: https://{}.infura.io/v3/$WEB3_INFURA_PROJECT_ID
+alchemy:
+    host: https://eth-{}.alchemyapi.io/v2/$WEB3_ALCHEMY_PROJECT_ID

--- a/docs/network-management.rst
+++ b/docs/network-management.rst
@@ -187,16 +187,68 @@ Clients such as `Geth <https://geth.ethereum.org/>`_ or `Parity <https://www.par
 
 If you wish to learn more about running a node, ethereum.org provides a `list of resources <https://ethereum.org/en/developers/docs/nodes-and-clients/>`_ that you can use to get started.
 
-Using a Hosted Node
-*******************
+Using a Hosted Node / Providers
+========================================
 
-Services such as `Infura <https://infura.io>`_ provide public access to Ethereum nodes. This is a much simpler option than running your own, but it is not without limitations:
+Services such as `Alchemy <https://www.alchemy.com>`_ and `Infura <https://infura.io>`_ provide public access to Ethereum nodes. This is a much simpler option than running your own, but it is not without limitations:
 
     1. Some RPC endpoints may be unavailable. In particular, Infura does not provide access to the `debug_traceTransaction <https://geth.ethereum.org/docs/rpc/ns-debug#debug_tracetransaction>`_ method. For this reason, Brownie's :ref:`debugging tools<debug>` will not work when connected via Infura.
     2. Hosted nodes do not provide access to accounts - this would be a major security hazard! You will have to manually unlock your own :ref:`local account<local-accounts>` before you can make a transaction.
 
-Using Infura
-^^^^^^^^^^^^
+Brownie allows you to bulk modify the provider you use by setting the `provider` field in the networks, and the associated provider. 
+
+::
+
+    $ brownie networks providers_list
+
+    Brownie v1.17.2 - Python development framework for Ethereum
+
+    The following providers are declared:
+    ├─dict_keys(['infura', 'alchemy']):
+
+or
+
+::
+
+    $ brownie networks providers_list True
+
+    Brownie v1.17.2 - Python development framework for Ethereum
+
+    The following providers are declared:
+    ├─provider: infura:
+    ├─   host: {'host': 'https://{}.infura.io/v3/$WEB3_INFURA_PROJECT_ID'}:
+    ├─provider: alchemy:
+    ├─   host: {'host': 'https://eth-{}.alchemyapi.io/v2/$WEB3_ALCHEMY_PROJECT_ID'}:
+
+
+Any `network` that has a `provider` set will be able to be swapped to the format of another provider. For example, to swap all provider-based networks to Alchemy, run:
+
+::
+
+    $ brownie networks set_provider alchemy
+
+
+And it'll print out all the valid networks to swap to the Alchemy format. If you don't have a `provider` set, you can set one with:
+
+::
+
+    $ brownie networks modify mainnet provider=alchemy
+
+
+Adding Providers
+----------------
+
+To add or update a provider, run: 
+
+::
+
+    $ brownie networks update_provider alchemy https://eth-{}.alchemyapi.io/v2/$WEB3_ALCHEMY_PROJECT_ID
+
+
+This URL will allow brownie to swap out the {} with whatever network it's on, and you'll set a `WEB3_ALCHEMY_PROJECT_ID` environment variable as your Alchemy key. 
+
+Using Infura 
+************
 
 To Infura you need to `register for an account <https://infura.io/register>`_. Once you have signed up, login and create a new project. You will be provided with a project ID, as well as API URLs that can be leveraged to access the network.
 
@@ -205,6 +257,26 @@ To connect to Infura using Brownie, store your project ID as an environment vari
 ::
 
     $ export WEB3_INFURA_PROJECT_ID=YourProjectID
+
+Or adding `export WEB3_INFURA_PROJECT_ID=YourProjectID` to your `.env` and adding `dotenv: .env` to your `brownie-config.yaml`. 
+
+
+Using Alchemy
+*************
+
+To Alchemy you need to `signup for an account <https://auth.alchemyapi.io/signup>`_. Once you have signed up, login and create a new project. You will be provided with a URL that can be leveraged to access the network.
+
+Hit the `view key` button, and you'll be given a URL. You can just use the section after the last slash as your `WEB3_ALCHEMY_PROJECT_ID`. For example if your full key is: `https://eth-mainnet.alchemyapi.io/v2/1234`, your `WEB3_ALCHEMY_PROJECT_ID` would be `1234`.
+Note, this only works well with ETH networks at the moment, but you can modify your providers list at any time. 
+
+You can set your `WEB3_ALCHEMY_PROJECT_ID` with the following command
+::
+
+    $ export WEB3_ALCHEMY_PROJECT_ID=YourProjectID
+
+Or adding `export WEB3_ALCHEMY_PROJECT_ID=YourProjectID` to your `.env` and adding `dotenv: .env` to your `brownie-config.yaml`. 
+
+To connect with other non-ethereum networks through alchemy, you'll have to follow the normal network adding process. 
 
 .. _network-management-fork:
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -26,7 +26,7 @@ certifi==2021.10.8
     #   requests
 cffi==1.15.0
     # via cryptography
-charset-normalizer==2.0.7
+charset-normalizer==2.0.9
     # via
     #   -c requirements.txt
     #   requests
@@ -61,7 +61,7 @@ idna==3.3
     #   requests
 imagesize==1.2.0
     # via sphinx
-importlib-metadata==4.8.1
+importlib-metadata==4.8.2
     # via
     #   keyring
     #   twine
@@ -89,7 +89,7 @@ mypy-extensions==0.4.3
     # via
     #   -c requirements.txt
     #   mypy
-packaging==21.0
+packaging==21.3
     # via
     #   -c requirements.txt
     #   bleach
@@ -111,7 +111,7 @@ pluggy==1.0.0
     #   -c requirements.txt
     #   pytest
     #   tox
-py==1.10.0
+py==1.11.0
     # via
     #   -c requirements.txt
     #   pytest
@@ -127,7 +127,7 @@ pygments==2.10.0
     #   -c requirements.txt
     #   readme-renderer
     #   sphinx
-pyparsing==3.0.3
+pyparsing==3.0.6
     # via
     #   -c requirements.txt
     #   packaging


### PR DESCRIPTION
### What I did

Added support for Alchemy built-in

Related issue: #

https://github.com/eth-brownie/brownie/issues/1177

### How I did it

I added a `providers-config.yaml` to the `.brownie` dir. Now, if you want to switch from Infura to Alchemy, you set your `WEB3_ALCHEMY_PROJECT_ID` and run:

```
brownie networks set_provider alchemy
```

### How to verify it

Try it out!

1. Add a `provider` flag to your infura network of choice.

```
brownie networks modify mainnet provider=infura
```

Then, swap it to alchemy

```
brownie networks set_provider alchemy
```

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [x] I have updated the documentation
- [x] I have added an entry to the changelog


For some reason, a few tests locally keep failing for me... wondering if I can get some help cleaning up the last few. 
