### PR TITLE
fix: crash when waiting for a tx confirmation

### DIFF
--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -216,10 +216,10 @@ class TransactionReceipt:
         # await confirmation of tx in a separate thread which is blocking if
         # required_confs > 0 or tx has already confirmed (`blockNumber` != None)
         confirm_thread = threading.Thread(
-            target=self._await_confirmation, args=(tx["blockNumber"], required_confs), daemon=True
+            target=self._await_confirmation, args=(tx.get("blockNumber"), required_confs), daemon=True
         )
         confirm_thread.start()
-        if is_blocking and (required_confs > 0 or tx["blockNumber"]):
+        if is_blocking and (required_confs > 0 or tx.get("blockNumber")):
             confirm_thread.join()
 
     def __repr__(self) -> str:
@@ -508,7 +508,7 @@ class TransactionReceipt:
                 # check if tx is still in mempool, this will raise otherwise
                 tx = web3.eth.get_transaction(self.txid)
                 self.block_number = None
-                return self._await_confirmation(tx["blockNumber"], required_confs)
+                return self._await_confirmation(tx.get("blockNumber"), required_confs)
             if required_confs - self.confirmations != remaining_confs:
                 remaining_confs = required_confs - self.confirmations
                 if not self._silent:


### PR DESCRIPTION
### What I did

in recent versions of anvil sometimes brownie ends up in a race condition when waiting for a tx confirmation. the bug results in`KeyError: 'blockNumber'`.

the root cause is anvil retuning no `blockNumber` field in `eth_getTransactionByHash` for pending transactions.

the bug was introduced here https://github.com/alloy-rs/alloy/pull/523

### How I did it

use `tx.get('blockNumber')` instead of `tx['blockNumber']`

### How to verify it

run a bunch of transactions, it doesn't happen every time. it's easier if you run anvil alongside, so you can see its output. the bug manifests when there is a `eth_getTransactionByHash` before `Transaction` printout.

```
eth_sendTransaction
eth_getTransactionByHash
eth_getCode

    Transaction: 0xc94c6c69570ca19763eda0a33a9b6a67803a5fa1fca2861ed2f4c08607edf0fb
    Gas used: 21000
```

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
