### PR TITLE
Update main.py

### DIFF
--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -1025,7 +1025,7 @@ def _load_sources(project_path: Path, subfolder: str, allow_json: bool) -> Dict:
             continue
         if next((i for i in path.relative_to(project_path).parts if i.startswith("_")), False):
             continue
-        with path.open() as fp:
+        with path.open(errors="replace") as fp:
             source = fp.read()
 
         if hasattr(hooks, "brownie_load_source"):


### PR DESCRIPTION
added errors="replace" when reading the solidity files

### What I did

I added errors="replace" in the project\main.py file because I encountered errors compiling contracts with non-cp1252 encoded characters even if the characters are only the comment

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
