### PR TITLE
Add support for `OPTIMISTIC_ETHERSCAN_TOKEN` env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/eth-brownie/brownie)
+- Add support for `OPTIMISTIC_ETHERSCAN_TOKEN` env var ([#1673](https://github.com/eth-brownie/brownie/pull/1673))
 
 ## [1.19.3](https://github.com/eth-brownie/brownie/tree/v1.19.3) - 2023-01-29
 ### Added

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -75,6 +75,7 @@ from .web3 import ContractEvent, _ContractEvents, _resolve_address, web3
 _unverified_addresses: Set = set()
 
 _explorer_tokens = {
+    "optimistic.etherscan": "OPTIMISTIC_ETHERSCAN_TOKEN",
     "etherscan": "ETHERSCAN_TOKEN",
     "bscscan": "BSCSCAN_TOKEN",
     "polygonscan": "POLYGONSCAN_TOKEN",


### PR DESCRIPTION
### What I did

Add support for providing api key to optimistic etherscan api.

### How I did it

Add an entry to `__explorer_tokens` dictionary before `etherscan` key.

### How to verify it

### Checklist

- [X] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
No existing test cases available for env variables
- [x] I have updated the documentation 
No documentation available for accepted env variables

- [x] I have added an entry to the changelog
