### PR TITLE
Fixing Docs Typo

### DIFF
--- a/docs/compile.rst
+++ b/docs/compile.rst
@@ -168,5 +168,5 @@ If you wish to manually install a different version of ``solc`` or ``vyper``:
 
 .. code-block:: python
 
-    >>> from brownie.project.compiler import install_vyper
+    >>> from brownie.project.compiler.vyper import install_vyper
     >>> install_vyper("0.2.4")


### PR DESCRIPTION
Otherwise the import doesn't work. I guess alternatively the python export can be changed.

### What I did

Fixed a typo in the docs.

### How to verify it

```py
>>> from brownie.project.compiler import install_vyper
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name 'install_vyper' from 'brownie.project.compiler' (/usr/lib/python3.9/site-packages/brownie/project/compiler/__init__.py)
>>> from brownie.project.compiler.vyper import install_vyper
>>>
```