### PR TITLE
Update module import script

### DIFF
--- a/brownie/project/scripts.py
+++ b/brownie/project/scripts.py
@@ -147,13 +147,21 @@ def _get_path(path_str: str) -> Tuple[Path, Optional[Project]]:
     return path.resolve(), project
 
 
+def _import_module(import_str: str, module_name: str) -> ModuleType:
+    # Import module from import_str
+    module_specs = importlib.util.spec_from_file_location(module_name, import_str)
+    module = importlib.util.module_from_spec(module_specs)
+    module_specs.loader.exec_module(module)
+    return module
+
+
 def _import_from_path(path: Path) -> ModuleType:
     # Imports a module from the given path
-    import_str = ".".join(path.parts[1:-1] + (path.stem,))
+    import_str = "/" + "/".join(path.parts[1:-1] + (path.name,))
     if import_str in _import_cache:
         importlib.reload(_import_cache[import_str])
     else:
-        _import_cache[import_str] = importlib.import_module(import_str)
+        _import_cache[import_str] = _import_module(import_str, f".{path.stem}")
     return _import_cache[import_str]
 
 


### PR DESCRIPTION
Currently, running `brownie run scripts/deploy.py` fails when the path to the project has a `.` in it.

The following path
```
/Users/john.doe/Projects/Chainlink
```

Gets converted to
```
Users.john.doe.Projects.Chainlink
```
Which fails because it thinks that `john` and `doe` are two directories. Using the above method fixes this error.

### What I did

Add an import_module script that works regardless of the path.

### How I did it

Using "/" instead if "." in the path string.

### How to verify it

Run it locally in a path that has a `.` in it.

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
