### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/eth-brownie/brownie)
+- Fix get_pragma_spec() to exclude commented out pragma statements on compile ([#1443](https://github.com/eth-brownie/brownie/pull/1443))
 
 ## [1.18.1](https://github.com/eth-brownie/brownie/tree/v1.18.1) - 2022-02-15
 ### Fixed


### PR DESCRIPTION
Add to Unrelease section - Fix get_pragma_spec() to exclude commented out pragma statements on compile ([#1443](https://github.com/eth-brownie/brownie/pull/1443))
