### PR TITLE
Function that allows the encoding of custom errors

### DIFF
--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -1857,8 +1857,8 @@ class _ContractMethod:
                         return 'Unsported type'
                     encoded_params = encoded_params + val
                 return('typed error: 0x'+error_signature_hex+encoded_params)
-             else:
-                return 'error not found' 
+             
+         return 'error not found' 
 
 
 class ContractTx(_ContractMethod):

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -1857,6 +1857,8 @@ class _ContractMethod:
                         return 'Unsported type'
                     encoded_params = encoded_params + val
                 return('typed error: 0x'+error_signature_hex+encoded_params)
+             else:
+                return 'error not found' 
 
 
 class ContractTx(_ContractMethod):


### PR DESCRIPTION
### What I did
Function that allows the encoding of custom errors.
Can be used in testing as follows:
with brownie.reverts(<DeployedContract>.encode_custom_error(<nameOfCustomError>, [params_of_custom_error]))
Related issue: #1108

### How I did it
- Checks if the error is in the contract abi
- Creates an incoded string that allows the "brownie.reverts" function to compare with the received message
### How to verify it

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
