### PR TITLE
Remove tdqm progress bars

### DIFF
--- a/brownie/project/compiler/solidity.py
+++ b/brownie/project/compiler/solidity.py
@@ -93,7 +93,7 @@ def set_solc_version(version: Union[str, Version]) -> str:
 def install_solc(*versions: Union[Version, str]) -> None:
     """Installs solc versions."""
     for version in versions:
-        solcx.install_solc(version, show_progress=True)
+        solcx.install_solc(version, show_progress=False)
 
 
 def get_abi(contract_source: str, allow_paths: Optional[str] = None) -> Dict:

--- a/brownie/project/compiler/vyper.py
+++ b/brownie/project/compiler/vyper.py
@@ -99,7 +99,7 @@ def _get_vyper_version_list() -> Tuple[List, List]:
 def install_vyper(*versions: str) -> None:
     """Installs vyper versions."""
     for version in versions:
-        vvm.install_vyper(version, show_progress=True)
+        vvm.install_vyper(version, show_progress=False)
 
 
 def find_vyper_versions(


### PR DESCRIPTION
### What I did
Removed the `tdqm` progress bar when installing the compiler.  Turns out this makes the install process magnitudes slower :scream:   Go figure.