### PR TITLE
fix parsing of dependencies with @ in version

### DIFF
--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -835,7 +835,7 @@ def _maybe_retrieve_github_auth() -> Dict[str, str]:
 
 def _install_from_github(package_id: str) -> str:
     try:
-        path, version = package_id.split("@")
+        path, version = package_id.split("@", 1)
         org, repo = path.split("/")
     except ValueError:
         raise ValueError(


### PR DESCRIPTION
### What I did
Split package_id with only the first '@'. This prevents raising ValueError when '@' is in the name of the version. For example, adding 'superfluid-finance/protocol-monorepo@ethereum_contracts@v1.3.0' to dependencies in brownie-config.yaml raises an ValueError. ethereum_contracts@v1.3.0 is the name of the version.

### How I did it
Change `package_id.split("@")` -> `package_id.split("@", 1)`.

### How to verify it

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
