### PR TITLE
fix: pass allow_revert on deployment

### DIFF
--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -535,6 +535,7 @@ class ContractConstructor:
             priority_fee=tx.get("priority_fee"),
             nonce=tx["nonce"],
             required_confs=tx["required_confs"],
+            allow_revert=tx.get("allow_revert"),
             publish_source=publish_source,
         )
 


### PR DESCRIPTION
### What I did
Correctly pass the `allow_revert` kwarg when deploying a contract.
