### PR TITLE
adding disable namespace collisions flag

### DIFF
--- a/brownie/_cli/compile.py
+++ b/brownie/_cli/compile.py
@@ -18,6 +18,7 @@ Arguments
 Options:
   --all -a              Recompile all contracts
   --size -s             Show deployed bytecode sizes contracts
+  --disable_collisions  Disable namespace collisions check
   --help -h             Display this message
 
 Compiles the contract source files for this project and saves the results
@@ -37,6 +38,9 @@ def main():
 
     contract_artifact_path = build_path.joinpath("contracts")
     interface_artifact_path = build_path.joinpath("interfaces")
+
+    if args["--disable_collisions"] :
+        brownie._config.disable_namespace_collisions=True
 
     if args["--all"]:
         shutil.rmtree(contract_artifact_path, ignore_errors=True)

--- a/brownie/_config.py
+++ b/brownie/_config.py
@@ -34,6 +34,7 @@ python_version = (
 )
 REQUEST_HEADERS = {"User-Agent": f"Brownie/{__version__} (Python/{python_version})"}
 
+disable_namespace_collisions = False
 
 class ConfigContainer:
     def __init__(self):

--- a/brownie/project/sources.py
+++ b/brownie/project/sources.py
@@ -54,7 +54,7 @@ class Sources:
                     collisions.setdefault(name, set()).update([path, self._interfaces[name]])
                 self._interfaces[name] = path
 
-        if collisions:
+        if collisions and not brownie._config.disable_namespace_collisions :
             raise NamespaceCollision(
                 "Multiple contracts or interfaces with the same name\n  "
                 + "\n  ".join(f"{k}: {', '.join(sorted(v))}" for k, v in collisions.items())


### PR DESCRIPTION
### What I did
Add the possibility to disable namespace collision between contracts having the same name

Related issue: #1404

### How I did it

### How to verify it

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
