### PR TITLE
fix: vyper coverage data generation for version >= 0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/eth-brownie/brownie)
 ### Fixed
 - Handle version bytecode for Vyper `>=0.3.4` ([#1578](https://github.com/eth-brownie/brownie/pull/1578))
+- Handle Vyper `>=0.3.4` coverage data generation breaking project compilation ([#1586](https://github.com/eth-brownie/brownie/pull/1586))
 
 ### Fixed
 - Handle null value of `to` field in transaction receipt so that contract deploying with Anvil works properly ([#1573](https://github.com/eth-brownie/brownie/pull/1573))

--- a/brownie/project/compiler/vyper.py
+++ b/brownie/project/compiler/vyper.py
@@ -309,10 +309,7 @@ def _generate_coverage_data(
         # we can identify these optimizer reverts within traces.
         revert_pc = len(opcodes) + sum(int(i[4:]) - 1 for i in opcodes if i.startswith("PUSH")) - 5
 
-    while opcodes:
-        # ignore vyper version bytecode for >= 0.3.4
-        if len(source_map) == 0 and get_version() >= Version("0.3.4"):
-            return {}, {}, {}
+    while opcodes and source_map:
 
         # format of source is [start, stop, contract_id, jump code]
         source = source_map.popleft()

--- a/brownie/project/compiler/vyper.py
+++ b/brownie/project/compiler/vyper.py
@@ -311,7 +311,7 @@ def _generate_coverage_data(
 
     while opcodes:
         # ignore vyper version bytecode for >= 0.3.4
-        if get_version() >= Version("0.3.4"):
+        if len(source_map) == 0 and get_version() >= Version("0.3.4"):
             return {}, {}, {}
 
         # format of source is [start, stop, contract_id, jump code]

--- a/brownie/project/compiler/vyper.py
+++ b/brownie/project/compiler/vyper.py
@@ -311,8 +311,8 @@ def _generate_coverage_data(
 
     while opcodes:
         # ignore vyper version bytecode for >= 0.3.4
-        if len(source_map) == 0 and opcodes[0] == "PUSH6" and opcodes[1] == "0x767970657283":
-            break
+        if get_version() >= Version("0.3.4"):
+            return {}, {}, {}
 
         # format of source is [start, stop, contract_id, jump code]
         source = source_map.popleft()


### PR DESCRIPTION
### What I did

Terminate coverage generation early for vyper versions >= 0.3.4

Related issue: #1578 

### How I did it

Check the version set globally and terminate early if >= 0.3.4

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [x] I have added an entry to the changelog
