### PR TITLE
fix: `TypeError` when outputting custom errors

### DIFF
--- a/brownie/exceptions.py
+++ b/brownie/exceptions.py
@@ -291,6 +291,6 @@ def decode_typed_error(data: str) -> str:
         if selector == ERROR_SIG:
             return result[0]
         else:
-            return f"{_errors[selector]['name']}: {', '.join(result)}"
+            return f"{_errors[selector]['name']}: {', '.join([str(i) for i in result])}"
     else:
         return f"Unknown typed error: {data}"


### PR DESCRIPTION
### What I did
Fixes #1749