### PR TITLE
Improvements to caching middleware

### DIFF
--- a/brownie/network/middlewares/caching.py
+++ b/brownie/network/middlewares/caching.py
@@ -105,17 +105,21 @@ class RequestCachingMiddleware(BrownieMiddlewareABC):
         self.cur = Cursor(_get_data_folder().joinpath("cache.db"))
         self.cur.execute(f"CREATE TABLE IF NOT EXISTS {self.table_key} (method, params, result)")
 
-        latest = w3.eth.get_block("latest")
-        self.last_block = latest.hash
-        self.last_block_seen = latest.timestamp
-        self.last_request = 0.0
-        self.block_cache: OrderedDict = OrderedDict()
-        self.block_filter = w3.eth.filter("latest")
-
         self.lock = threading.Lock()
         self.event = threading.Event()
+        self.start()
+
+    def start(self):
+        latest = self.w3.eth.get_block("latest")
+        self.last_block = latest.hash
+        self.last_block_seen = latest.timestamp
+        self.last_request = time.time()
+        self.block_cache: OrderedDict = OrderedDict()
+        self.block_filter = self.w3.eth.filter("latest")
+
         self.is_killed = False
-        threading.Thread(target=self.block_filter_loop, daemon=True).start()
+        self.loop_thread = threading.Thread(target=self.loop_exception_handler, daemon=True)
+        self.loop_thread.start()
 
     @classmethod
     def get_layer(cls, w3: Web3, network_type: str) -> Optional[int]:
@@ -137,6 +141,14 @@ class RequestCachingMiddleware(BrownieMiddlewareABC):
     @property
     def time_since(self) -> float:
         return time.time() - self.last_request
+
+    def loop_exception_handler(self) -> None:
+        try:
+            self.block_filter_loop()
+        except Exception:
+            # catch unhandled exceptions to avoid random error messages in the console
+            self.block_cache.clear()
+            self.is_killed = True
 
     def block_filter_loop(self) -> None:
         while not self.is_killed:
@@ -214,6 +226,10 @@ class RequestCachingMiddleware(BrownieMiddlewareABC):
                 if isinstance(data, bytes):
                     data = HexBytes(data)
                 return {"id": "cache", "jsonrpc": "2.0", "result": data}
+
+        if not self.loop_thread.is_alive():
+            # restart the block filter loop if it has crashed (usually from a ConnectionError)
+            self.start()
 
         with self.lock:
             self.last_request = time.time()


### PR DESCRIPTION
### What I did
Restart the block filter loop automatically if it crashes. This sometimes happens from a temporary loss of internet connection.  previously you'd have to either restart brownie altogether, or `web3.reset_middlewares()`

### How to verify it
I've been running brownie locally with these edits for a week or so now and it seems to work.  Tried suspending my laptop a few times, as well as restarting my router to mess up the connection.