### PR TITLE
Fix exception handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new solidity compiler setting `use_latest_patch` in brownie-config.yaml to use the latest patch version of a compiler based on the pragma version of the contract.
 - Add cli flag `-r` for raising exceptions to the caller instead of doing a system exit.
 
+### Fixed
+- Improve support for Ganache 7 reverted transactions
+
 ## [1.17.2](https://github.com/eth-brownie/brownie/tree/v1.17.2) - 2021-12-04
 ### Changed
 - Bump deps to support vyper `v0.3.1`

--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -774,6 +774,23 @@ class _PrivateKeyAccount(PublicKeyAccount):
                     time.sleep(1)
 
         receipt = self._await_confirmation(receipt, required_confs, gas_strategy, gas_iter)
+        if receipt.status != 1 and exc is None:
+            error_data = {
+                "message": (
+                    f"VM Exception while processing transaction: revert {receipt.revert_msg}"
+                ),
+                "code": -32000,
+                "data": {
+                    receipt.txid: {
+                        "error": "revert",
+                        "program_counter": receipt._revert_pc,
+                        "return": receipt.return_value,
+                        "reason": receipt.revert_msg,
+                    },
+                },
+            }
+            exc = VirtualMachineError(ValueError(error_data))
+
         return receipt, exc
 
     def _await_confirmation(


### PR DESCRIPTION
### What I did

Exception handling seems to be failing in a few cases with Ganache 7, which is now the latest stable version.
This seems a bit hacky overall but does seem to do the job for our fairly large test suite, so hopefully, it should be better than nothing. It should also not introduce any regression since most of the additions only occur if the logic already in place failed to handle the exception.

### How I did it

1. With the latest ganache, for some reason, web3py does not raise a `ValueError` when a contracts revert so we manually create a `VirtualMachineError` in Brownie when the receipt status is `0` otherwise, we have an attribute error in Brownie because the exception is `None`. This works for almost everything but we lose the PC and a few other nice-to-have features. I think that the longer-term fix would be either in Ganache (keep a backward-compatible format) or in web3py (support new Ganache response format)
2. The error format seems to be slightly different in the latest version of Ganache (i.e. the txid is not in the data), which causes the `VirtualMachineError` to throw a `ValueError`, breaking `brownie.reverts`. When this is the case, we try to see if we can still find the program counter and `revert_type`  before throwing a `ValueError`

### How to verify it

A simple script running on ganache v7 should do the trick.

```solidity
// Foo.sol
contract Foo {
  function foo() external {
    revert("done");
  }
}
```

```python
# foo.py
foo = accounts[0].deploy(Foo)
with brownie.reverts("done"):
    foo.foo({"from": accounts[0]})
```

This fails with the current version of Brownie but works with this patch.

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [x] I have added an entry to the changelog
