### PR TITLE
fix: target different blocks for live/dev network

### DIFF
--- a/brownie/network/middlewares/geth_poa.py
+++ b/brownie/network/middlewares/geth_poa.py
@@ -10,8 +10,9 @@ from brownie.network.middlewares import BrownieMiddlewareABC
 class GethPOAMiddleware(BrownieMiddlewareABC):
     @classmethod
     def get_layer(cls, w3: Web3, network_type: str) -> Optional[int]:
+        block_ident = "latest" if network_type == "live" else 0
         try:
-            w3.eth.get_block(0)
+            w3.eth.get_block(block_ident)
             return None
         except ExtraDataLengthError:
             return -1


### PR DESCRIPTION
### What I did
For live networks, determine if the POA middleware is required by looking at the latest block.  For dev networks, check the first block.

Closes #1762