### PR TITLE
Limit workflow concurrency

### DIFF
--- a/.github/workflows/core-ganache-3.10.yaml
+++ b/.github/workflows/core-ganache-3.10.yaml
@@ -1,6 +1,11 @@
 name: Core Ganache (py3.10)
 on: ["push", "pull_request"]
 
+# This limits the workflow to 1 active run at any given time for a specific branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   ETHERSCAN_TOKEN: 9MKURTHE8FNA9NRUUJBHMUEVY6IQ5K1EGY
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/core-ganache-3.11.yaml
+++ b/.github/workflows/core-ganache-3.11.yaml
@@ -1,6 +1,11 @@
 name: Core Ganache (py3.11)
 on: ["push", "pull_request"]
 
+# This limits the workflow to 1 active run at any given time for a specific branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   ETHERSCAN_TOKEN: 9MKURTHE8FNA9NRUUJBHMUEVY6IQ5K1EGY
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/core-ganache-3.12.yaml
+++ b/.github/workflows/core-ganache-3.12.yaml
@@ -1,6 +1,11 @@
 name: Core Ganache (py3.12)
 on: ["push", "pull_request"]
 
+# This limits the workflow to 1 active run at any given time for a specific branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   ETHERSCAN_TOKEN: 9MKURTHE8FNA9NRUUJBHMUEVY6IQ5K1EGY
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/evm.yaml
+++ b/.github/workflows/evm.yaml
@@ -2,6 +2,11 @@ on: ["push", "pull_request"]
 
 name: evm tests
 
+# This limits the workflow to 1 active run at any given time for a specific branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   ETHERSCAN_TOKEN: 9MKURTHE8FNA9NRUUJBHMUEVY6IQ5K1EGY
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/functionality.yaml
+++ b/.github/workflows/functionality.yaml
@@ -2,6 +2,11 @@ on: ["push", "pull_request"]
 
 name: functionality
 
+# This limits the workflow to 1 active run at any given time for a specific branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   ETHERSCAN_TOKEN: 9MKURTHE8FNA9NRUUJBHMUEVY6IQ5K1EGY
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,6 +2,11 @@ on: ["push", "pull_request"]
 
 name: linting
 
+# This limits the workflow to 1 active run at any given time for a specific branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   ETHERSCAN_TOKEN: 9MKURTHE8FNA9NRUUJBHMUEVY6IQ5K1EGY
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### What I did
This PR limits each github workflow to 1 concurrent run per branch to avoid annoying emails and the queue backing up.

Does not impact the library in any way.

Related issue: #

### How I did it
Added a short snippet to each workflow's yaml file

### How to verify it
Just merge and see

### Checklist

- [x] I have confirmed that my PR passes all linting checks
