### PR TITLE
fix versions parsing RegExp

### DIFF
--- a/brownie/project/sources.py
+++ b/brownie/project/sources.py
@@ -231,7 +231,9 @@ def get_vyper_pragma_spec(source: str, path: Optional[str] = None) -> NpmSpec:
 
     Returns: NpmSpec object
     """
-    pragma_match = next(re.finditer(r"(?:\n|^)\s*#\s*@version\s*([^\n]*)", source), None)
+    pragma_match = next(
+        re.finditer(r"(?:\n|^)\s*#\s*(?:pragma version|@version)\s*([^\n]*)", source), None
+    )
     if pragma_match is None:
         if path:
             raise PragmaError(f"No version pragma in '{path}'")


### PR DESCRIPTION
### What I did
Added supporting the new pragma string for Vyper 0.3.10 according to [the docs](https://docs.vyperlang.org/en/latest/structure-of-a-contract.html#version-pragma)

Closes #1745

### How I did it
Changed RegExp pattern to obtain the version of compiler

### How to verify it

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
