### PR TITLE
feat: add `eager_caching: true` to default-config.yaml

### DIFF
--- a/brownie/data/default-config.yaml
+++ b/brownie/data/default-config.yaml
@@ -71,3 +71,4 @@ hypothesis:
 autofetch_sources: false
 dependencies: null
 dev_deployment_artifacts: false
+eager_caching: false

--- a/brownie/data/default-config.yaml
+++ b/brownie/data/default-config.yaml
@@ -71,4 +71,4 @@ hypothesis:
 autofetch_sources: false
 dependencies: null
 dev_deployment_artifacts: false
-eager_caching: false
+eager_caching: true

--- a/brownie/network/middlewares/caching.py
+++ b/brownie/network/middlewares/caching.py
@@ -117,6 +117,9 @@ class RequestCachingMiddleware(BrownieMiddlewareABC):
 
     @classmethod
     def get_layer(cls, w3: Web3, network_type: str) -> Optional[int]:
+        if CONFIG.settings['eager_caching'] is False:
+            # do not cache when user doesn't want it
+            return None
         if network_type != "live":
             # do not cache on development chains
             return None

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -390,3 +390,10 @@ Other Settings
     .. code-block:: yaml
 
         dotenv: .env
+
+.. py:attribute:: eager_caching
+    If set to ``false``, brownie will not start the background caching thread and will only call the RPC on an as-needed basis.
+
+    This is useful for always-on services or while using pay-as-you-go private RPCs
+
+    default value: ``true``


### PR DESCRIPTION
### What I did

Related issue: # N/A
I added a `eager_caching` setting to brownie-config.yaml which tells brownie not to enable the background caching thread

### How I did it
easy!

### How to verify it
pending

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [x] I have updated the documentation
- [ ] I have added an entry to the changelog
