### PR TITLE
Ensure contract address exists in contract map before deleting

### DIFF
--- a/brownie/network/state.py
+++ b/brownie/network/state.py
@@ -583,7 +583,8 @@ def _add_contract(contract: Any) -> None:
 
 
 def _remove_contract(contract: Any) -> None:
-    del _contract_map[contract.address]
+    if contract.address in _contract_map:
+        del _contract_map[contract.address]
 
 
 def _get_deployment(

--- a/brownie/network/state.py
+++ b/brownie/network/state.py
@@ -583,8 +583,7 @@ def _add_contract(contract: Any) -> None:
 
 
 def _remove_contract(contract: Any) -> None:
-    if contract.address in _contract_map:
-        del _contract_map[contract.address]
+    _contract_map.pop(contract.address, None)
 
 
 def _get_deployment(


### PR DESCRIPTION
Closes https://github.com/eth-brownie/brownie/issues/1144

### What I did
A simple check that the Key exists to avoid KeyError

Related issue: #1144

### How I did it

### How to verify it
Local and GitHub Action tests used to fail with KeyError in https://github.com/oceanprotocol/df-py/
Investigated against the existing issue in the brownie repo (#1144). Using `from_abi` did not fix it when used as a combination (both `at` and `from_abi`). Currently in df-py we are rewriting the problematic line from brownie/network/state.py using a `sed` command:

https://github.com/oceanprotocol/df-py/blob/ee7a5f9b1449ed3d308639add306d0c0f98a4a7e/.github/workflows/test.yml#L57

However, it seems like a no-hassle fix and would help a lot of devs using brownie.

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
