### PR TITLE
fix for Darwin systems that cont find a specific process as per https…

### DIFF
--- a/brownie/network/rpc/__init__.py
+++ b/brownie/network/rpc/__init__.py
@@ -252,5 +252,10 @@ class Rpc(metaclass=_Singleton):
 
     def _find_proc_by_name(self, process_name: str) -> psutil.Process:
         for proc in psutil.process_iter():
-            if process_name.lower() in proc.name().lower():
+            try:
+                proc_name = proc.name().lower()
+            except psutil.NoSuchProcess:
+                continue
+
+            if process_name.lower() in proc_name:
                 return proc


### PR DESCRIPTION
…://github.com/eth-brownie/brownie/issues/1588

### What I did

I added a check to ensure that a process in  is actually an active process. There are many circumstances in OSX where one can have hanging processes. In this instance, the process name does not exist as the process has been terminated. This causes a really confusing `psutil` error for the user 


```python
  File "/opt/homebrew/anaconda3/envs/keyring-verifier-api/lib/python3.8/site-packages/brownie/network/main.py", line 48, in connect
    rpc.attach(host)
  File "/opt/homebrew/anaconda3/envs/keyring-verifier-api/lib/python3.8/site-packages/brownie/network/rpc/__init__.py", line 114, in attach
    pid = self._find_rpc_process_pid(resolved_addr)
  File "/opt/homebrew/anaconda3/envs/keyring-verifier-api/lib/python3.8/site-packages/brownie/network/rpc/__init__.py", line 193, in _find_rpc_process_pid
    return self._get_pid_from_docker_backend()
  File "/opt/homebrew/anaconda3/envs/keyring-verifier-api/lib/python3.8/site-packages/brownie/network/rpc/__init__.py", line 241, in _get_pid_from_docker_backend
    proc = self._find_proc_by_name("com.docker.backend")
  File "/opt/homebrew/anaconda3/envs/keyring-verifier-api/lib/python3.8/site-packages/brownie/network/rpc/__init__.py", line 255, in _find_proc_by_name
    if process_name.lower() in proc.name().lower():
  File "/opt/homebrew/anaconda3/envs/keyring-verifier-api/lib/python3.8/site-packages/psutil/__init__.py", line 628, in name
    cmdline = self.cmdline()
  File "/opt/homebrew/anaconda3/envs/keyring-verifier-api/lib/python3.8/site-packages/psutil/__init__.py", line 681, in cmdline
    return self._proc.cmdline()
  File "/opt/homebrew/anaconda3/envs/keyring-verifier-api/lib/python3.8/site-packages/psutil/_psosx.py", line 348, in wrapper
    raise NoSuchProcess(self.pid, self._name)
psutil.NoSuchProcess: process no longer exists (pid=696)
```

Related issue: #1588 

### How I did it

As with many bugs, this fix is quite simple when the origin of the bug has been pinned down...

```python
            try:
                proc_name = proc.name().lower()
            except psutil.NoSuchProcess:
                continue

### How to verify it

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
