### PR TITLE
Caching fixes

### DIFF
--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -708,7 +708,9 @@ class _DeployedContractBase(_ContractBase):
         self, address: str, owner: Optional[AccountsType] = None, tx: TransactionReceiptType = None
     ) -> None:
         address = _resolve_address(address)
-        self.bytecode = web3.eth.get_code(address).hex()[2:]
+        self.bytecode = (
+            self._build.get("deployedBytecode", None) or web3.eth.get_code(address).hex()[2:]
+        )
         if not self.bytecode:
             raise ContractNotFound(f"No contract deployed at {address}")
         self._owner = owner
@@ -948,7 +950,13 @@ class Contract(_DeployedContractBase):
             will be performed using this account.
         """
         address = _resolve_address(address)
-        build = {"abi": abi, "address": address, "contractName": name, "type": "contract"}
+        build = {
+            "abi": abi,
+            "address": address,
+            "contractName": name,
+            "type": "contract",
+            "deployedBytecode": web3.eth.get_code(address).hex()[2:],
+        }
 
         self = cls.__new__(cls)
         _ContractBase.__init__(self, None, build, {})  # type: ignore

--- a/brownie/network/state.py
+++ b/brownie/network/state.py
@@ -632,6 +632,12 @@ def _add_deployment(contract: Any, alias: Optional[str] = None) -> None:
         f"(address UNIQUE, alias UNIQUE, paths, {', '.join(DEPLOYMENT_KEYS)})"
     )
 
+    if "compiler" not in contract._build:
+        # do not replace full contract artifacts with ABI-only ones
+        row = cur.fetchone(f"SELECT compiler FROM {name} WHERE address=?", (address,))
+        if row and row[0]:
+            return
+
     all_sources = {}
     for key, path in contract._build.get("allSourcePaths", {}).items():
         source = contract._sources.get(path)


### PR DESCRIPTION
### What I did
* when instantiating a `Contract` object, the cached bytecode is used if available to avoid a call to `eth_getCode`
* `Contract.from_abi` no longer overwrites full contract artifacts

The first item improves load times fairly significantly for me.