### PR TITLE
Fix: "to" field is null during contract creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/eth-brownie/brownie)
 
+### Fixed
+- Handle null value of `to` field in transaction receipt so that contract deploying with Anvil works properly ([#1573](https://github.com/eth-brownie/brownie/pull/1573))
+
 ## [1.19.0](https://github.com/eth-brownie/brownie/tree/v1.19.0) - 2022-05-29
 ### Added
 - Initial support for [Anvil](https://github.com/foundry-rs/foundry/tree/master/anvil), a blazing-fast local testnet node implementation in Rust ([#1541](https://github.com/eth-brownie/brownie/pull/1541))

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -546,7 +546,7 @@ class TransactionReceipt:
     def _set_from_tx(self, tx: Dict) -> None:
         if not self.sender:
             self.sender = EthAddress(tx["from"])
-        self.receiver = EthAddress(tx["to"]) if tx["to"] else None
+        self.receiver = EthAddress(tx["to"]) if tx.get("to", None) else None
         self.value = Wei(tx["value"])
         self.gas_price = tx.get("gasPrice")
         self.max_fee = tx.get("maxFeePerGas")
@@ -560,7 +560,7 @@ class TransactionReceipt:
         if self.fn_name:
             return
         try:
-            contract = state._find_contract(tx["to"])
+            contract = state._find_contract(tx.get("to"))
             if contract is not None:
                 self.contract_name = contract._name
                 self.fn_name = contract.get_method(tx["input"])


### PR DESCRIPTION
### What I did

Related issue: #1549 

### How I did it

Set receiver in TransactionReceipt ```None``` when transaction dict has no ```to``` attribute.

### How to verify it

Existing unit tests

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [x] I have added an entry to the changelog
