### PR TITLE
added __version__ attribute to brownie for issue #1575

### DIFF
--- a/brownie/__init__.py
+++ b/brownie/__init__.py
@@ -4,7 +4,7 @@
 isort:skip_file
 """
 from brownie.project import compile_source, run
-from brownie._config import CONFIG as _CONFIG
+from brownie._config import CONFIG as _CONFIG, __version__
 from brownie.convert import Fixed, Wei
 from brownie.network import accounts, alert, chain, history, rpc, web3
 from brownie.network.contract import Contract  # NOQA: F401


### PR DESCRIPTION
### What I did
Added a __version__ attribute to brownie.

Related issue: #1575

### How I did it
Imported __version__ from _config.py in __init__.py

### How to verify it
(yt-fork-env) ryanjsfx@MB-145 brownie-ryanjsfx % python3
Python 3.8.9 (default, Jul 19 2021, 09:37:30) 
[Clang 13.0.0 (clang-1300.0.27.3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import brownie
>>> brownie.__version__ != None
True

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog

Not that it fails `tox -e lint` due to:
```
brownie/__init__.py:7:1: F401 'brownie._config.__version__' imported but unused
ERROR: InvocationError for command /Users/ryanjsfx/Documents/brownie-ryanjsfx/.tox/lint/bin/flake8 brownie tests (exited with code 1)

```___________________________________ summary ____________________________________
ERROR:   lint: commands failed

Although it's not supposed to be used...¯\_(ツ)_/¯

I prob need to include a test case and update docs but in case you all don't want this included (or tackled from a different angle) I thought I should just submit the PR now :)