### PR TITLE
feat: add vyper version bytecode check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/eth-brownie/brownie)
+### Fixed
+- Handle version bytecode for Vyper `>=0.3.4` ([#1578](https://github.com/eth-brownie/brownie/pull/1578))
 
 ## [1.19.0](https://github.com/eth-brownie/brownie/tree/v1.19.0) - 2022-05-29
 ### Added

--- a/brownie/project/compiler/vyper.py
+++ b/brownie/project/compiler/vyper.py
@@ -310,6 +310,10 @@ def _generate_coverage_data(
         revert_pc = len(opcodes) + sum(int(i[4:]) - 1 for i in opcodes if i.startswith("PUSH")) - 5
 
     while opcodes:
+        # ignore vyper version bytecode for >= 0.3.4
+        if len(source_map) == 0 and opcodes[0] == "PUSH6" and opcodes[1] == "0x767970657283":
+            break
+            
         # format of source is [start, stop, contract_id, jump code]
         source = source_map.popleft()
         pc_list.append({"op": opcodes.popleft(), "pc": pc})

--- a/brownie/project/compiler/vyper.py
+++ b/brownie/project/compiler/vyper.py
@@ -313,7 +313,7 @@ def _generate_coverage_data(
         # ignore vyper version bytecode for >= 0.3.4
         if len(source_map) == 0 and opcodes[0] == "PUSH6" and opcodes[1] == "0x767970657283":
             break
-            
+
         # format of source is [start, stop, contract_id, jump code]
         source = source_map.popleft()
         pc_list.append({"op": opcodes.popleft(), "pc": pc})


### PR DESCRIPTION
### What I did

Vyper 0.3.4 adds a signature to the bytecode. This causes an error when compiling in Brownie because the source map is empty before the opcodes queue is exhausted in `_generate_coverage_data()` in `brownie/project/compiler/vyper.py`.

Related issue: #1566 and https://github.com/vyperlang/vyper/issues/2955

### How I did it

Check for the signature when the source map is empty, and exit the `while` loop.

### How to verify it

### Checklist

- [X] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [X] I have added an entry to the changelog
