### PR TITLE
Handle equal signs in network rpc address

### DIFF
--- a/brownie/_cli/networks.py
+++ b/brownie/_cli/networks.py
@@ -347,7 +347,7 @@ def _list_providers(verbose=False):
 
 def _parse_args(args):
     try:
-        args = dict(i.split("=") for i in args)
+        args = dict(i.split("=", maxsplit=1) for i in args)
     except ValueError:
         raise ValueError("Arguments must be given as key=value") from None
 


### PR DESCRIPTION
Currently, a network RPC address like `https://stardust.metis.io/?owner=588` fails with
```
Brownie v1.17.1 - Python development framework for Ethereum

('host=https://stardust.metis.io/\\?owner\\=588', 'chainid=588')
  File "brownie/_cli/__main__.py", line 64, in main
    importlib.import_module(f"brownie._cli.{cmd}").main()
  File "brownie/_cli/networks.py", line 68, in main
    fn(*args["<arguments>"])
  File "brownie/_cli/networks.py", line 111, in _add
    args = _parse_args(args)
  File "brownie/_cli/networks.py", line 278, in _parse_args
    raise ValueError("Arguments must be given as key=value") from None
```

This fixed this.

### What I did

Related issue: #

### How I did it

### How to verify it

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
