### PR TITLE
fix: typo "Package is al(r)eady installed"

### DIFF
--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -806,7 +806,7 @@ def _install_from_ethpm(uri: str) -> str:
     install_path.mkdir(exist_ok=True)
     install_path = install_path.joinpath(f"{repo}@{version}")
     if install_path.exists():
-        raise FileExistsError("Package is aleady installed")
+        raise FileExistsError("Package is already installed")
 
     try:
         new(str(install_path), ignore_existing=True)


### PR DESCRIPTION
Fix typo, changing "Package is aleady installed" to "Package is already installed" when installing an already-installed package.

### What I did
Changed FileExistsError() message in project/main.py line 809 to solve a typo.