### PR TITLE
Typo in docs

### DIFF
--- a/docs/tests-coverage.rst
+++ b/docs/tests-coverage.rst
@@ -84,6 +84,6 @@ Some things to keep in mind that can help to reduce your test runtime when evalu
     1. Coverage is analyzed on a per-transaction basis, and the results are cached. If you repeat an identical transaction, Brownie will not analyze it the 2nd time. Keep this in mind when designing and sequencing setup fixtures.
     2. For tests that involve many calls to the same getter method, use the :func:`no_call_coverage <pytest.mark.no_call_coverage>` marker to significantly speed execution.
     3. Omit very complex tests altogether with the :func:`skip_coverage <pytest.mark.skip_coverage>` marker.
-    4. If possible, always run your tests in parralel with :ref:`xdist<xdist>`.
+    4. If possible, always run your tests in parallel with :ref:`xdist<xdist>`.
 
 You can use the ``--durations`` flag to view a profile of your slowest tests. You may find good candidates for optimization, or the use of the :func:`no_call_coverage <pytest.mark.no_call_coverage>` and :func:`skip_coverage <pytest.mark.skip_coverage>` fixtures.


### PR DESCRIPTION
### What I did
Changed misspelled word: parralel -> parallel

Related issue: #

### How I did it

### How to verify it

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [x] I have updated the documentation
- [ ] I have added an entry to the changelog
