### PR TITLE
fix: anvil mine

### DIFF
--- a/brownie/network/rpc/anvil.py
+++ b/brownie/network/rpc/anvil.py
@@ -75,10 +75,8 @@ def sleep(seconds: int) -> int:
     return seconds
 
 
-def mine(timestamp: Optional[int] = None) -> None:
-    if timestamp:
-        _request("evm_setNextBlockTimestamp", [timestamp])
-    _request("evm_mine", [1])
+def mine(blocks: Optional[int] = None) -> None:
+    _request("evm_mine", blocks)
 
 
 def snapshot() -> int:


### PR DESCRIPTION
### What I did

small refactor so `chain.mine()` works as expected w/ anvil

Currently, `chain.mine()` or `chain.mine(x)` both revert with error `brownie.exceptions.RPCRequestError: Timestamp error: 1 is lower than or equal to previous block's timestamp`

Related issue: #

### How I did it

set the `mine` function to only use `evm_mine` and to pass `blocks` instead of defaulting to hardcoded 1

### How to verify it

- `chain.mine()` mines 1 block
- `chain.mine(x)` mines x blocks

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
