### PR TITLE
Support ganache 7 cli flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/eth-brownie/brownie)
+### Added
+- Add support for Ganache 7 CLI flags
 ### Changed
 - Force files to be opened as UTF-8
 - Added a new solidity compiler setting `use_latest_patch` in brownie-config.yaml to use the latest patch version of a compiler based on the pragma version of the contract.


### PR DESCRIPTION
### What I did

Ganache changed their CLI flags in version 7, which breaks Brownie, especially because `--chainId` is not a thing anymore, it's now `--chain.chainId`.

### How I did it

We now check the current version of ganache and use the appropriate flags.

### How to verify it

Installing Ganache 7 and running a console in non-development network should do it

```
brownie console --network mainnet-fork
```

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [x] I have added an entry to the changelog
