### PR TITLE
Search parent paths for import file during source verification

### DIFF
--- a/brownie/project/flattener.py
+++ b/brownie/project/flattener.py
@@ -147,4 +147,11 @@ class Flattener:
         if path.is_absolute():
             return path.as_posix()
 
-        return (Path(source_file_dir) / path).resolve().as_posix()
+        source_file_dir = Path(source_file_dir).resolve()
+        newpath = (source_file_dir / path).resolve()
+        while not newpath.exists():
+            source_file_dir = source_file_dir.parent
+            newpath = (source_file_dir / path).resolve()
+            if source_file_dir == Path("/"):
+                raise FileNotFoundError(f"Cannot determine location of {import_path}")
+        return newpath.as_posix()


### PR DESCRIPTION
### What I did
During source file verification, recursively check each parent folder to find the absolute path of a file import.

Related issue: #1775 

### How I did it
Recursively check each `.parent` of `source_file_dir` until the path exists. If the check fails, raise a `FileNotFoundError`.

I'm unsure how to go about writing tests for this, but confirm the behavior works for my case.
