### PR TITLE
Allow to use unlimited contract size with ganache-cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Allow to override EVM version per language
 - Add support for Ganache 7 CLI flags
+- Support Ganache unlimited contract size
 
 ### Changed
 - Force files to be opened as UTF-8

--- a/brownie/_cli/networks.py
+++ b/brownie/_cli/networks.py
@@ -58,6 +58,7 @@ DEV_CMD_SETTINGS = (
     "time",
     "network_id",
     "chain_id",
+    "unlimited_contract_size",
 )
 
 

--- a/brownie/network/rpc/ganache.py
+++ b/brownie/network/rpc/ganache.py
@@ -31,6 +31,7 @@ CLI_FLAGS = {
         "unlock": "--wallet.unlockedAccounts",
         "network_id": "--chain.networkId",
         "chain_id": "--chain.chainId",
+        "unlimited_contract_size": "--chain.allowUnlimitedContractSize",
     },
     "<=6": {
         "port": "--port",
@@ -46,6 +47,7 @@ CLI_FLAGS = {
         "unlock": "--unlock",
         "network_id": "--networkId",
         "chain_id": "--chainId",
+        "unlimited_contract_size": "--allowUnlimitedContractSize",
     },
 }
 
@@ -85,7 +87,10 @@ def launch(cmd: str, **kwargs: Dict) -> None:
                 cmd_list.extend([cli_flags[key], address])
         else:
             try:
-                cmd_list.extend([cli_flags[key], str(value)])
+                if value is True:
+                    cmd_list.append(cli_flags[key])
+                elif value is not False:
+                    cmd_list.extend([cli_flags[key], str(value)])
             except KeyError:
                 warnings.warn(
                     f"Ignoring invalid commandline setting for ganache-cli: "

--- a/docs/network-management.rst
+++ b/docs/network-management.rst
@@ -105,6 +105,7 @@ The following optional fields may be given for development networks, which are p
     * ``default_balance``: The starting balance for all unlocked accounts. Can be given as unit string like "1000 ether" or "50 gwei" or as an number **in Ether**. Will default to 100 ether.
     * ``time``: Date (ISO 8601) that the first block should start. Use this feature, along with :func:`Chain.sleep <Chain.sleep>` to test time-dependent code. Defaults to the current time.
     * ``unlock``: A single address or a list of addresses to unlock. These accounts are added to the :func:`Accounts <brownie.network.account.Accounts>` container and can be used as if the private key is known. Also works in combination with ``fork`` to send transactions from any account.
+    * ``unlimited_contract_size``: Allows deployed contracts to be over the maximum limit of 24675 bytes. The value should be either `true` or `false`.
 
 .. note::
     These optional commandline fields can also be specified on a project level in the project's ``brownie-config.yaml`` file. See the :ref:`configuration files<config>`.


### PR DESCRIPTION
### What I did

Allow configuring Ganache's `allowUnlimitedContractSize`

### How I did it

Add the flag to `ganache.py` and the CLI

### How to verify it

```
brownie networks modify development unlimited_contract_size=true
```

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [x] I have updated the documentation
- [x] I have added an entry to the changelog
