### PR TITLE
Separate branch and statement splitting

### DIFF
--- a/brownie/test/output.py
+++ b/brownie/test/output.py
@@ -225,12 +225,11 @@ def _split(coverage_eval, coverage_map, key):
     results = {}
     branches = coverage_map["branches"][key]
     statements = coverage_map["statements"][key]
-    for fn in branches.keys() & statements.keys():
-        results[fn] = [
-            [i for i in statements[fn] if int(i) in coverage_eval[0]],
-            [i for i in branches[fn] if int(i) in coverage_eval[1]],
-            [i for i in branches[fn] if int(i) in coverage_eval[2]],
-        ]
+    for fn, map_ in statements.items():
+        results[fn] = [[i for i in map_ if int(i) in coverage_eval[0]], [], []]
+    for fn, map_ in branches.items():
+        results[fn][1] = [i for i in map_ if int(i) in coverage_eval[1]]
+        results[fn][2] = [i for i in map_ if int(i) in coverage_eval[2]]
     return results
 
 


### PR DESCRIPTION
### What I did

I ran into some issues as described in #1087 and had a look into the code. I believe that I found the solution in order to show all functions of a contract and if they have been fully covered.

Related issue: #1087 

### How I did it

I created a sample project using `brownie bake token`.
In `brownie` version 1.19.2 when you run `brownie test -C`, the coverage report shows only results for `transferFrom` and `_transfer`. `approve`, `balanceOf` and `transfer` are not shown in the results.

So I went down the rabbit hole and realized, that the modified code has the following statement: `branches.keys() & statements.keys()`

The `approve` function has no branches and is therefore not included in the `branches.keys()` list.
By using the `&`, we are excluding functions which do not contain branches.

I saw that version 1.14.6 did not have the issue. So, I took the code from v1.14.6 and it all works now.

### How to verify it

See the previous section.

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
