### PR TITLE
Avoid removing dependencies from the build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Handle version bytecode for Vyper `>=0.3.4` ([#1578](https://github.com/eth-brownie/brownie/pull/1578))
 - Handle Vyper `>=0.3.4` coverage data generation breaking project compilation ([#1586](https://github.com/eth-brownie/brownie/pull/1586))
-
-### Fixed
 - Handle null value of `to` field in transaction receipt so that contract deploying with Anvil works properly ([#1573](https://github.com/eth-brownie/brownie/pull/1573))
+- Avoid removing dependencies from the build ([#1564](https://github.com/eth-brownie/brownie/pull/1564))
 
 ## [1.19.0](https://github.com/eth-brownie/brownie/tree/v1.19.0) - 2022-05-29
 ### Added


### PR DESCRIPTION
### What I did

This solves an issue where some fixtures that were dependencies
of the project would be found right after compilation but not
in subsequent runs of the tests.

### How I did it

Only remove build files if they do not have any dependents in the project.

### How to verify it

Add an out-of-project dependency and compile twice

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [x] I have added an entry to the changelog
