### PR TITLE
add anvil and docker build caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ build/
 coverage.xml
 dist/
 docs/_build
+node_modules/
 venv*/
 env/
 *egg-info/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,42 @@
-FROM python:3.7
+FROM ghcr.io/foundry-rs/foundry:nightly as foundry
 
-# Set up code directory
-RUN mkdir -p /usr/src/app
-WORKDIR /usr/src/app
+FROM python:3.9
 
 # Install linux dependencies
-RUN apt-get update \
- && apt-get install -y libssl-dev npm
+RUN --mount=type=cache,target=/var/lib/apt/lists \
+    apt-get update \
+    && apt-get install --no-install-recommends -y curl libssl-dev
 
-RUN npm install n -g \
- && npm install -g npm@latest
-RUN npm install -g ganache
+# install node v18 for ganache and hardhat
+# c22ac94432765ecaa9b4c462b9a7f8dd509071da is v8.2.0
+RUN --mount=type=cache,target=/root/.cache \
+    curl -L https://raw.githubusercontent.com/tj/n/c22ac94432765ecaa9b4c462b9a7f8dd509071da/bin/n -o /usr/local/bin/n \
+    && chmod 755 /usr/local/bin/n \
+    && n 18 \
+    && npm set cache /root/.cache/npm --global \
+    && npm install -g npm@latest
 
+# install ganache
+RUN --mount=type=cache,target=/root/.cache \
+    npm install --verbose --global "ganache@7.2.0"
+
+# prepare python dependencies
+RUN --mount=type=cache,target=/root/.cache \
+    pip install --upgrade pip wheel setuptools
+
+# install anvil
+COPY --from=foundry /usr/local/bin/anvil /usr/local/bin/
+
+# install python dependencies
+WORKDIR /usr/src/app
 COPY requirements.txt .
+RUN --mount=type=cache,target=/root/.cache \
+    pip install -r requirements.txt
+
 COPY requirements-dev.txt .
+RUN --mount=type=cache,target=/root/.cache \
+    pip install -r requirements-dev.txt
 
-RUN pip install -r requirements.txt
-RUN pip install -r requirements-dev.txt
-
+# Set up code directory
+# use docker volumes to mount brownie's code at /code
 WORKDIR /code

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,5 @@ services:
     volumes:
       - .:/code
     command: tail -f /dev/null
+    # TODO: load this from an environment variable so M1 macs can easily use this
+    platform: linux/x86_64


### PR DESCRIPTION
### What I did

Related issue: #1526

### How I did it

Copy the binary of anvil from the official image into brownie. Currently, the "anvil" binary is only available in the "nightly" build. That should be in the "latest" (stable) image soon though.

### How to verify it

```
export DOCKER_BUILDKIT=1
docker-compose build
```

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
