### PR TITLE
Multicall

### DIFF
--- a/brownie/network/multicall.py
+++ b/brownie/network/multicall.py
@@ -49,7 +49,7 @@ class Multicall:
 
     def __init__(self) -> None:
         self.address = None
-        self.default_verbosity = False
+        self.default_verbose = False
         self._block_number = defaultdict(lambda: None)  # type: ignore
         self._verbose = defaultdict(lambda: None)  # type: ignore
         self._contract = None
@@ -72,7 +72,7 @@ class Multicall:
     ) -> "Multicall":
         self.address = address  # type: ignore
         self._block_number[get_ident()] = block_identifier  # type: ignore
-        self._verbose[get_ident()] = verbose if verbose is not None else self.default_verbosity
+        self._verbose[get_ident()] = verbose if verbose is not None else self.default_verbose
         return self
 
     def _flush(self, future_result: Result = None) -> Any:
@@ -84,7 +84,7 @@ class Multicall:
             # or this result has already been retrieved
             return future_result
         with self._lock:
-            if self._verbose.get(get_ident(), self.default_verbosity):
+            if self._verbose.get(get_ident(), self.default_verbose):
                 message = (
                     "Multicall:"
                     f"\n  Thread ID: {get_ident()}"

--- a/brownie/network/multicall.py
+++ b/brownie/network/multicall.py
@@ -162,6 +162,9 @@ class Multicall:
         self.flush()
         getattr(ContractCall, "__multicall")[get_ident()] = None
 
+        self._block_number.pop(get_ident(), None)
+        self._verbose.pop(get_ident(), None)
+
     @staticmethod
     def deploy(tx_params: Dict) -> Contract:
         """Deploy an instance of the `Multicall2` contract.

--- a/docs/api-network.rst
+++ b/docs/api-network.rst
@@ -1900,6 +1900,21 @@ Multicall Attributes
         ...     brownie.multicall.block_number
         12733683
 
+.. py:attribute:: Multicall.default_verbosity
+
+    Default verbosity setting for multicall. Set to ``False`` by default. If set to ``True``, the content of each batched call is printed to the console. This is useful for debugging, to ensure a multicall is performing as expected.
+
+    .. code-block:: python
+
+        >>> multicall.default_verbosity = True
+
+    You can also enable verbosity for individual multicalls by setting the `verbose` keyword:
+
+    .. code-block:: python
+
+        >>> with brownie.multicall(verbose=True):
+        ...
+
 Multicall Methods
 *****************
 

--- a/docs/api-network.rst
+++ b/docs/api-network.rst
@@ -1900,13 +1900,13 @@ Multicall Attributes
         ...     brownie.multicall.block_number
         12733683
 
-.. py:attribute:: Multicall.default_verbosity
+.. py:attribute:: Multicall.default_verbose
 
     Default verbosity setting for multicall. Set to ``False`` by default. If set to ``True``, the content of each batched call is printed to the console. This is useful for debugging, to ensure a multicall is performing as expected.
 
     .. code-block:: python
 
-        >>> multicall.default_verbosity = True
+        >>> multicall.default_verbose = True
 
     You can also enable verbosity for individual multicalls by setting the `verbose` keyword:
 


### PR DESCRIPTION
### What I did
* fix a bug within `multicall` where multiple uninitialized references would always target the same block height
* add a `verbose` kwarg and `default_verbose` attribute to see the content of each multicall (useful for debugging)