### PR TITLE
Fix: npm WARN deprecated ganache-cli@6.12.2: ganache-cli is now ganache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,12 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 # Install linux dependencies
-RUN apt-get update && apt-get install -y libssl-dev
+RUN apt-get update \
+ && apt-get install -y libssl-dev npm
 
-RUN apt-get update && apt-get install -y \
-    npm
-
-RUN npm install -g ganache-cli
+RUN npm install n -g \
+ && npm install -g npm@latest
+RUN npm install -g ganache
 
 COPY requirements.txt .
 COPY requirements-dev.txt .


### PR DESCRIPTION
I updated Dockerfile for a fix to following warning message during its installation:

```npm WARN deprecated ganache-cli@6.12.2: ganache-cli is now ganache; visit https://trfl.io/g7 for details```

### What I did

Fix: npm WARN deprecated ganache-cli@6.12.2: ganache-cli is now ganache; visit https://trfl.io/g7 for details

### How I did it

Updated npm before installing ganache:

```
RUN npm install n -g \
 && npm install -g npm@latest

RUN npm install -g ganache
```
### Checklist

- [X] I have confirmed that my PR passes all linting checks
