### PR TITLE
Added Support for Remappings in from_explorer

### DIFF
--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -1161,10 +1161,11 @@ class Contract(_DeployedContractBase):
             input_json = json.loads(source_str[1:-1])
             sources = {k: v["content"] for k, v in input_json["sources"].items()}
             evm_version = input_json["settings"].get("evmVersion", evm_version)
+            remappings = input_json["settings"].get("remappings", [])
 
             compiler.set_solc_version(str(version))
             input_json.update(
-                compiler.generate_input_json(sources, optimizer=optimizer, evm_version=evm_version)
+                compiler.generate_input_json(sources, optimizer=optimizer, evm_version=evm_version, remappings=remappings)
             )
             output_json = compiler.compile_from_input_json(input_json)
             build_json = compiler.generate_build_json(input_json, output_json)


### PR DESCRIPTION
### What I did

Currently, brownie did not handle remappings when trying to get source in `from_explorer`. 

### How I did it

Fetched remappings and utilized @0xCalibur time.

### How to verify it

Try to get source code for a contract with from_explorer that uses remappings, e.g. those compiled with forge.

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
