### PR TITLE
Upgrade docopt_ng

### DIFF
--- a/brownie/_cli/run.py
+++ b/brownie/_cli/run.py
@@ -33,7 +33,7 @@ interactions, or for gas profiling."""
 
 
 def main():
-    args = docopt(__doc__, more_magic=True)
+    args = docopt(__doc__)
     _update_argv_from_docopt(args)
 
     active_project = None

--- a/setup.py
+++ b/setup.py
@@ -49,5 +49,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     lint
     docs-{local,external}
-    py{37,38,39}
+    py{37,38,39,310,311}
     {pm,evm,plugin}test
     evm-{byzantium,petersburg,istanbul,latest}
 
@@ -12,11 +12,11 @@ passenv =
     GITHUB_TOKEN
     WEB3_INFURA_PROJECT_ID
 deps =
-    py{37,38,39},{pm,plugin}test,evm-{byzantium,petersburg,istanbul,latest}: coverage==5.2.1
-    py{37,38,39},{pm,plugin}test,evm-{byzantium,petersburg,istanbul,latest}: pytest==6.0.1
-    py{37,38,39},{pm,plugin}test,evm-{byzantium,petersburg,istanbul,latest}: pytest-cov==2.10.1
-    py{37,38,39},{pm,plugin}test,evm-{byzantium,petersburg,istanbul,latest}: pytest-mock==3.3.1
-    py{37,38,39},{pm,plugin}test,evm-{byzantium,petersburg,istanbul,latest}: pytest-xdist==1.34.0
+    py{37,38,39,310,311},{pm,plugin}test,evm-{byzantium,petersburg,istanbul,latest}: coverage==5.2.1
+    py{37,38,39,310,311},{pm,plugin}test,evm-{byzantium,petersburg,istanbul,latest}: pytest==6.0.1
+    py{37,38,39,310,311},{pm,plugin}test,evm-{byzantium,petersburg,istanbul,latest}: pytest-cov==2.10.1
+    py{37,38,39,310,311},{pm,plugin}test,evm-{byzantium,petersburg,istanbul,latest}: pytest-mock==3.3.1
+    py{37,38,39,310,311},{pm,plugin}test,evm-{byzantium,petersburg,istanbul,latest}: pytest-xdist==1.34.0
     docs-{local,external}: sphinx
     docs-{local,external}: sphinx_rtd_theme
     docs-{local,external}: pygments_lexer_solidity


### PR DESCRIPTION
Upgrade docopt to ver. 0.9.0 to restore compatibility with Python 3.11. See jazzband/docopt-ng#49 for further details.
### What I did

Related issue: jazzband/docopt-ng#49

### How I did it

Just tried to use Brownie with Python 3.11

### How to verify it

Try to run Brownie with a few commanfd-line switches with Python 3.11

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
