### PR TITLE
revise moonbeam rpc urls

### DIFF
--- a/brownie/data/network-config.yaml
+++ b/brownie/data/network-config.yaml
@@ -136,13 +136,13 @@ live:
       - name: Mainnet
         chainid: 1284
         id: moonbeam-main
-        host: https://moonbeam.api.onfinality.io/public
+        host: https://moonbeam.unitedbloc.com
         explorer: https://api-moonbeam.moonscan.io/api
         multicall2: "0x1337BedC9D22ecbe766dF105c9623922A27963EC"
       - name: Moonbase Alpha
         chainid: 1287 
         id: moonbeam-test
-        host: https://moonbeam-alpha.api.onfinality.io/public
+        host: https://moonbase.unitedbloc.com
         explorer: https://api-moonbase.moonscan.io/api
         multicall2: "0x37084d0158C68128d6Bc3E5db537Be996f7B6979"
   - name: Moonriver
@@ -150,7 +150,7 @@ live:
       - name: Mainnet
         chainid: 1285
         id: moonriver-main
-        host: https://moonriver.api.onfinality.io/public
+        host: https://moonriver.unitedbloc.com
         explorer: https://api-moonriver.moonscan.io/api
         multicall2: "0xaef00a0cf402d9dedd54092d9ca179be6f9e5ce3"
   - name: Optimistic Ethereum


### PR DESCRIPTION
### What I did

Updated Moonbeam Endpoints because OnFinality is no longer supporting free public endpoints for Moonbeam, Moonriver, and Moonbase Alpha

For a full listing of all available Moonbeam network RPC urls, see here: https://docs.moonbeam.network/builders/get-started/endpoints/

### How I did it

### How to verify it

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
