### PR TITLE
Allow to override the EVM version per language when compiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/eth-brownie/brownie)
+### Added
+- Allow to override EVM version per language
 ### Changed
 - Force files to be opened as UTF-8
 - Added a new solidity compiler setting `use_latest_patch` in brownie-config.yaml to use the latest patch version of a compiler based on the pragma version of the contract.

--- a/brownie/project/compiler/__init__.py
+++ b/brownie/project/compiler/__init__.py
@@ -4,7 +4,7 @@ import json
 from copy import deepcopy
 from hashlib import sha1
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 
 import solcast
 from eth_utils import remove_0x_prefix
@@ -52,7 +52,7 @@ def compile_and_format(
     vyper_version: Optional[str] = None,
     optimize: bool = True,
     runs: int = 200,
-    evm_version: Optional[str] = None,
+    evm_version: Optional[Union[str, Dict[str, str]]] = None,
     silent: bool = True,
     allow_paths: Optional[str] = None,
     interface_sources: Optional[Dict[str, str]] = None,
@@ -131,7 +131,7 @@ def compile_and_format(
 
         input_json = generate_input_json(
             to_compile,
-            evm_version=evm_version,
+            evm_version=evm_version[language] if isinstance(evm_version, dict) else evm_version,
             language=language,
             interface_sources=interfaces,
             remappings=remappings,

--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -92,13 +92,18 @@ class _ProjectBase:
             os.chdir(self._path)
 
         try:
+            project_evm_version = compiler_config["evm_version"]
+            evm_version = {
+                "Solidity": compiler_config["solc"].get("evm_version", project_evm_version),
+                "Vyper": compiler_config["vyper"].get("evm_version", project_evm_version),
+            }
             build_json = compiler.compile_and_format(
                 contract_sources,
                 solc_version=compiler_config["solc"].get("version", None),
                 vyper_version=compiler_config["vyper"].get("version", None),
                 optimize=compiler_config["solc"].get("optimize", None),
                 runs=compiler_config["solc"].get("runs", None),
-                evm_version=compiler_config["evm_version"],
+                evm_version=evm_version,
                 silent=silent,
                 allow_paths=allow_paths,
                 remappings=compiler_config["solc"].get("remappings", []),

--- a/docs/compile.rst
+++ b/docs/compile.rst
@@ -79,6 +79,8 @@ By default ``evm_version`` is set to ``null``. Brownie sets the ruleset based on
 
 You can also set the EVM version manually. Valid options are ``byzantium``, ``constantinople``, ``petersburg`` and ``istanbul``. You can also use the Ethereum Classic rulesets ``atlantis`` and ``agharta``, which are converted to their Ethereum equivalents prior to being passed to the compiler.
 
+If needed, the EVM version can be different between Solidity and Vyper by setting `evm_version` under `solc` or `vyper`.
+
 See the `Solidity EVM documentation <https://solidity.readthedocs.io/en/latest/using-the-compiler.html#setting-the-evm-version-to-target>`_ or `Vyper EVM documentation <https://vyper.readthedocs.io/en/latest/compiling-a-contract.html#setting-the-target-evm-version>`_ for more info on the different EVM versions and how they affect compilation.
 
 Compiler Optimization

--- a/tests/project/compiler/test_main_compiler.py
+++ b/tests/project/compiler/test_main_compiler.py
@@ -17,6 +17,20 @@ def test_multiple_compilers(solc4source, vysource):
     )
 
 
+def test_multiple_compilers_evm_version_override(solc4source, vysource):
+    result = compiler.compile_and_format(
+        {
+            "solc4.sol": solc4source,
+            "vyper.vy": vysource,
+            "vyperold.vy": "# @version 0.1.0b16\n",
+            "solc6.sol": "pragma solidity 0.6.2; contract Foo {}",
+        },
+        evm_version={"Solidity": "byzantium", "Vyper": "petersburg"},
+    )
+    assert result["Bar"]["compiler"]["evm_version"] == "byzantium"
+    assert result["vyper"]["compiler"]["evm_version"] == "petersburg"
+
+
 def test_wrong_suffix():
     with pytest.raises(UnsupportedLanguage):
         compiler.compile_and_format({"foo.bar": ""})


### PR DESCRIPTION
### What I did

Allow to override the `evm_version` per language, e.g.

```yaml
compiler:
  evm_version: london
  solc:
    version: 0.8.9
  vyper:
    evm_version: istanbul
```

### How I did it

`compile_and_format` can now either take a `string` or a dict that must map all the used languages (`Vyper` and `Solidity`) to their desired EVM version.
The change is fully backward-compatible.

### How to verify it

Try the YAML config given above.

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [x] I have updated the documentation
- [x] I have added an entry to the changelog
