### PR TITLE
Add anvil cli flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.19.0](https://github.com/eth-brownie/brownie/tree/v1.19.0) - 2022-05-29
 ### Added
 - Initial support for [Anvil](https://github.com/foundry-rs/foundry/tree/master/anvil), a blazing-fast local testnet node implementation in Rust ([#1541](https://github.com/eth-brownie/brownie/pull/1541))
+- Support configurable initial wallet balance, chain id, and gas limit.
 
 ### Fixed
 - `StopIteration` when compiling some Vyper `v0.3.3` contracts ([#1547](https://github.com/eth-brownie/brownie/pull/1547))

--- a/brownie/network/rpc/anvil.py
+++ b/brownie/network/rpc/anvil.py
@@ -17,6 +17,8 @@ CLI_FLAGS = {
     "fork": "--fork-url",
     "fork_block": "--fork-block-number",
     "chain_id": "--chain-id",
+    "default_balance": "--balance",
+    "gas_limit": "--gas-limit",
 }
 
 


### PR DESCRIPTION
### What I did

Add the following CLI flags for Anvil: `chain_id`, `default_balance`, `gas_limit`

Related issue: #1526 

### How I did it

Add a few flags to `CLI_FLAGS` variable in `anvil.py`

### How to verify it

The following settings (backward compatible with ganache): 

`cmd_settings: {'chain_id': 1, 'default_balance': 10000000000, 'fork': mainnet, 'gas_limit': 12000000, 'port': 8545}`

It now launches anvil with the correct settings

```
$ brownie console --network anvil-test
Launching 'anvil --chain-id 1 --initial-balance 120000000000000 --fork-url <mainnet_rpc> --gas-limit 12000000 --port 8545
>>> a[0].balance()
120000000000000000000000000000000
>>> chain.id
1
>>> chain.time()
1654069248 
```

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [x] I have updated the documentation
- [x] I have added an entry to the changelog
