### PR TITLE
fix: allow to reset the gas price to zero on development network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/eth-brownie/brownie)
 
+### Fixed
+- Allow to reset gas_price to zero on development network [#1445](https://github.com/eth-brownie/brownie/pull/1445)
+
 ## [1.18.1](https://github.com/eth-brownie/brownie/tree/v1.18.1) - 2022-02-15
 ### Fixed
 - Correctly modify chain time when using `chain.mine` with Ganache v7 ([#1438](https://github.com/eth-brownie/brownie/pull/1438))

--- a/brownie/network/main.py
+++ b/brownie/network/main.py
@@ -117,7 +117,8 @@ def gas_price(*args: Tuple[Union[int, str, bool, None]]) -> Union[int, bool]:
     if args:
         if isinstance(args[0], GasABC):
             CONFIG.active_network["settings"]["gas_price"] = args[0]
-        elif args[0] in (None, False, True, "auto"):
+        # `args[0] is x` ensures both the type and value match
+        elif any(args[0] is x for x in (None, False, True, "auto")):
             CONFIG.active_network["settings"]["gas_price"] = False
         else:
             try:


### PR DESCRIPTION
### What I did

Fixed a bug that does not allow to reset the gas price to `0` on the development network.

### How I did it

Ensure the arguments of `brownie.network.gas_price(*args)`  are checked both for value and **type**.

### How to verify it

Here is the code that reproduces the issue before this PR:

```python
from brownie import network, Wei
from brownie._config import CONFIG

network.connect("development")

# default config for dev network
CONFIG.active_network["settings"]["gas_price"] = 0

assert network.gas_price() == 0
assert network.gas_price() == False # Note that this is also true
assert network.gas_price() in (0,)
assert network.gas_price() in (False, ) # This is also true, because of python...

assert type(network.gas_price()) is int # <==================== Here is an int
assert network.gas_price(network.gas_price()) == 0
assert type(network.gas_price(network.gas_price())) is bool # <== Now it is a bool

# So none of this works (i.e., the asserts pass)
assert type(network.gas_price(0)) is bool
assert type(network.gas_price(Wei(0))) is bool
assert type(network.gas_price(1)) is bool
assert type(network.gas_price(Wei(1))) is bool

assert type(network.gas_price(2)) is Wei # only gas >= 2 works
```

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [x] I have added an entry to the changelog
