### PR TITLE
chore: fix empty remappings

### DIFF
--- a/brownie/project/compiler/__init__.py
+++ b/brownie/project/compiler/__init__.py
@@ -202,7 +202,7 @@ def generate_input_json(
 
 def _get_solc_remappings(remappings: Optional[list]) -> list:
     if remappings is None:
-        remap_dict: Dict = {}
+        return []
     elif isinstance(remappings, str):
         remap_dict = dict([remappings.split("=")])
     else:


### PR DESCRIPTION
### What I did

If no remappings are used, Brownie should not be passing any remappings to Solc. However, it currently passes the absolute path to the packages folder. This causes the byte metadata hash obtained when compiling contracts to be different between users just because this unnecessary remapping is being passed to the compiler.

### How I did it

When no remapping is being passed, an empty array should be returned instead of returning a dict with the `packages` full path.

### How to verify it

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
