### PR TITLE
loosen package install restrictions

### DIFF
--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -855,7 +855,7 @@ def _install_from_github(package_id: str) -> str:
             elif len(contract_paths) == 1:
                 brownie_config["project_structure"]["contracts"] = contract_paths.pop()
             else:
-                raise InvalidPackage(
+                raise Exception(
                     f"{package_id} has no `contracts/` subdirectory, and "
                     "multiple directories containing source files"
                 )


### PR DESCRIPTION
### What I did
Allow installing a package where there is no `contracts` folder, and multiple folders contain smart contracts.

This helps when dealing with mono-repos, or projects using foundry where unit tests are also marked as `.sol`.