### PR TITLE
camelCase -> snake_case fixes

### DIFF
--- a/brownie/network/middlewares/caching.py
+++ b/brownie/network/middlewares/caching.py
@@ -243,4 +243,4 @@ class RequestCachingMiddleware(BrownieMiddlewareABC):
         self.is_killed = True
         self.block_cache.clear()
         if self.w3.isConnected():
-            self.w3.eth.uninstallFilter(self.block_filter.filter_id)
+            self.w3.eth.uninstall_filter(self.block_filter.filter_id)

--- a/brownie/network/web3.py
+++ b/brownie/network/web3.py
@@ -110,10 +110,14 @@ class Web3(_Web3):
             self._chain_id = None
             self._remove_middlewares()
 
-    def isConnected(self) -> bool:
+    def is_connected(self) -> bool:
         if not self.provider:
             return False
         return super().is_connected()
+
+    def isConnected(self) -> bool:
+        # retained to avoid breaking an interface explicitly defined in brownie
+        return self.is_connected()
 
     @property
     def supports_traces(self) -> bool:
@@ -135,7 +139,7 @@ class Web3(_Web3):
     @property
     def _mainnet(self) -> _Web3:
         # a web3 instance connected to the mainnet
-        if self.isConnected() and CONFIG.active_network["id"] == "mainnet":
+        if self.is_connected() and CONFIG.active_network["id"] == "mainnet":
             return self
         try:
             mainnet = CONFIG.networks["mainnet"]


### PR DESCRIPTION
### What I did
Missed a few spots of converting camelCase to snake_case when upgrading web3 to v6.

I realize that brownie subclasses `Web3` and so the breaking changes here probably denoted a v2 bump...  lets just not talk about that.