### PR TITLE
Fix get_pragma_spec() to exclude commented out pragma statements on load

### DIFF
--- a/brownie/project/sources.py
+++ b/brownie/project/sources.py
@@ -213,11 +213,13 @@ def get_pragma_spec(source: str, path: Optional[str] = None) -> NpmSpec:
     Returns: NpmSpec object
     """
 
-    pragma_match = next(re.finditer(r"pragma +solidity([^;]*);", source), None)
-    if pragma_match is not None:
-        pragma_string = pragma_match.groups()[0]
-        pragma_string = " ".join(pragma_string.split())
-        return NpmSpec(pragma_string)
+    matches = re.findall(r"(.*)pragma +solidity([^;]*);", source)
+    if len(matches) != 0 or matches is not None:
+        for match in matches:
+            if match[0].strip() != "":
+                continue
+            pragma_match = " ".join(match[1].split())
+            return NpmSpec(pragma_match)
     if path:
         raise PragmaError(f"No version pragma in '{path}'")
     raise PragmaError("String does not contain a version pragma")


### PR DESCRIPTION
Fix get_pragma_spec() to exclude commented out pragma statements at the beginning of the file.

### What I did
Refactor brownie/project/sources.py::`get_pragma_spec()`

### How I did it
Reconfigure regex to grab all `pragma solidity` statements in the file and then loop through and skip over any that are prefixed with a "//". Cotinue looping until first valid pragma statement is found.

### How to verify it
Wrote three new unit tests to look at scenarios where:

- one valid pragma version statement listed
- no valid pragma version statement listed
- one valid in-between pragma version statement listed

### Checklist

- [X] I have confirmed that my PR passes all linting checks
- [X] I have included test cases
- [X] I have updated the documentation
- [ ] I have added an entry to the changelog
