### PR TITLE
Correct URL to PyTest Isolation Guide

### DIFF
--- a/brownie/test/managers/master.py
+++ b/brownie/test/managers/master.py
@@ -64,7 +64,7 @@ class PytestBrownieMaster(PytestBrownieBase):
             raise pytest.UsageError(
                 "xdist workers failed to collect tests. Ensure all test cases are "
                 "isolated with the module_isolation or fn_isolation fixtures.\n\n"
-                "https://eth-brownie.readthedocs.io/en/stable/tests.html#isolating-tests"
+                "https://eth-brownie.readthedocs.io/en/stable/tests-pytest-intro.html#pytest-fixtures-isolation"
             )
         build_path = self.project._build_path
 


### PR DESCRIPTION
Closes #1648

### What I did

Corrected PyTest Isolation Guide URL
Related issue: #1648

### How I did it
Corrected the URL to the correct one.

### How to verify it
Run the test suite.

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [x] I have updated the documentation
- [ ] I have added an entry to the changelog
