### PR TITLE
encoding='utf-8' for reading contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optimisim (fixed explorer support)
 - Gnosis Chain
 
+### Fixed
+- Force using utf-8 for reading contracts
+
 ## [1.19.3](https://github.com/eth-brownie/brownie/tree/v1.19.3) - 2023-01-29
 ### Added
 - Ganache 7.7.x support ([#1652](https://github.com/eth-brownie/brownie/pull/1652))

--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -1026,7 +1026,7 @@ def _load_sources(project_path: Path, subfolder: str, allow_json: bool) -> Dict:
             continue
         if next((i for i in path.relative_to(project_path).parts if i.startswith("_")), False):
             continue
-        with path.open() as fp:
+        with path.open(encoding='utf-8') as fp:
             source = fp.read()
 
         if hasattr(hooks, "brownie_load_source"):


### PR DESCRIPTION
### What I did
On Windows without utf-8 encoding by default, there can be errors like `UnicodeDecodeError: 'gbk' codec can't decode byte 0x80 in position 52: illegal multibyte sequence` when contracts are being read.
Related issue: None

### How I did it
Using encoding='utf-8' for contracts
### How to verify it
I cloned https://github.com/RockX-SG/stake and made brownie work with the contracts on Windows 10.
### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [x] I have added an entry to the changelog
