### PR TITLE
fix: only pass kwargs if not None

### DIFF
--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -1300,7 +1300,9 @@ class OverloadedMethod:
         self, *args: Tuple, block_identifier: Union[int, str, bytes] = None, override: Dict = None
     ) -> Any:
         fn = self._get_fn_from_args(args)
-        return fn(*args, block_identifier=block_identifier, override=override)  # type: ignore
+        kwargs = {"block_identifier": block_identifier, "override": override}
+        kwargs = {k: v for k, v in kwargs.items() if v is not None}
+        return fn(*args, **kwargs)  # type: ignore
 
     def call(
         self, *args: Tuple, block_identifier: Union[int, str, bytes] = None, override: Dict = None


### PR DESCRIPTION
### What I did
Fix a bug in `OverloadedMethod.__call__` where passing `block_identifier` and `override` would raise when `fn` is a `ContractTx`.

Related to #1412 

