### PR TITLE
Make contract deployments optional, disabled for interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add cli flag `-r` for raising exceptions to the caller instead of doing a system exit.
 - Added support for alchemy out of the box with a `WEB3_ALCHEMY_PROJECT_ID` after running `brownie networks set_provider alchemy`. 
 - Add `override` argument to contract methods which allows changing the state before the call, including overwriting balance, nonce, code, and storage of any address.
+- Add `persist` argument (default=`True`) to contract methods that controls if the contract should be added to the deployments db. Disabled the deployments for interfaces to make them ephemereal ([#1092](https://github.com/eth-brownie/brownie/issues/1092)). Added a `Contract.remove_deployment(address)` class helper method.
 
 ### Fixed
 - Improve support for Ganache 7 reverted transactions

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -217,6 +217,7 @@ class ContractContainer(_ContractBase):
         address: str,
         owner: Optional[AccountsType] = None,
         tx: Optional[TransactionReceiptType] = None,
+        persist: bool = True,
     ) -> "ProjectContract":
         """Returns a contract address.
 
@@ -245,7 +246,8 @@ class ContractContainer(_ContractBase):
         _add_contract(contract)
         self._contracts.append(contract)
         if CONFIG.network_type == "live":
-            _add_deployment(contract)
+            if persist:
+                _add_deployment(contract)
 
         return contract
 
@@ -619,7 +621,7 @@ class InterfaceConstructor:
         }
 
     def __call__(self, address: str, owner: Optional[AccountsType] = None) -> "Contract":
-        return Contract.from_abi(self._name, address, self.abi, owner)
+        return Contract.from_abi(self._name, address, self.abi, owner, persist=False)
 
     def __repr__(self) -> str:
         return f"<{type(self).__name__} '{self._name}'>"
@@ -916,7 +918,12 @@ class Contract(_DeployedContractBase):
 
     @classmethod
     def from_abi(
-        cls, name: str, address: str, abi: List, owner: Optional[AccountsType] = None
+        cls,
+        name: str,
+        address: str,
+        abi: List,
+        owner: Optional[AccountsType] = None,
+        persist: bool = True,
     ) -> "Contract":
         """
         Create a new `Contract` object from an ABI.
@@ -939,7 +946,8 @@ class Contract(_DeployedContractBase):
         self = cls.__new__(cls)
         _ContractBase.__init__(self, None, build, {})  # type: ignore
         _DeployedContractBase.__init__(self, address, owner, None)
-        _add_deployment(self)
+        if persist:
+            _add_deployment(self)
         return self
 
     @classmethod
@@ -949,6 +957,7 @@ class Contract(_DeployedContractBase):
         manifest_uri: str,
         address: Optional[str] = None,
         owner: Optional[AccountsType] = None,
+        persist: bool = True,
     ) -> "Contract":
         """
         Create a new `Contract` object from an ethPM manifest.
@@ -995,7 +1004,8 @@ class Contract(_DeployedContractBase):
         self = cls.__new__(cls)
         _ContractBase.__init__(self, None, build, manifest["sources"])  # type: ignore
         _DeployedContractBase.__init__(self, address, owner)
-        _add_deployment(self)
+        if persist:
+            _add_deployment(self)
         return self
 
     @classmethod
@@ -1005,6 +1015,7 @@ class Contract(_DeployedContractBase):
         as_proxy_for: Optional[str] = None,
         owner: Optional[AccountsType] = None,
         silent: bool = False,
+        persist: bool = True,
     ) -> "Contract":
         """
         Create a new `Contract` object with source code queried from a block explorer.
@@ -1172,7 +1183,8 @@ class Contract(_DeployedContractBase):
         self = cls.__new__(cls)
         _ContractBase.__init__(self, None, build_json, sources)  # type: ignore
         _DeployedContractBase.__init__(self, address, owner)
-        _add_deployment(self)
+        if persist:
+            _add_deployment(self)
         return self
 
     @classmethod
@@ -1208,7 +1220,7 @@ class Contract(_DeployedContractBase):
 
         return version
 
