### PR TITLE
fix: gui - highlight source code when selecting opcode

### DIFF
--- a/brownie/_gui/opcodes.py
+++ b/brownie/_gui/opcodes.py
@@ -118,7 +118,8 @@ class OpcodeList(ttk.Treeview):
         if "path" not in pcMap:
             note.active_frame().clear_highlight()
             return
-        note.set_active(pcMap["path"])
+        label = self.root.pathMap[pcMap["path"]]
+        note.set_active(label)
         note.active_frame().highlight(*pcMap["offset"])
 
     def _seek(self, event):


### PR DESCRIPTION
### What I did

I fixed the following exception that happens when clicking opcode in right pane:

```
Exception in Tkinter callback
Traceback (most recent call last):
  File "/usr/lib/python3.9/tkinter/__init__.py", line 1892, in __call__
    return self.func(*args)
  File "/home/kaz/.local/pipx/venvs/eth-brownie/lib/python3.9/site-packages/brownie/_gui/opcodes.py", line 121, in _select_bind
    note.set_active(pcMap["path"])
  File "/home/kaz/.local/pipx/venvs/eth-brownie/lib/python3.9/site-packages/brownie/_gui/source.py", line 84, in set_active
    self.select(self.get_frame(label))
  File "/home/kaz/.local/pipx/venvs/eth-brownie/lib/python3.9/site-packages/brownie/_gui/source.py", line 50, in get_frame
    return next(i for i in self._frames if i._label == label)
StopIteration
```


### How I did it

Opcode on-click callback (`_select_bind` in `opcodes.py`) passes `pcMap["path"]` (which is an integer index) to `SourceNoteBook.set_active` to show source code. `SourceNoteBook.set_active` expects a label to be passed though, which is a string path to source file. I've changed the `_select_bind` to pass proper label instead of index.

### How to verify it

I believe GUI has no tests, so you need to run it manually and click an opcode.

### Checklist

- [N] I have confirmed that my PR passes all linting checks - No, I'm getting mypy issues unrelated to my changes.
- [N] I have included test cases - No, this it not a new feature, it's a fix.
- [N] I have updated the documentation - ditto.
- [N] I have added an entry to the changelog. - No, what's the guideline here? It's not described in CONTRIBUTING.md
