### PR TITLE
feat: eth_call state override for contract methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Force files to be opened as UTF-8
 - Added a new solidity compiler setting `use_latest_patch` in brownie-config.yaml to use the latest patch version of a compiler based on the pragma version of the contract.
 - Add cli flag `-r` for raising exceptions to the caller instead of doing a system exit.
+- Add `override` argument to contract methods which allows changing the state before the call, including overwriting balance, nonce, code, and storage of any address.
 
 ## [1.17.2](https://github.com/eth-brownie/brownie/tree/v1.17.2) - 2021-12-04
 ### Changed


### PR DESCRIPTION
- fix: inconsistency between `__call__` and `call` arguments in `OverloadedMethod`
- feat: add state override support to contract calls
- docs: add docs about eth_call override

### What I did

Added basic support for [state override](https://geth.ethereum.org/docs/rpc/ns-eth) feature of `eth_call`. It allows ephemerally changing the state of any addresses before call, including balance, nonce, code, storage slots.

### How I did it

Added an optional `override` argument to `ContractCall` and to everything that plugs into it.

### How to verify it

See example provided in the docs.

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [x] I have updated the documentation
- [x] I have added an entry to the changelog