-    def set_alias(self, alias: Optional[str]) -> None:
+    def set_alias(self, alias: Optional[str], persist: bool = True) -> None:
         """
         Apply a unique alias this object. The alias can be used to restore the
         object in future sessions.
@@ -1230,7 +1242,8 @@ class Contract(_DeployedContractBase):
                     raise ValueError("Alias is already in use on another contract")
                 return
 
-        _add_deployment(self, alias)
+        if persist:
+            _add_deployment(self, alias)
         self._build["alias"] = alias
 
     @property

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -1225,7 +1225,16 @@ class Contract(_DeployedContractBase):
     def remove_deployment(
         cls, address: str, alias: str = None
     ) -> Tuple[Optional[Dict], Optional[Dict]]:
+        """
+        Removes this contract from the internal deployments db.
 
+        Arguments
+        ---------
+        address: str
+            An address to apply
+        alias: str | None
+            An alias to apply
+        """
         return _remove_deployment(address, alias)
 
     def set_alias(self, alias: Optional[str], persist: bool = True) -> None:

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -1223,14 +1223,15 @@ class Contract(_DeployedContractBase):
 
     @classmethod
     def remove_deployment(
-        cls, address: str, alias: str = None
+        cls, address: str = None, alias: str = None
     ) -> Tuple[Optional[Dict], Optional[Dict]]:
         """
-        Removes this contract from the internal deployments db.
+        Removes this contract from the internal deployments db
+        with the passed address or alias.
 
         Arguments
         ---------
-        address: str
+        address: str | None
             An address to apply
         alias: str | None
             An alias to apply

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -51,6 +51,7 @@ from .state import (
     _find_contract,
     _get_deployment,
     _remove_contract,
+    _remove_deployment,
     _revert_register,
 )
 from .web3 import _resolve_address, web3
@@ -1219,6 +1220,13 @@ class Contract(_DeployedContractBase):
                         version = v
 
         return version
