### PR TITLE
Ensure .env file exists for installed packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.18.1](https://github.com/eth-brownie/brownie/tree/v1.18.1) - 2022-02-15
 ### Fixed
 - Correctly modify chain time when using `chain.mine` with Ganache v7 ([#1438](https://github.com/eth-brownie/brownie/pull/1438))
+-  Ensure `.env` file exists for installed packages ([#1504](https://github.com/eth-brownie/brownie/pull/1504))
 
 ## [1.18.0](https://github.com/eth-brownie/brownie/tree/v1.18.0) - 2022-02-14
 ### Added

--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -811,6 +811,7 @@ def _install_from_ethpm(uri: str) -> str:
     try:
         new(str(install_path), ignore_existing=True)
         ethpm.install_package(install_path, uri)
+        Path.touch(install_path / ".env")
         project = load(install_path)
         project.close()
     except Exception as e:
@@ -887,6 +888,8 @@ def _install_from_github(package_id: str) -> str:
 
             with install_path.joinpath("brownie-config.yaml").open("w") as fp:
                 yaml.dump(brownie_config, fp)
+
+            Path.touch(install_path / ".env")
 
         project = load(install_path)
         project.close()


### PR DESCRIPTION
### After installing a package, `touch` a `.env` file within that folder.

Fixes #1499 

### How I did it

### How to verify it

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have added an entry to the changelog
