### PR TITLE
Default to EIP1559-style transactions on live networks

### DIFF
--- a/brownie/data/default-config.yaml
+++ b/brownie/data/default-config.yaml
@@ -27,9 +27,9 @@ networks:
     live:
         gas_limit: auto
         gas_buffer: 1.1
-        gas_price: auto
+        gas_price: null
         max_fee: null
-        priority_fee: null
+        priority_fee: auto
         reverting_tx_gas_limit: false
         default_contract_owner: false
 

--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -728,7 +728,12 @@ class _PrivateKeyAccount(PublicKeyAccount):
                 priority_fee = CONFIG.active_network["settings"]["priority_fee"] or None
 
         if priority_fee == "auto":
-            priority_fee = Chain().priority_fee
+            try:
+                priority_fee = Chain().priority_fee
+            except ValueError:
+                # fallback to legacy transactions if network does not support EIP1559
+                CONFIG.active_network["settings"]["priority_fee"] = None
+                priority_fee = None
 
         try:
             # if max fee and priority fee are not set, use gas price


### PR DESCRIPTION
### What I did
* default to using EIP1559 gas pricing of transactions when connected to a live network
* fall back to legacy style if the network does not support
