### PR TITLE
Fix: Use network host parameter when launching local rpc network node

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
         name: black

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/eth-brownie/brownie)
 
+### Fixed
+- Pass the network host parameter to local RPC networks (this allows hostname configuration, for example, for use with dockerized RPC clients).
+
 ## [1.18.2](https://github.com/eth-brownie/brownie/tree/v1.18.2) - 2022-05-15
 ### Added
 - Subscribe to events, with callbacks, using the corresponding contract instance ([#1453](https://github.com/eth-brownie/brownie/pull/1453))

--- a/brownie/network/main.py
+++ b/brownie/network/main.py
@@ -47,7 +47,9 @@ def connect(network: str = None, launch_rpc: bool = True) -> None:
                     )
                 rpc.attach(host)
             else:
-                rpc.launch(active["cmd"], **active["cmd_settings"])
+                cmd_args = active["cmd_settings"]
+                cmd_args["host"] = active["host"].replace("http://", "")
+                rpc.launch(active["cmd"], **cmd_args)
         else:
             Accounts()._reset()
         if CONFIG.network_type == "live" or CONFIG.settings["dev_deployment_artifacts"]:

--- a/brownie/network/rpc/ganache.py
+++ b/brownie/network/rpc/ganache.py
@@ -18,6 +18,7 @@ from brownie.network.web3 import web3
 
 CLI_FLAGS = {
     "7": {
+        "host": "--server.host",
         "port": "--server.port",
         "gas_limit": "--miner.blockGasLimit",
         "accounts": "--wallet.totalAccounts",
@@ -35,6 +36,7 @@ CLI_FLAGS = {
         "unlimited_contract_size": "--chain.allowUnlimitedContractSize",
     },
     "<=6": {
+        "host": "--host",
         "port": "--port",
         "gas_limit": "--gasLimit",
         "accounts": "--accounts",
@@ -166,6 +168,7 @@ def _validate_cmd_settings(cmd_settings: dict) -> dict:
     ganache_keys = set(k for f in CLI_FLAGS.values() for k in f.keys())
 
     CMD_TYPES = {
+        "host": str,
         "port": int,
         "gas_limit": int,
         "block_time": int,

--- a/tests/network/rpc/test_launch.py
+++ b/tests/network/rpc/test_launch.py
@@ -16,19 +16,20 @@ def test_launch_process_fails(no_rpc):
         no_rpc.launch("ganache-cli --help")
 
 
-def test_launch(no_rpc, temp_port):
+def test_launch(no_rpc, temp_port, temp_host):
     assert not no_rpc.is_active()
     assert not no_rpc.is_child()
-    no_rpc.launch("ganache-cli", port=temp_port)
+    no_rpc.launch("ganache-cli", port=temp_port, host=temp_host)
     assert no_rpc.is_active()
     assert no_rpc.is_child()
 
 
-def test_launch_with_mnemonic(no_rpc, temp_port):
+def test_launch_with_mnemonic(no_rpc, temp_port, temp_host):
     no_rpc.kill(False)
     no_rpc.launch(
         "ganache-cli",
         port=temp_port,
+        host=temp_host,
         mnemonic="patient rude simple dog close planet oval animal hunt sketch suspect slim",
     )
     assert brownie.network.accounts[0] == "0x7cB87a59C85a0c6d8E2953ed54f1c9E4C28E25E5"


### PR DESCRIPTION
### What I did

I modified brownie so that the host parameter used by the networks CLI is now used when launching a local RPC network node.

Related issue: #1533 

### How I did it

I made some small changes brownie/networks/rpc/*.py.

### How to verify it

The modifications to the fixtures and units tests in this PR test that the network node launches and correctly configures the host parameter. 

They do not test that the parameter is correctly passed from networks CLI though, this can be verified locally very easily by modifying the host parameter via the CLI and starting hardhat/ganache:

Ganache:
```
brownie networks modify development host="http://127.0.0.2"
brownie console --network development
# ->
# Launching 'ganache-cli --accounts 10 --hardfork istanbul --gasLimit 12000000 --mnemonic brownie --port 8545 --host 127.0.0.2'...
```

Hardhat:
```
brownie networks modify hardhat host="http://127.0.0.2"
brownie console --network hardhat
# ->
# Launching 'npx hardhat node --port 8545 --hostname 127.0.0.2'
```

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [ ] I have updated the documentation
- [x] I have added an entry to the changelog
