### PR TITLE
fix: publish_source with crossing remmapings

### DIFF
--- a/brownie/project/flattener.py
+++ b/brownie/project/flattener.py
@@ -118,7 +118,7 @@ class Flattener:
         Returns:
             str: The import path string correctly remapped.
         """
-        for k, v in self.remappings.items():
+        for k, v in sorted(self.remappings.items(), key=lambda x: len(x[0]), reverse=True):
             if import_path.startswith(k):
                 return import_path.replace(k, v, 1)
         return import_path


### PR DESCRIPTION
### What I did

In projects with overlapping remappings publish_source returns an error:

`FileNotFoundError: [Errno 2] No such file or directory: '/Users/user/.brownie/packages/OpenZeppelin/openzeppelin-contracts@4.4.2-upgradeable/contracts/token/ERC1155/IERC1155Upgradeable.sol'`

The remap_import function checks the match in any order.

```yaml
compiler:
    solc:
        version: 0.8.11
        optimizer:
            enabled: true
        remappings:
        - "@openzeppelin-upgradeable=OpenZeppelin/openzeppelin-contracts-upgradeable@4.4.2"
        - "@openzeppelin-upgradeable=OpenZeppelin/openzeppelin-contracts@4.4.2"

dependencies:
  - OpenZeppelin/openzeppelin-contracts-upgradeable@4.4.2
  - OpenZeppelin/openzeppelin-contracts@4.4.2 
```

### How I did it

Sorted the list remappings by length in descending order, which allowed to exclude the crossing like openzeppelin-upgradeable in openzeppelin-upgradeable.

### How to verify it

I could not find suitable tests for this part of the functionality. For check, it is necessary to pass verification with the configuration specified above.

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
