### PR TITLE
fix: gui - highlight opcodes when selecting source

### DIFF
--- a/brownie/_gui/source.py
+++ b/brownie/_gui/source.py
@@ -159,7 +159,7 @@ class SourceNoteBook(ttk.Notebook):
                 k
                 for k, v in self.root.pcMap.items()
                 if "path" in v
-                and frame._label in v["path"]
+                and frame._label in self.root.pathMap[v["path"]]
                 and is_inside_offset((start, stop), v["offset"])
             ]
         if not pc:


### PR DESCRIPTION
### What I did

Selecting any text just causes the selection to disappear, instead of highlighting relevant opcodes. This PR fixes this.

Related PR: #1512

### How I did it

After releasing a button, `SourceNoteBook._search()` is triggered to find opcodes related to given source code. When searching for opcodes, it filters the `pcMap` with a term `frame._label in v["path"]`. `v["path"]` here is an integer index, while `frame._label` is a string path to the source file. As this compares apples-to-oranges, it always evaluates to false and triggers the code branch that clears selection.

In this PR I've changed the term to compare label to label.

### How to verify it

I believe GUI has no tests, so you need to run it manually and select some source code.

### Checklist

- [N] I have confirmed that my PR passes all linting checks - No, I'm getting mypy issues unrelated to my changes.
- [N] I have included test cases - No, this it not a new feature, it's a fix.
- [N] I have updated the documentation - ditto.
- [N] I have added an entry to the changelog. - No, what's the guideline here? It's not described in CONTRIBUTING.md

