### PR TITLE
Add Hedera's JSON-RPC relay to default network-config.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/eth-brownie/brownie)
 
+- Add Hedera network integration ([#1658](https://github.com/eth-brownie/brownie/pull/1658))
+
 ## [1.19.2](https://github.com/eth-brownie/brownie/tree/v1.19.2) - 2022-10-16
 ### Added
 - Support for remappings in `from_explorer` ([#1596](https://github.com/eth-brownie/brownie/pull/1596))

--- a/brownie/data/network-config.yaml
+++ b/brownie/data/network-config.yaml
@@ -125,6 +125,23 @@ live:
         host: https://api.harmony.one
         id: harmony-main
         multicall2: "0x3E01dD8a5E1fb3481F0F589056b428Fc308AF0Fb"
+  - name: Hedera
+    networks:
+      - name: Mainnet
+        chainid: 295
+        id: hedera-main
+        host: https://mainnet.hashio.io/api
+        explorer: https://hashscan.io/mainnet
+      - name: Testnet
+        chainid: 296
+        id: hedera-test
+        host: https://testnet.hashio.io/api
+        explorer: https://hashscan.io/testnet
+      - name: Previewnet
+        chainid: 297
+        id: hedera-preview
+        host: https://previewnet.hashio.io/api
+        explorer: https://hashscan.io/previewnet
   - name: Moonbeam
     networks:
       - name: Mainnet
@@ -134,7 +151,7 @@ live:
         explorer: https://api-moonbeam.moonscan.io/api
         multicall2: "0x1337BedC9D22ecbe766dF105c9623922A27963EC"
       - name: Moonbase Alpha
-        chainid: 1287 
+        chainid: 1287
         id: moonbeam-test
         host: https://moonbeam-alpha.api.onfinality.io/public
         explorer: https://api-moonbase.moonscan.io/api

--- a/docs/network-management.rst
+++ b/docs/network-management.rst
@@ -306,8 +306,17 @@ Native EVM-Compatible Chain Integrations
 Brownie natively supports the following collection of EVM-compatible chains:
 
 * Ethereum Classic
+* Arbitrum
+* Avalanche
+* Aurora
 * Binance Smart Chain
+* Boba
 * Fantom Opera
+* Harmony
+* Hedera
+* Moonbeam
+* Moonriver
+* Optimistic Ethereum
 * Polygon Network
 * XDai Network
 


### PR DESCRIPTION
### What I did

Add polygon networks to default network-config.yaml

Related issue: #

### How I did it

Hedera's JSON-RPC relay based on https://swirldslabs.com/hashio/ and https://github.com/hashgraph/hedera-json-rpc-relay. Swirlds Labs part of Swirlds (https://swirldslabs.com/hashio/), a Hedera council member, is providing an implementation of JSON-RPC relay for Hedera based on https://github.com/hashgraph/hedera-json-rpc-relay

### How to verify it

<img width="695" alt="image" src="https://user-images.githubusercontent.com/52283659/210708325-41da23ae-297c-4e3d-917c-d27572bce69d.png">

That is the contract:
https://hashscan.io/testnet/transaction/1672895810.943115003?tid=0.0.902-1672895801-932790323

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [x] I have updated the documentation
- [x] I have added an entry to the changelog
