### PR TITLE
Fix typo in network management doc

### DIFF
--- a/docs/network-management.rst
+++ b/docs/network-management.rst
@@ -201,7 +201,7 @@ Brownie allows you to bulk modify the provider you use by setting the `provider`
 
 ::
 
-    $ brownie networks providers_list
+    $ brownie networks list_providers
 
     Brownie v1.17.2 - Python development framework for Ethereum
 
@@ -212,7 +212,7 @@ or
 
 ::
 
-    $ brownie networks providers_list True
+    $ brownie networks list_providers True
 
     Brownie v1.17.2 - Python development framework for Ethereum
 


### PR DESCRIPTION
### What I did
Fixed typo in command to list providers.
Related issue: #

### How I did it
`$ brownie networks providers_list` -> `$ brownie networks list_providers`
### How to verify it

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
