### PR TITLE
Python 3.11 compatibility - upgrade yarl and set versions for bitarray

### DIFF
--- a/requirements-windows.txt
+++ b/requirements-windows.txt
@@ -343,7 +343,7 @@ wheel==0.37.1
     #   vyper
 wrapt==1.14.1
     # via -r requirements.txt
-yarl==1.8.1
+yarl==1.8.2
     # via
     #   -r requirements.txt
     #   aiohttp

--- a/requirements-windows.txt
+++ b/requirements-windows.txt
@@ -31,7 +31,7 @@ base58==2.1.1
     # via
     #   -r requirements.txt
     #   multiaddr
-bitarray==2.6.0
+bitarray>=2.6.0,<3
     # via
     #   -r requirements.txt
     #   eth-account

--- a/requirements.txt
+++ b/requirements.txt
@@ -254,7 +254,7 @@ wheel==0.37.1
     # via vyper
 wrapt==1.14.1
     # via -r requirements.in
-yarl==1.8.1
+yarl==1.8.2
     # via aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ attrs==22.1.0
     #   pytest
 base58==2.1.1
     # via multiaddr
-bitarray==2.6.0
+bitarray>=2.6.0,<3
     # via eth-account
 black==22.10.0
     # via -r requirements.in


### PR DESCRIPTION
### What I did
I encountered issues with Python 3.11 compatibility in a project using `eth-brownie`. I fixed the problem of dependencies and tested with a matrix strategy for python 3.8, 3.10 and 3.11 on ubuntu, mac and windows. The solution helped a lot and I thought to share it with brownie core :)

I've also seen this reported here: [#](https://github.com/eth-brownie/brownie/issues/1640) and it should fix that too.

### How I did it
Upgraded yarl and added version constraints for bitarray for compatibility with Python 3.11.

### How to verify it
A pip install and running the tests should do it.

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog

Not sure how the checklist applies but I'll see if any CI is triggered automatically and fill in the list if necessary.