### PR TITLE
Correct Moonscan API for Moonbase Alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/eth-brownie/brownie)
+- Correct Moonscan API for Moonbase Alpha testnet([#1611](https://github.com/eth-brownie/brownie/pull/1611))
 
 ## [1.19.1](https://github.com/eth-brownie/brownie/tree/v1.19.1) - 2022-08-07
 ### Fixed

--- a/brownie/data/network-config.yaml
+++ b/brownie/data/network-config.yaml
@@ -137,7 +137,7 @@ live:
         chainid: 1287 
         id: moonbeam-test
         host: https://moonbeam-alpha.api.onfinality.io/public
-        explorer: https://api-moonbeam.moonscan.io/api
+        explorer: https://api-moonbase.moonscan.io/api
         multicall2: "0x37084d0158C68128d6Bc3E5db537Be996f7B6979"
   - name: Moonriver
     networks:


### PR DESCRIPTION
### What I did
Update Moonscan API for Moonbase Alpha. Previously, the Moonscan API for the Moonbeam Production mainnet was specified instead of the one for Moonbase Alpha (Testnet). 

Related issue: #

### How I did it

### How to verify it

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [x] I have added an entry to the changelog