+
+    @classmethod
+    def remove_deployment(
+        cls, address: str, alias: str = None
+    ) -> Tuple[Optional[Dict], Optional[Dict]]:
+
+        return _remove_deployment(address, alias)
 
     def set_alias(self, alias: Optional[str], persist: bool = True) -> None:
         """

--- a/brownie/network/state.py
+++ b/brownie/network/state.py
@@ -590,7 +590,7 @@ def _get_deployment(
     address: str = None, alias: str = None
 ) -> Tuple[Optional[Dict], Optional[Dict]]:
     if address and alias:
-        raise
+        raise ValueError("Passed both params address and alias, should be only one!")
     if address:
         address = _resolve_address(address)
         query = f"address='{address}'"
@@ -649,7 +649,7 @@ def _add_deployment(contract: Any, alias: Optional[str] = None) -> None:
 
 def _remove_deployment(address: str, alias: str = None) -> Tuple[Optional[Dict], Optional[Dict]]:
     if address and alias:
-        raise
+        raise ValueError("Passed both params address and alias, should be only one!")
     if address:
         address = _resolve_address(address)
         query = f"address='{address}'"

--- a/brownie/network/state.py
+++ b/brownie/network/state.py
@@ -645,3 +645,32 @@ def _add_deployment(contract: Any, alias: Optional[str] = None) -> None:
 
     values = [contract._build.get(i) for i in DEPLOYMENT_KEYS]
     cur.insert(name, address, alias, all_sources, *values)
+
+
+def _remove_deployment(address: str, alias: str = None) -> Tuple[Optional[Dict], Optional[Dict]]:
+    if address and alias:
+        raise
+    if address:
+        address = _resolve_address(address)
+        query = f"address='{address}'"
+    elif alias:
+        query = f"alias='{alias}'"
+
+    try:
+        name = f"chain{CONFIG.active_network['chainid']}"
+    except KeyError:
+        raise BrownieEnvironmentError("Functionality not available in local environment") from None
+
+    build_json, sources = _get_deployment(address, alias)
+    contract = _find_contract(address)
+    # delete entry from chain{n}
+    cur.execute(f"DELETE FROM {name} WHERE {query}")
+    # delete all entries from sources matching the contract's source hashes
+    for key, path in contract._build.get("allSourcePaths", {}).items():
+        source = contract._sources.get(path)
+        if source is None:
+            source = Path(path).read_text()
+        hash_ = sha1(source.encode()).hexdigest()
+        cur.execute(f"DELETE FROM sources WHERE hash='{hash_}'")
+
+    return build_json, sources

--- a/tests/network/contract/test_contract.py
+++ b/tests/network/contract/test_contract.py
@@ -16,7 +16,6 @@ from brownie.network.contract import (
     _DeployedContractBase,
     _get_deployment,
 )
-from brownie.network.state import _remove_deployment
 
 
 @pytest.fixture
@@ -378,7 +377,7 @@ def test_abi_deployment_enabled_by_default(network, build):
 
     assert _get_deployment(address) != (None, None)
     # cleanup
-    _remove_deployment(address)
+    Contract.remove_deployment(address)
 
 
 def test_abi_deployment_disabled(network, build):
@@ -396,7 +395,7 @@ def test_from_explorer_deployment_enabled_by_default(network):
 
     assert _get_deployment(address) != (None, None)
     # cleanup
-    _remove_deployment(address)
+    Contract.remove_deployment(address)
 
 
 def test_from_explorer_deployment_disabled(network):
@@ -411,7 +410,7 @@ def test_remove_deployment(network):
     network.connect("mainnet")
     address = "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e"
     Contract.from_explorer(address)
-    _remove_deployment(address)
+    Contract.remove_deployment(address)
 
     assert _get_deployment(address) == (None, None)
 
@@ -423,7 +422,7 @@ def test_remove_deployment_returns(network):
     build_json, sources = _get_deployment(address)
 
     assert (build_json, sources) != (None, None)
-    assert (build_json, sources) == (_remove_deployment(address))
+    assert (build_json, sources) == (Contract.remove_deployment(address))
 
 
 # @pytest.mark.parametrize(

--- a/tests/network/contract/test_contract.py
+++ b/tests/network/contract/test_contract.py
@@ -16,6 +16,7 @@ from brownie.network.contract import (
     _DeployedContractBase,
     _get_deployment,
 )
+from brownie.network.state import _remove_deployment
 
 
 @pytest.fixture
@@ -370,6 +371,16 @@ def test_solc_use_latest_patch_specific_included(testproject, network):
     ) == Version("0.4.26")
 
 
+def test_abi_deployment_enabled_by_default(network, build):
+    network.connect("mainnet")
+    address = "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e"
+    Contract.from_abi("abiTester", address, build["abi"])
+
+    assert _get_deployment(address) != (None, None)
+    # cleanup
+    _remove_deployment(address)
+
+
 def test_abi_deployment_disabled(network, build):
     network.connect("mainnet")
     address = "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e"
@@ -378,12 +389,41 @@ def test_abi_deployment_disabled(network, build):
     assert _get_deployment(address) == (None, None)
 
 
+def test_from_explorer_deployment_enabled_by_default(network):
+    network.connect("mainnet")
+    address = "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e"
+    Contract.from_explorer(address)
+
+    assert _get_deployment(address) != (None, None)
+    # cleanup
+    _remove_deployment(address)
+
+
 def test_from_explorer_deployment_disabled(network):
     network.connect("mainnet")
     address = "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e"
     Contract.from_explorer(address, persist=False)
 
     assert _get_deployment(address) == (None, None)
+
+
+def test_remove_deployment(network):
+    network.connect("mainnet")
+    address = "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e"
+    Contract.from_explorer(address)
+    _remove_deployment(address)
+
+    assert _get_deployment(address) == (None, None)
+
+
+def test_remove_deployment_returns(network):
+    network.connect("mainnet")
+    address = "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e"
+    Contract.from_explorer(address)
+    build_json, sources = _get_deployment(address)
+
+    assert (build_json, sources) != (None, None)
+    assert (build_json, sources) == (_remove_deployment(address))
 
 
 # @pytest.mark.parametrize(

--- a/tests/network/contract/test_contract.py
+++ b/tests/network/contract/test_contract.py
@@ -14,6 +14,7 @@ from brownie.network.contract import (
     ContractTx,
     ProjectContract,
     _DeployedContractBase,
+    _get_deployment,
 )
 
 
@@ -367,6 +368,38 @@ def test_solc_use_latest_patch_specific_included(testproject, network):
     assert Contract.get_solc_version(
         "v0.4.16", "0x514910771AF9Ca656af840dff83E8264EcF986CA"
     ) == Version("0.4.26")
+
+
+def test_abi_deployment_enabled_by_default(network, build):
+    network.connect("mainnet")
+    address = "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e"
+    Contract.from_abi("abiTester", address, build["abi"])
+
+    assert _get_deployment(address) != (None, None)
+
+
+def test_abi_deployment_disabled(network, build):
+    network.connect("mainnet")
+    address = "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e"
+    Contract.from_abi("abiTester", address, build["abi"], persist=False)
+
+    assert _get_deployment(address) == (None, None)
+
+
+def test_from_explorer_deployment_enabled_by_default(network):
+    network.connect("mainnet")
+    address = "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e"
+    Contract.from_explorer(address)
+
+    assert _get_deployment(address) != (None, None)
+
+
+def test_from_explorer_deployment_disabled(network):
+    network.connect("mainnet")
+    address = "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e"
+    Contract.from_explorer(address, persist=False)
+
+    assert _get_deployment(address) == (None, None)
 
 
 # @pytest.mark.parametrize(

--- a/tests/network/contract/test_contract.py
+++ b/tests/network/contract/test_contract.py
@@ -370,28 +370,12 @@ def test_solc_use_latest_patch_specific_included(testproject, network):
     ) == Version("0.4.26")
 
 
-def test_abi_deployment_enabled_by_default(network, build):
-    network.connect("mainnet")
-    address = "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e"
-    Contract.from_abi("abiTester", address, build["abi"])
-
-    assert _get_deployment(address) != (None, None)
-
-
 def test_abi_deployment_disabled(network, build):
     network.connect("mainnet")
     address = "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e"
     Contract.from_abi("abiTester", address, build["abi"], persist=False)
 
     assert _get_deployment(address) == (None, None)
-
-
-def test_from_explorer_deployment_enabled_by_default(network):
-    network.connect("mainnet")
-    address = "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e"
-    Contract.from_explorer(address)
-
-    assert _get_deployment(address) != (None, None)
 
 
 def test_from_explorer_deployment_disabled(network):

--- a/tests/network/contract/test_interface.py
+++ b/tests/network/contract/test_interface.py
@@ -1,4 +1,9 @@
-from brownie.network.contract import Contract, InterfaceConstructor, InterfaceContainer
+from brownie.network.contract import (
+    Contract,
+    InterfaceConstructor,
+    InterfaceContainer,
+    _get_deployment,
+)
 
 
 def test_interfacecontainer_add():
@@ -17,3 +22,13 @@ def test_interfaceconstructor_call(tester):
 
     assert isinstance(contract, Contract)
     assert contract.abi == [{"type": "foo"}]
+
+
+def test_interface_is_not_persisted(network):
+    network.connect("mainnet")
+    interface = InterfaceContainer(None)
+    interface._add("Test", [{"type": "foo"}])
+
+    address = "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e"
+    interface.Test(address)
+    assert _get_deployment(address) == (None, None)


### PR DESCRIPTION
### What I did
I've disabled the persistence of interfaces into the deployments db.

Related issue: #1092

### How I did it
- Added a new function param `persist: bool = True` to several contract methods
- Passing `persist=False` for interfaces
- Added helper function `Contract.remove_deployment()`

### How to verify it
I've created some new tests in:
- test_contract.py
- test_interfaces.py

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [x] I have updated the documentation
- [x] I have added an entry to the changelog
