### PR TITLE
Issue 1676 fix verification of same name files

### DIFF
--- a/brownie/project/flattener.py
+++ b/brownie/project/flattener.py
@@ -24,12 +24,12 @@ class Flattener:
         self.dependencies: DefaultDict[str, Set[str]] = defaultdict(set)
         self.compiler_settings = compiler_settings
         self.contract_name = contract_name
-        self.contract_file = Path(primary_source_fp).name
+        self.contract_file = self.path_to_name(primary_source_fp)
         self.remappings = remappings
 
         self.traverse(primary_source_fp)
 
-        license_search = LICENSE_PATTERN.search(self.sources[Path(primary_source_fp).name])
+        license_search = LICENSE_PATTERN.search(self.path_to_name(primary_source_fp))
         self.license = license_search.group(1) if license_search else "NONE"
 
     @classmethod

--- a/brownie/project/flattener.py
+++ b/brownie/project/flattener.py
@@ -32,6 +32,15 @@ class Flattener:
         license_search = LICENSE_PATTERN.search(self.sources[Path(primary_source_fp).name])
         self.license = license_search.group(1) if license_search else "NONE"
 
+    @classmethod
+    def path_to_name(cls, pth: str) -> str:
+        """Turn the full-path of every Solidity file to a unique shorten name.
+
+        Note, that sometimes there could be several different files with the same name in a project,
+        so these files should keep uniq name to correct verification.
+        """
+        return 'contracts/' + pth.split('/contracts/')[1]
+
     def traverse(self, fp: str) -> None:
         """Traverse a contract source files dependencies.
 
@@ -42,8 +51,9 @@ class Flattener:
             fp: The contract source file to traverse, if it's already been traversed, return early.
         """
         # if already traversed file, return early
+        name = self.path_to_name(fp)
         fp_obj = Path(fp)
-        if fp_obj.name in self.sources:
+        if name in self.sources:
             return
 
         # read in the source file
@@ -56,18 +66,17 @@ class Flattener:
         # replacement function for re.sub, we just sanitize the path
         repl = (  # noqa: E731
             lambda m: f'import{m.group("prefix")}'
-            + f'"{Path(sanitize(m.group("path"))).name}"'
-            + f'{m.group("suffix")}'
+                      + f'"{self.path_to_name(sanitize(m.group("path")))}"'
+                      + f'{m.group("suffix")}'
         )
-
-        self.sources[fp_obj.name] = IMPORT_PATTERN.sub(repl, source)
+        self.sources[name] = IMPORT_PATTERN.sub(repl, source)
         if fp_obj.name not in self.dependencies:
-            self.dependencies[fp_obj.name] = set()
+            self.dependencies[name] = set()
 
         # traverse dependency files - can circular imports happen?
         for m in IMPORT_PATTERN.finditer(source):
             import_path = sanitize(m.group("path"))
-            self.dependencies[fp_obj.name].add(Path(import_path).name)
+            self.dependencies[name].add(self.path_to_name(import_path))
             self.traverse(import_path)
 
     @property


### PR DESCRIPTION
### What I did

every filename inside get_verification_info and payload_verification has it's own unique subpath (even in case if there are several files with the same name) 

Related issue: #1676

### How I did it

created classmethod path_to_name and used it everywhere instead of Path(filepath).name

### How to verify it

1. clone https://github.com/vsmelov/brownie_fail_verification
2. checkout branch "check-fix"
3. remove venv and create empty venv and do pip install -r requirements (there is a new brownie version inside requirements)
4. try to run `brownie run scripts/deploy_and_verify_fail.py --network polygon-main` IT WORKS!

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
