### PR TITLE
Ensure chain time is correct when using `chain.mine` with ganache 7

### DIFF
--- a/brownie/network/rpc/ganache.py
+++ b/brownie/network/rpc/ganache.py
@@ -136,6 +136,10 @@ def sleep(seconds: int) -> int:
 def mine(timestamp: Optional[int] = None) -> None:
     params = [timestamp] if timestamp else []
     _request("evm_mine", params)
+    if timestamp and web3.clientVersion.lower().startswith("ganache/v7"):
+        # ganache v7 does not modify the internal time when mining new blocks
+        # so we also set the time to maintain consistency with v6 behavior
+        _request("evm_setTime", [(timestamp + 1) * 1000])
 
 
 def snapshot() -> int:

--- a/tests/network/state/test_blocks.py
+++ b/tests/network/state/test_blocks.py
@@ -55,11 +55,28 @@ def test_mine_timestamp(devnetwork, chain):
     assert chain.time() - 999999999999 < 3
 
 
+def test_mine_timestamp_next_block(devnetwork, chain):
+    chain.mine(timestamp=999999999999)
+    chain.mine()
+
+    assert chain[-1].timestamp >= 999999999999
+    assert chain.time() >= 999999999999
+
+
 def test_mine_timedelta(devnetwork, chain):
     now = chain.time()
     chain.mine(timedelta=12345)
 
     assert 0 <= chain[-1].timestamp - 12345 - now <= 1
+
+
+def test_mine_timedelta_next_block(devnetwork, chain):
+    now = chain.time()
+    chain.mine(timedelta=12345)
+    chain.mine()
+
+    assert chain[-1].timestamp >= now + 12345
+    assert chain.time() >= now + 12345
 
 
 def test_mine_multiple_timestamp(devnetwork, chain):


### PR DESCRIPTION
### What I did
Fix an issue with `chain.mine` where setting a new timestamp wasn't remembered in subsequent blocks.

This seems to be changed behavior from ganache 6 to 7 but I can't find any documentation on it, so not sure if it's intentional.

### How I did it
When calling `evm_mine` with a timestamp, also call `evm_setTime`.
