### PR TITLE
Include encoded return data in transaction trace

### DIFF
--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -920,6 +920,20 @@ class TransactionReceipt:
                     last["address"], trace[i]["stack"][-2][-40:], trace[i]["stack"][-3]
                 )
 
+            # If the function signature is not available for decoding return data attach
+            # the encoded data.
+            # If the function signature is available this will be overridden by setting
+            # `return_value` a few lines below.
+            if trace[i]["depth"] and opcode == "RETURN":
+                subcall: dict = next(
+                    i for i in self._subcalls[::-1] if i["to"] == last["address"]  # type: ignore
+                )
+
+                if opcode == "RETURN":
+                    returndata = _get_memory(trace[i], -1)
+                    if returndata.hex() not in ("", "0x"):
+                        subcall["returndata"] = returndata.hex()
+
             try:
                 pc = last["pc_map"][trace[i]["pc"]]
             except (KeyError, TypeError):


### PR DESCRIPTION
### What I did
The transaction trace didn't include the encoded return value of function calls if there was no source code contact information. This PR always includes the return data (when not null). If contract source code information is available, the `returndata` gets overridden by `return_value.` 

Related issue: https://github.com/eth-brownie/brownie/issues/1360

### How I did it
I've decoded the `returndata` in the loop that loops through the trace steps before it chooses to ignore a step that doesn't have contract source code information available.

### How to verify it
Run `call_trace(True)` on any transaction. Example before: 
![Screenshot 2023-12-19 at 13 14 20](https://github.com/eth-brownie/brownie/assets/579910/175c766d-cd73-46a9-8841-a7fac0d50b4a)
Example after (including this change): 
![Screenshot 2023-12-19 at 13 14 33](https://github.com/eth-brownie/brownie/assets/579910/f49a907b-b46e-4031-a3ed-3c0ba009e60c)


### Checklist
- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
