### PR TITLE
Retry compilation with multiple compilers matching version pragma

### DIFF
--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -1130,13 +1130,17 @@ class Contract(_DeployedContractBase):
             sources = {k: v["content"] for k, v in input_json["sources"].items()}
             evm_version = input_json["settings"].get("evmVersion", evm_version)
 
-            compiler.set_solc_version(str(version))
-            input_json.update(
-                compiler.generate_input_json(sources, optimizer=optimizer, evm_version=evm_version)
+            compiler_targets = [
+                {"version": str(version), "language": "Solidity", "to_compile": list(sources)}
+            ]
+            build_json = compiler.compile_and_format(
+                sources,
+                version=str(version),
+                optimizer=optimizer,
+                evm_version=evm_version,
+                compiler_targets=compiler_targets,
+                silent=silent,
             )
-            output_json = compiler.compile_from_input_json(input_json)
-            compiler_data = {"version": str(version)}
-            build_json = compiler.generate_build_json(input_json, output_json, compiler_data)
         else:
             if source_str.startswith("{"):
                 # source was submitted as multiple files
@@ -1149,12 +1153,12 @@ class Contract(_DeployedContractBase):
                     path_str = f"{name}-flattened.sol"
                 sources = {path_str: source_str}
 
-            build_json = compiler.try_compile_and_format(
+            build_json = compiler.compile_and_format(
                 sources,
-                solc_version=str(version),
-                vyper_version=str(version),
+                version=str(version),
                 optimizer=optimizer,
                 evm_version=evm_version,
+                silent=silent,
             )
 
         build_json = build_json[name]

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -1148,7 +1148,7 @@ class Contract(_DeployedContractBase):
                     path_str = f"{name}-flattened.sol"
                 sources = {path_str: source_str}
 
-            build_json = compiler.compile_and_format(
+            build_json = compiler.try_compile_and_format(
                 sources,
                 solc_version=str(version),
                 vyper_version=str(version),

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -1157,6 +1157,10 @@ class Contract(_DeployedContractBase):
             )
 
         build_json = build_json[name]
+        if not silent:
+            lang = build_json["language"]
+            version = build_json["version"]
+            print(f"Successfully compiled {address} with {lang} compiler version {version}")
         if as_proxy_for is not None:
             build_json.update(abi=abi, natspec=implementation_contract._build.get("natspec"))
 

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -1135,7 +1135,8 @@ class Contract(_DeployedContractBase):
                 compiler.generate_input_json(sources, optimizer=optimizer, evm_version=evm_version)
             )
             output_json = compiler.compile_from_input_json(input_json)
-            build_json = compiler.generate_build_json(input_json, output_json)
+            compiler_data = {"version": str(version)}
+            build_json = compiler.generate_build_json(input_json, output_json, compiler_data)
         else:
             if source_str.startswith("{"):
                 # source was submitted as multiple files

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -1135,7 +1135,8 @@ class Contract(_DeployedContractBase):
             ]
             build_json = compiler.compile_and_format(
                 sources,
-                version=str(version),
+                solc_version=str(version),
+                vyper_version=str(version),
                 optimizer=optimizer,
                 evm_version=evm_version,
                 compiler_targets=compiler_targets,
@@ -1156,7 +1157,8 @@ class Contract(_DeployedContractBase):
 
             build_json = compiler.compile_and_format(
                 sources,
-                version=str(version),
+                solc_version=str(version),
+                vyper_version=str(version),
                 optimizer=optimizer,
                 evm_version=evm_version,
                 silent=silent,

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -1140,6 +1140,7 @@ class Contract(_DeployedContractBase):
                 evm_version=evm_version,
                 compiler_targets=compiler_targets,
                 silent=silent,
+                retry=compiler.get_retry(),
             )
         else:
             if source_str.startswith("{"):
@@ -1159,6 +1160,7 @@ class Contract(_DeployedContractBase):
                 optimizer=optimizer,
                 evm_version=evm_version,
                 silent=silent,
+                retry=compiler.get_retry(),
             )
 
         build_json = build_json[name]

--- a/brownie/project/build.py
+++ b/brownie/project/build.py
@@ -31,6 +31,7 @@ BUILD_KEYS = [
     "sha1",
     "source",
     "sourcePath",
+    "version",
 ] + DEPLOYMENT_KEYS
 
 _revert_map: Dict = {}

--- a/brownie/project/compiler/__init__.py
+++ b/brownie/project/compiler/__init__.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 import json
+import os
 import warnings
 from copy import deepcopy
 from hashlib import sha1
@@ -11,7 +12,7 @@ import solcast
 from eth_utils import remove_0x_prefix
 from semantic_version import Version
 
-from brownie._config import _get_data_folder
+from brownie._config import _get_data_folder, _load_project_compiler_config
 from brownie.exceptions import BrownieCompilerWarning, UnsupportedLanguage
 from brownie.project import sources
 from brownie.project.compiler.solidity import (  # NOQA: F401
@@ -611,3 +612,20 @@ def get_abi(
             }
 
     return final_output
+
+    def get_retry_compiler_config(self) -> bool:
+        """
+        Return the compiler boolean flag 'retry' which toggles if the compilation
+        should be retried with the next compatible compiler in case of an exception.
+
+        If this is set to `True`, it will use compiler versions in the following order:
+        `[ contract_version, latest_installed_version, latest_available_version ]`
+
+        The first compilation that is not throwing an exception will be returned.
+        If all compilers throw an exception, the exeption will be raised.
+
+        If this is set to `False` or the key is missing, no retries will be performed
+        and the first compilation result will be returned or the exception raised.
+        """
+        compiler_config = _load_project_compiler_config(Path(os.getcwd()))
+        return compiler_config.get("retry", False)

--- a/brownie/project/compiler/__init__.py
+++ b/brownie/project/compiler/__init__.py
@@ -613,19 +613,20 @@ def get_abi(
 
     return final_output
 
-    def get_retry_compiler_config(self) -> bool:
-        """
-        Return the compiler boolean flag 'retry' which toggles if the compilation
-        should be retried with the next compatible compiler in case of an exception.
 
-        If this is set to `True`, it will use compiler versions in the following order:
-        `[ contract_version, latest_installed_version, latest_available_version ]`
+def get_retry(self) -> bool:
+    """
+    Return the compiler boolean flag 'retry' which toggles if the compilation
+    should be retried with the next compatible compiler in case of an exception.
 
-        The first compilation that is not throwing an exception will be returned.
-        If all compilers throw an exception, the exeption will be raised.
+    If this is set to `True`, it will use compiler versions in the following order:
+    `[ contract_version, latest_installed_version, latest_available_version ]`
 
-        If this is set to `False` or the key is missing, no retries will be performed
-        and the first compilation result will be returned or the exception raised.
-        """
-        compiler_config = _load_project_compiler_config(Path(os.getcwd()))
-        return compiler_config.get("retry", False)
+    The first compilation that is not throwing an exception will be returned.
+    If all compilers throw an exception, the exeption will be raised.
+
+    If this is set to `False` or the key is missing, no retries will be performed
+    and the first compilation result will be returned or the exception raised.
+    """
+    compiler_config = _load_project_compiler_config(Path(os.getcwd()))
+    return compiler_config.get("retry", False)

--- a/brownie/project/compiler/__init__.py
+++ b/brownie/project/compiler/__init__.py
@@ -5,7 +5,7 @@ import warnings
 from copy import deepcopy
 from hashlib import sha1
 from pathlib import Path
-from typing import Dict, Optional, Union
+from typing import Callable, Collection, Dict, List, Optional, Tuple, Union
 
 import solcast
 from eth_utils import remove_0x_prefix
@@ -47,104 +47,153 @@ EVM_SOLC_VERSIONS = [
 ]
 
 
-def try_compile_and_format(
+def get_compiler_targets(
     contract_sources: Dict[str, str],
-    solc_version: Optional[str] = None,
-    vyper_version: Optional[str] = None,
+    find_version_func: Callable,
+    language: str,
+    version: str = None,
+    retry: bool = False,
+    silent: bool = True,
+) -> List[Dict[str, Collection[str]]]:
+
+    compiler_targets = []
+    versions = []
+    # TODO add `vyper_version` input arg to manually specify, support in config file
+    if version:
+        # add the compiler matching the passed version
+        compiler_targets.append(
+            {
+                "language": language,
+                "version": version,
+                "to_compile": contract_sources,
+            }
+        )
+        if not retry:
+            return compiler_targets
+
+        versions.append(version)
+
+    for file_name, contents in contract_sources.items():
+        if len(contents) == 0:
+            continue
+        # add the latest installed compiler
+        for v in find_version_func(
+            contract_sources, install_needed=True, install_latest=False, silent=silent
+        ).keys():
+            if v not in versions:
+                versions.append(v)
+                compiler_targets.append(
+                    {
+                        "language": language,
+                        "version": v,
+                        "to_compile": contract_sources,
+                    }
+                )
+
+        # add the latest available compiler
+        for v in find_version_func(
+            contract_sources, install_needed=True, install_latest=True, silent=silent
+        ).keys():
+            if v not in versions:
+                versions.append(v)
+                compiler_targets.append(
+                    {
+                        "language": language,
+                        "version": v,
+                        "to_compile": contract_sources,
+                    }
+                )
+
+    return compiler_targets
+
+
+def prepare_compilers(
+    contract_sources: Dict[str, str],
+    interface_sources: Dict[str, str],
+    version: Optional[str] = None,
     optimize: bool = True,
+    optimizer: Optional[Dict] = None,
     runs: int = 200,
     evm_version: Optional[str] = None,
+    retry: bool = False,
     silent: bool = True,
-    allow_paths: Optional[str] = None,
+) -> Tuple[List[Dict], Optional[Dict], Optional[Dict], Optional[str]]:
+
+    compiler_targets: List[Dict] = []
+    interfaces: Dict = {}
+    vyper_sources = {k: v for k, v in contract_sources.items() if Path(k).suffix == ".vy"}
+    solc_sources = {k: v for k, v in contract_sources.items() if Path(k).suffix == ".sol"}
+    language = None
+    if vyper_sources:
+        language = "Vyper"
+        compiler_targets = get_compiler_targets(
+            contract_sources=vyper_sources,
+            version=version,
+            find_version_func=find_vyper_versions,
+            language=language,
+            retry=retry,
+            silent=silent,
+        )
+        interfaces = {k: v for k, v in interface_sources.items() if Path(k).suffix != ".sol"}
+    elif solc_sources:
+        language = "Solidity"
+        compiler_targets = get_compiler_targets(
+            contract_sources=solc_sources,
+            version=version,
+            find_version_func=find_solc_versions,
+            language=language,
+            retry=retry,
+            silent=silent,
+        )
+        interfaces = {
+            k: v
+            for k, v in interface_sources.items()
+            if Path(k).suffix == ".sol" and Version(version) in sources.get_pragma_spec(v, k)
+        }
+        if optimizer is None:
+            optimizer = {"enabled": optimize, "runs": runs if optimize else 0}
+    
+    evm_version = evm_version[language] if isinstance(evm_version, dict) else evm_version
+    return compiler_targets, interfaces, optimizer, evm_version
+
+
+def prepared_compile_and_format(
+    to_compile: Dict[str, str],
+    version: str,
+    language: str,
     interface_sources: Optional[Dict[str, str]] = None,
+    allow_paths: Optional[str] = None,
     remappings: Optional[list] = None,
     optimizer: Optional[Dict] = None,
+    evm_version: Optional[str] = None,
+    silent: bool = True,
 ) -> Dict:
 
-    exceptions = []
-    build_json = None
-    try:
-        build_json = compile_and_format(
-            contract_sources=contract_sources,
-            solc_version=solc_version,
-            vyper_version=vyper_version,
-            optimize=optimize,
-            runs=runs,
-            evm_version=evm_version,
-            silent=silent,
-            allow_paths=allow_paths,
-            interface_sources=interface_sources,
-            remappings=remappings,
-            optimizer=optimizer,
-            install_latest=False,
-        )
-    except Exception as e1:
-        if not solc_version and not vyper_version:
-            raise
+    build_json: Dict = {}
+    compiler_data = {}
 
-        exceptions.append(e1)
-        if not silent:
-            warnings.warn(
-                "Re-trying compilation with the latest installed version.",
-                BrownieCompilerWarning,
-            )
-        # now try one more time with the latest installed one
-        try:
-            build_json = compile_and_format(
-                contract_sources=contract_sources,
-                runs=runs,
-                evm_version=evm_version,
-                silent=silent,
-                allow_paths=allow_paths,
-                interface_sources=interface_sources,
-                remappings=remappings,
-                optimizer=optimizer,
-                optimize=optimize,
-                install_latest=False,
-            )
-        except Exception as e2:
-            exceptions.append(e2)
-            if not silent:
-                warnings.warn(
-                    "Re-trying compilation with the latest available version.",
-                    BrownieCompilerWarning,
-                )
-            try:
-                # now try one more time with the latest available one
-                build_json = compile_and_format(
-                    contract_sources=contract_sources,
-                    runs=runs,
-                    evm_version=evm_version,
-                    silent=silent,
-                    allow_paths=allow_paths,
-                    interface_sources=interface_sources,
-                    remappings=remappings,
-                    optimizer=optimizer,
-                    optimize=optimize,
-                    install_latest=True,
-                )
-            except Exception as e3:
-                exceptions.append(e3)
+    if language == "Vyper":
+        set_vyper_version(version)
+    elif language == "Solidity":
+        set_solc_version(version)
 
-    for e in exceptions:
-        print("Got exception during compilation:")
-        print(color.format_tb(e))
-        print("\n")
-
-    if not build_json:
-        # if it's still failing to compile raise
-        if len(exceptions) > 0:
-            raise exceptions[-1]
-        else:
-            raise Exception("Compilation failed!")
-
+    compiler_data["version"] = version
+    input_json = generate_input_json(
+        to_compile,
+        evm_version=evm_version,
+        language=language,
+        interface_sources=interface_sources,
+        remappings=remappings,
+        optimizer=optimizer,
+    )
+    output_json = compile_from_input_json(input_json, silent, allow_paths)
+    build_json.update(generate_build_json(input_json, output_json, compiler_data, silent))
     return build_json
 
 
 def compile_and_format(
     contract_sources: Dict[str, str],
-    solc_version: Optional[str] = None,
-    vyper_version: Optional[str] = None,
+    version: Optional[str] = None,
     optimize: bool = True,
     runs: int = 200,
     evm_version: Optional[Union[str, Dict[str, str]]] = None,
@@ -153,7 +202,8 @@ def compile_and_format(
     interface_sources: Optional[Dict[str, str]] = None,
     remappings: Optional[list] = None,
     optimizer: Optional[Dict] = None,
-    install_latest: bool = False,
+    compiler_targets: Optional[List[Dict]] = None,
+    retry: bool = False,
 ) -> Dict:
     """Compiles contracts and returns build data.
 
@@ -168,7 +218,8 @@ def compile_and_format(
         interface_sources: dictionary of interfaces as {'path': "source code"}
         remappings: list of solidity path remappings
         optimizer: dictionary of solidity optimizer settings
-        install_latest: boolean that toggles if the latest installable version should be downloaded
+        compiler_targets: list of compiler_targets containing versions and sources
+        retry: boolean that toggles if the compilation should be retried with compatible compilers
 
     Returns:
         build data dict
@@ -177,74 +228,52 @@ def compile_and_format(
         return {}
     if interface_sources is None:
         interface_sources = {}
+    if compiler_targets is None:
+        compiler_targets = []
+
+    interfaces: Optional[Dict] = {}
 
     if [i for i in contract_sources if Path(i).suffix not in (".sol", ".vy")]:
         raise UnsupportedLanguage("Source suffixes must be one of ('.sol', '.vy')")
     if [i for i in interface_sources if Path(i).suffix not in (".sol", ".vy", ".json")]:
         raise UnsupportedLanguage("Interface suffixes must be one of ('.sol', '.vy', '.json')")
 
-    build_json: Dict = {}
-    compiler_targets = {}
-
-    vyper_sources = {k: v for k, v in contract_sources.items() if Path(k).suffix == ".vy"}
-    if vyper_sources:
-        # TODO add `vyper_version` input arg to manually specify, support in config file
-        if vyper_version is None:
-            compiler_targets.update(
-                find_vyper_versions(
-                    vyper_sources, install_needed=True, install_latest=install_latest, silent=silent
-                )
-            )
-        else:
-            compiler_targets[vyper_version] = list(vyper_sources)
-    solc_sources = {k: v for k, v in contract_sources.items() if Path(k).suffix == ".sol"}
-    if solc_sources:
-        if solc_version is None:
-            compiler_targets.update(
-                find_solc_versions(
-                    solc_sources, install_needed=True, install_latest=install_latest, silent=silent
-                )
-            )
-        else:
-            compiler_targets[solc_version] = list(solc_sources)
-
-        if optimizer is None:
-            optimizer = {"enabled": optimize, "runs": runs if optimize else 0}
-
-    for version, path_list in compiler_targets.items():
-        compiler_data: Dict = {}
-        if path_list[0].endswith(".vy"):
-            set_vyper_version(version)
-            language = "Vyper"
-            compiler_data["version"] = str(vyper.get_version())
-            interfaces = {
-                k: v for k, v in interface_sources.items() if Path(k).suffix != ".sol"
-            }
-        else:
-            set_solc_version(version)
-            language = "Solidity"
-            compiler_data["version"] = str(solidity.get_version())
-            interfaces = {
-                k: v
-                for k, v in interface_sources.items()
-                if Path(k).suffix == ".sol"
-                and Version(version) in sources.get_pragma_spec(v, k)
-            }
-
-        to_compile = {k: v for k, v in contract_sources.items() if k in path_list}
-
-        input_json = generate_input_json(
-            to_compile,
-            evm_version=evm_version[language] if isinstance(evm_version, dict) else evm_version,
-            language=language,
-            interface_sources=interfaces,
-            remappings=remappings,
+    if len(compiler_targets) == 0:
+        compiler_targets, interfaces, optimizer, evm_version = prepare_compilers(
+            contract_sources=contract_sources,
+            interface_sources=interface_sources,
+            version=version,
             optimizer=optimizer,
+            evm_version=evm_version,
+            silent=silent,
+            retry=retry,
         )
-        output_json = compile_from_input_json(input_json, silent, allow_paths)
-        build_json.update(generate_build_json(input_json, output_json, compiler_data, silent))
 
-    return build_json
+    for i, compiler_target in enumerate(compiler_targets):
+        try:
+            v = compiler_target["version"]
+            language = compiler_target["language"]
+            to_compile = compiler_target["to_compile"]
+            return prepared_compile_and_format(
+                to_compile=to_compile,
+                version=v,
+                language=language,
+                interface_sources=interfaces,
+                optimizer=optimizer,
+                evm_version=evm_version,
+                silent=silent,
+            )
+        except Exception as e:
+            if retry:
+                warnings.warn(
+                    f"Got exception during compilation with {language} compiler version {version}",
+                    BrownieCompilerWarning,
+                )
+                print(color.format_tb(e))
+            if not retry or i == len(compiler_targets) - 1:
+                raise
+
+    return {}
 
 
 def generate_input_json(

--- a/brownie/project/compiler/__init__.py
+++ b/brownie/project/compiler/__init__.py
@@ -47,6 +47,100 @@ EVM_SOLC_VERSIONS = [
 ]
 
 
+def try_compile_and_format(
+    contract_sources: Dict[str, str],
+    solc_version: Optional[str] = None,
+    vyper_version: Optional[str] = None,
+    optimize: bool = True,
+    runs: int = 200,
+    evm_version: Optional[str] = None,
+    silent: bool = True,
+    allow_paths: Optional[str] = None,
+    interface_sources: Optional[Dict[str, str]] = None,
+    remappings: Optional[list] = None,
+    optimizer: Optional[Dict] = None,
+) -> Dict:
+
+    exceptions = []
+    build_json = None
+    try:
+        build_json = compile_and_format(
+            contract_sources=contract_sources,
+            solc_version=solc_version,
+            vyper_version=vyper_version,
+            optimize=optimize,
+            runs=runs,
+            evm_version=evm_version,
+            silent=silent,
+            allow_paths=allow_paths,
+            interface_sources=interface_sources,
+            remappings=remappings,
+            optimizer=optimizer,
+            install_latest=False,
+        )
+    except Exception as e1:
+        if not solc_version and not vyper_version:
+            raise
+
+        exceptions.append(e1)
+        if not silent:
+            warnings.warn(
+                "Re-trying compilation with the latest installed version.",
+                BrownieCompilerWarning,
+            )
+        # now try one more time with the latest installed one
+        try:
+            build_json = compile_and_format(
+                contract_sources=contract_sources,
+                runs=runs,
+                evm_version=evm_version,
+                silent=silent,
+                allow_paths=allow_paths,
+                interface_sources=interface_sources,
+                remappings=remappings,
+                optimizer=optimizer,
+                optimize=optimize,
+                install_latest=False,
+            )
+        except Exception as e2:
+            exceptions.append(e2)
+            if not silent:
+                warnings.warn(
+                    "Re-trying compilation with the latest available version.",
+                    BrownieCompilerWarning,
+                )
+            try:
+                # now try one more time with the latest available one
+                build_json = compile_and_format(
+                    contract_sources=contract_sources,
+                    runs=runs,
+                    evm_version=evm_version,
+                    silent=silent,
+                    allow_paths=allow_paths,
+                    interface_sources=interface_sources,
+                    remappings=remappings,
+                    optimizer=optimizer,
+                    optimize=optimize,
+                    install_latest=True,
+                )
+            except Exception as e3:
+                exceptions.append(e3)
+
+    for e in exceptions:
+        print("Got exception during compilation:")
+        print(color.format_tb(e))
+        print("\n")
+
+    if not build_json:
+        # if it's still failing to compile raise
+        if len(exceptions) > 0:
+            raise exceptions[-1]
+        else:
+            raise Exception("Compilation failed!")
+
+    return build_json
+
+
 def compile_and_format(
     contract_sources: Dict[str, str],
     solc_version: Optional[str] = None,
@@ -59,7 +153,6 @@ def compile_and_format(
     interface_sources: Optional[Dict[str, str]] = None,
     remappings: Optional[list] = None,
     optimizer: Optional[Dict] = None,
-    use_strict: bool = True,
     install_latest: bool = False,
 ) -> Dict:
     """Compiles contracts and returns build data.
@@ -75,7 +168,6 @@ def compile_and_format(
         interface_sources: dictionary of interfaces as {'path': "source code"}
         remappings: list of solidity path remappings
         optimizer: dictionary of solidity optimizer settings
-        use_strict: boolean that toggles if only the given version should be used for compilation
         install_latest: boolean that toggles if the latest installable version should be downloaded
 
     Returns:
@@ -97,7 +189,7 @@ def compile_and_format(
     vyper_sources = {k: v for k, v in contract_sources.items() if Path(k).suffix == ".vy"}
     if vyper_sources:
         # TODO add `vyper_version` input arg to manually specify, support in config file
-        if vyper_version is None or not use_strict:
+        if vyper_version is None:
             compiler_targets.update(
                 find_vyper_versions(
                     vyper_sources, install_needed=True, install_latest=install_latest, silent=silent
@@ -107,7 +199,7 @@ def compile_and_format(
             compiler_targets[vyper_version] = list(vyper_sources)
     solc_sources = {k: v for k, v in contract_sources.items() if Path(k).suffix == ".sol"}
     if solc_sources:
-        if solc_version is None or not use_strict:
+        if solc_version is None:
             compiler_targets.update(
                 find_solc_versions(
                     solc_sources, install_needed=True, install_latest=install_latest, silent=silent
@@ -120,97 +212,37 @@ def compile_and_format(
             optimizer = {"enabled": optimize, "runs": runs if optimize else 0}
 
     for version, path_list in compiler_targets.items():
-        try:
-            compiler_data: Dict = {}
-            if path_list[0].endswith(".vy"):
-                set_vyper_version(version)
-                language = "Vyper"
-                compiler_data["version"] = str(vyper.get_version())
-                interfaces = {
-                    k: v for k, v in interface_sources.items() if Path(k).suffix != ".sol"
-                }
-            else:
-                set_solc_version(version)
-                language = "Solidity"
-                compiler_data["version"] = str(solidity.get_version())
-                interfaces = {
-                    k: v
-                    for k, v in interface_sources.items()
-                    if Path(k).suffix == ".sol"
-                    and Version(version) in sources.get_pragma_spec(v, k)
-                }
+        compiler_data: Dict = {}
+        if path_list[0].endswith(".vy"):
+            set_vyper_version(version)
+            language = "Vyper"
+            compiler_data["version"] = str(vyper.get_version())
+            interfaces = {
+                k: v for k, v in interface_sources.items() if Path(k).suffix != ".sol"
+            }
+        else:
+            set_solc_version(version)
+            language = "Solidity"
+            compiler_data["version"] = str(solidity.get_version())
+            interfaces = {
+                k: v
+                for k, v in interface_sources.items()
+                if Path(k).suffix == ".sol"
+                and Version(version) in sources.get_pragma_spec(v, k)
+            }
 
-            to_compile = {k: v for k, v in contract_sources.items() if k in path_list}
+        to_compile = {k: v for k, v in contract_sources.items() if k in path_list}
 
-            input_json = generate_input_json(
-                to_compile,
-                evm_version=evm_version[language] if isinstance(evm_version, dict) else evm_version,
-                language=language,
-                interface_sources=interfaces,
-                remappings=remappings,
-                optimizer=optimizer,
-            )
-            output_json = compile_from_input_json(input_json, silent, allow_paths)
-            build_json.update(generate_build_json(input_json, output_json, compiler_data, silent))
-
-        except Exception as e:
-            if not silent:
-                warnings.warn(
-                    f"Compilation failed with {language} compiler version {version}.",
-                    BrownieCompilerWarning,
-                )
-            if use_strict:
-                if not silent:
-                    warnings.warn(
-                        "Re-trying with the latest installed version.",
-                        BrownieCompilerWarning,
-                    )
-                    print(color.format_tb(e))
-                # current exception was caused by using the passed version passed,
-                # now try one more time with the latest installed one
-                return compile_and_format(
-                    contract_sources,
-                    solc_version,
-                    vyper_version,
-                    optimize,
-                    runs,
-                    evm_version,
-                    silent,
-                    allow_paths,
-                    interface_sources,
-                    remappings,
-                    optimizer,
-                    use_strict=False,
-                    install_latest=False,
-                )
-            elif not use_strict and not install_latest:
-                if not silent:
-                    warnings.warn(
-                        "Re-trying with the latest available version.",
-                        BrownieCompilerWarning,
-                    )
-                    print(color.format_tb(e))
-
-                # current exception was caused by using the latest installed version,
-                # now try one more time with the latest available one
-                return compile_and_format(
-                    contract_sources,
-                    solc_version,
-                    vyper_version,
-                    optimize,
-                    runs,
-                    evm_version,
-                    silent,
-                    allow_paths,
-                    interface_sources,
-                    remappings,
-                    optimizer,
-                    use_strict=False,
-                    install_latest=True,
-                )
-
-            # if it's still failing to compile
-            raise
+        input_json = generate_input_json(
+            to_compile,
+            evm_version=evm_version[language] if isinstance(evm_version, dict) else evm_version,
+            language=language,
+            interface_sources=interfaces,
+            remappings=remappings,
+            optimizer=optimizer,
+        )
+        output_json = compile_from_input_json(input_json, silent, allow_paths)
+        build_json.update(generate_build_json(input_json, output_json, compiler_data, silent))
 
     return build_json
 

--- a/brownie/project/ethpm.py
+++ b/brownie/project/ethpm.py
@@ -153,6 +153,7 @@ def process_manifest(manifest: Dict, uri: Optional[str] = None) -> Dict:
             manifest["sources"],
             version=version,
             interface_sources=_get_json_interfaces(manifest["contract_types"]),
+            retry=compiler.get_retry(),
         )
         for key, build in build_json.items():
             manifest["contract_types"].setdefault(key, {"contract_name": key})

--- a/brownie/project/ethpm.py
+++ b/brownie/project/ethpm.py
@@ -151,7 +151,7 @@ def process_manifest(manifest: Dict, uri: Optional[str] = None) -> Dict:
 
         build_json = compiler.compile_and_format(
             manifest["sources"],
-            solc_version=version,
+            version=version,
             interface_sources=_get_json_interfaces(manifest["contract_types"]),
         )
         for key, build in build_json.items():

--- a/brownie/project/ethpm.py
+++ b/brownie/project/ethpm.py
@@ -151,7 +151,7 @@ def process_manifest(manifest: Dict, uri: Optional[str] = None) -> Dict:
 
         build_json = compiler.compile_and_format(
             manifest["sources"],
-            version=version,
+            solc_version=version,
             interface_sources=_get_json_interfaces(manifest["contract_types"]),
             retry=compiler.get_retry(),
         )

--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -97,10 +97,12 @@ class _ProjectBase:
                 "Solidity": compiler_config["solc"].get("evm_version", project_evm_version),
                 "Vyper": compiler_config["vyper"].get("evm_version", project_evm_version),
             }
+            version = compiler_config["solc"].get("version", None)
+            if not version:
+                version = compiler_config["vyper"].get("version", None)
             build_json = compiler.compile_and_format(
                 contract_sources,
-                solc_version=compiler_config["solc"].get("version", None),
-                vyper_version=compiler_config["vyper"].get("version", None),
+                version=version,
                 optimize=compiler_config["solc"].get("optimize", None),
                 runs=compiler_config["solc"].get("runs", None),
                 evm_version=evm_version,

--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -110,6 +110,7 @@ class _ProjectBase:
                 allow_paths=allow_paths,
                 remappings=compiler_config["solc"].get("remappings", []),
                 optimizer=compiler_config["solc"].get("optimizer", None),
+                retry=compiler_config.get("retry", False),
             )
         finally:
             os.chdir(cwd)

--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -102,7 +102,8 @@ class _ProjectBase:
                 version = compiler_config["vyper"].get("version", None)
             build_json = compiler.compile_and_format(
                 contract_sources,
-                version=version,
+                solc_version=compiler_config["solc"].get("version", None),
+                vyper_version=compiler_config["vyper"].get("version", None),
                 optimize=compiler_config["solc"].get("optimize", None),
                 runs=compiler_config["solc"].get("runs", None),
                 evm_version=evm_version,

--- a/tests/project/compiler/test_solidity.py
+++ b/tests/project/compiler/test_solidity.py
@@ -133,11 +133,11 @@ def test_build_json_keys(solc5source):
 
 
 def test_build_json_unlinked_libraries(solc4source, solc5source, solc6source):
-    build_json = compiler.compile_and_format({"path.sol": solc4source}, version="0.4.25")
+    build_json = compiler.compile_and_format({"path.sol": solc4source}, solc_version="0.4.25")
     assert "__Bar__" in build_json["Foo"]["bytecode"]
-    build_json = compiler.compile_and_format({"path.sol": solc5source}, version="0.5.7")
+    build_json = compiler.compile_and_format({"path.sol": solc5source}, solc_version="0.5.7")
     assert "__Bar__" in build_json["Foo"]["bytecode"]
-    build_json = compiler.compile_and_format({"path.sol": solc6source}, version="0.6.2")
+    build_json = compiler.compile_and_format({"path.sol": solc6source}, solc_version="0.6.2")
     assert "__Bar__" in build_json["Foo"]["bytecode"]
 
 
@@ -152,9 +152,9 @@ def test_format_link_references(solc4json, solc5json, solc6json):
 
 def test_compiler_errors(solc4source, solc5source):
     with pytest.raises(CompilerError):
-        compiler.compile_and_format({"path.sol": solc4source}, version="0.5.7")
+        compiler.compile_and_format({"path.sol": solc4source}, solc_version="0.5.7")
     with pytest.raises(CompilerError):
-        compiler.compile_and_format({"path.sol": solc5source}, version="0.4.25")
+        compiler.compile_and_format({"path.sol": solc5source}, solc_version="0.4.25")
 
 
 def test_min_version():
@@ -207,7 +207,7 @@ def test_first_revert(BrownieTester, ExternalCallTester):
 
 
 def test_compile_empty():
-    compiler.compile_and_format({"empty.sol": ""}, version="0.4.25")
+    compiler.compile_and_format({"empty.sol": ""}, solc_version="0.4.25")
 
 
 def test_get_abi():

--- a/tests/project/compiler/test_vyper.py
+++ b/tests/project/compiler/test_vyper.py
@@ -60,7 +60,7 @@ from foo import bar
 
 
 def test_compile_empty():
-    compiler.compile_and_format({"empty.vy": ""}, vyper_version="0.2.4")
+    compiler.compile_and_format({"empty.vy": ""}, version="0.2.4")
 
 
 def test_get_abi():
@@ -81,5 +81,5 @@ def test_get_abi():
 
 def test_size_limit(capfd):
     code = f"@external\ndef baz():\n    assert msg.sender != ZERO_ADDRESS, '{'blah'*10000}'"
-    compiler.compile_and_format({"foo.vy": code}, vyper_version="0.2.4")
+    compiler.compile_and_format({"foo.vy": code}, version="0.2.4")
     assert "exceeds EIP-170 limit of 24577" in capfd.readouterr()[0]

--- a/tests/project/compiler/test_vyper.py
+++ b/tests/project/compiler/test_vyper.py
@@ -60,7 +60,7 @@ from foo import bar
 
 
 def test_compile_empty():
-    compiler.compile_and_format({"empty.vy": ""}, version="0.2.4")
+    compiler.compile_and_format({"empty.vy": ""}, vyper_version="0.2.4")
 
 
 def test_get_abi():
@@ -81,5 +81,5 @@ def test_get_abi():
 
 def test_size_limit(capfd):
     code = f"@external\ndef baz():\n    assert msg.sender != ZERO_ADDRESS, '{'blah'*10000}'"
-    compiler.compile_and_format({"foo.vy": code}, version="0.2.4")
+    compiler.compile_and_format({"foo.vy": code}, vyper_version="0.2.4")
     assert "exceeds EIP-170 limit of 24577" in capfd.readouterr()[0]

--- a/tests/project/conftest.py
+++ b/tests/project/conftest.py
@@ -34,6 +34,11 @@ def btsource():
 
 
 @pytest.fixture(scope="session")
+def solc8source():
+    return test_source.replace("[VERSION]", "^0.8.7")
+
+
+@pytest.fixture(scope="session")
 def solc6source():
     return test_source.replace("[VERSION]", "^0.6.0")
 


### PR DESCRIPTION
### What I did
I've observed the following contract can't be compiled with the 0.8.7 solc although that's in its version pragma:
`Contract.from_explorer("0xEdB67Ee1B171c4eC66E6c10EC43EDBbA20FaE8e9")`

So I've wrapped the `brownie.project.compiler.compile_and_format()` function into `try_compile_and_format` which does several things:

1. tries to compile the contract with the given solc_version or vyper_version
2. if 1. raises an exception it tries to compile it with the latest locally installed compiler (respecting pragma)
3. if 2. raises an exception it tries to compile it with the latest avaialble one to download (respecting pragma)
4. if 3. fails it raises the last exception

I'm collecting the exceptions from 1.-3. and outputting them to stdout so they're not lost.

Related issue: #
https://github.com/eth-brownie/brownie/issues/1118
https://github.com/eth-brownie/brownie/issues/1183
### How I did it
I've just changed the call in `Contract.from_explorer` so that the new logic will be used instead.
Therefore Contract object creation becomes a bit more robust, respecting the contract's version pragma which is expected behaviour IMO.

### How to verify it
```
>>> Contract.from_explorer("0xEdB67Ee1B171c4eC66E6c10EC43EDBbA20FaE8e9")
Got exception during compilation:
  File "brownie/project/compiler/__init__.py", line 67, in try_compile_and_format
    build_json = compile_and_format(
  File "brownie/project/compiler/__init__.py", line 243, in compile_and_format
    build_json.update(generate_build_json(input_json, output_json, compiler_data, silent))
  File "brownie/project/compiler/__init__.py", line 418, in generate_build_json
    build_json[contract_alias] = solidity._get_unique_build_json(
  File "brownie/project/compiler/solidity.py", line 260, in _get_unique_build_json
    pc_map, statement_map, branch_map = _generate_coverage_data(
  File "brownie/project/compiler/solidity.py", line 359, in _generate_coverage_data
    pc_list.append({"op": opcodes.popleft(), "pc": pc})
IndexError: pop from an empty deque


Successfully compiled 0xEdB67Ee1B171c4eC66E6c10EC43EDBbA20FaE8e9 with Solidity compiler version 0.8.11+commit.d7f03943
```

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
