### PR TITLE
chore: update ganache dependency in docs

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -62,7 +62,7 @@ Dependencies
 Brownie has the following dependencies:
 
 * `python3 <https://www.python.org/downloads/release/python-368/>`_ version 3.6 or greater, python3-dev
-* `ganache-cli <https://github.com/trufflesuite/ganache-cli>`_ - tested with version `6.12.2 <https://github.com/trufflesuite/ganache-cli/releases/tag/v6.12.2>`_
+* `ganache-cli <https://github.com/trufflesuite/ganache-cli>`_ - tested with version `7.0.2 <https://github.com/trufflesuite/ganache/releases/tag/v7.0.2>`_
 
 .. _install-tk:
 


### PR DESCRIPTION
### What I did

brownie now tests against ganache v7.0.2

updated docs to reflect this change.

### How I did it

checked workflows to see which version of ganache was being tested against, upgraded to that release number.

### How to verify it

https://github.com/eth-brownie/brownie/blob/ef0d5af3bb48edcd11abf985626fc99dbc577c7d/.github/workflows/core-ganache-3.7.yaml#L28

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [x] I have updated the documentation
- [ ] I have added an entry to the changelog
