### PR TITLE
chore: fix E741 rule in flake8

### DIFF
--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -1238,7 +1238,7 @@ class Contract(_DeployedContractBase):
 
             if needs_patch_version:
                 versions = [Version(str(i)) for i in solcx.get_installable_solc_versions()]
-                for v in filter(lambda l: l < version.next_minor(), versions):
+                for v in filter(lambda x: x < version.next_minor(), versions):
                     if v > version:
                         version = v
 


### PR DESCRIPTION
### What I did

Renamed a variable from `l` to `x`. This was causing flake8 to fail and consequently `tox`.

### References

From [PEP8](https://peps.python.org/pep-0008/#names-to-avoid):

> [Prescriptive: Naming Conventions](https://peps.python.org/pep-0008/#prescriptive-naming-conventions)
  [Names to Avoid](https://peps.python.org/pep-0008/#names-to-avoid)
  Never use the characters ‘l’ (lowercase letter el), ‘O’ (uppercase letter oh), or ‘I’ (uppercase letter eye) as single character variable names.
  In some fonts, these characters are indistinguishable from the numerals one and zero. When tempted to use ‘l’, use ‘L’ instead.