### PR TITLE
[fix] GethPOAMiddleware on Polygon networks with anvil fork

### DIFF
--- a/brownie/network/middlewares/geth_poa.py
+++ b/brownie/network/middlewares/geth_poa.py
@@ -10,7 +10,7 @@ from brownie.network.middlewares import BrownieMiddlewareABC
 class GethPOAMiddleware(BrownieMiddlewareABC):
     @classmethod
     def get_layer(cls, w3: Web3, network_type: str) -> Optional[int]:
-        block_idents = ["latest"] if network_type == "live" else [0, "latest"]
+        block_idents = ("latest",) if network_type == "live" else (0, "latest")
         try:
             for block_ident in block_idents:
                 w3.eth.get_block(block_ident)

--- a/brownie/network/middlewares/geth_poa.py
+++ b/brownie/network/middlewares/geth_poa.py
@@ -10,9 +10,10 @@ from brownie.network.middlewares import BrownieMiddlewareABC
 class GethPOAMiddleware(BrownieMiddlewareABC):
     @classmethod
     def get_layer(cls, w3: Web3, network_type: str) -> Optional[int]:
-        block_ident = "latest" if network_type == "live" else 0
+        block_idents = ["latest"] if network_type == "live" else [0, "latest"]
         try:
-            w3.eth.get_block(block_ident)
+            for block_ident in block_idents:
+                w3.eth.get_block(block_ident)
             return None
         except ExtraDataLengthError:
             return -1

--- a/brownie/network/middlewares/geth_poa.py
+++ b/brownie/network/middlewares/geth_poa.py
@@ -10,7 +10,8 @@ from brownie.network.middlewares import BrownieMiddlewareABC
 class GethPOAMiddleware(BrownieMiddlewareABC):
     @classmethod
     def get_layer(cls, w3: Web3, network_type: str) -> Optional[int]:
-        # On Polygon networks, anvil in forked development mode doesn't throw ExtraDataLengthError on the first block.
+        # NOTE: 0 because Ganache sometimes injects a block of their own. It doesn't have the extra data that we are checking for.
+        # "latest" because On Polygon networks, anvil in forked development mode doesn't throw ExtraDataLengthError on the first block.
         block_idents = ("latest",) if network_type == "live" else (0, "latest")
         try:
             for block_ident in block_idents:

--- a/brownie/network/middlewares/geth_poa.py
+++ b/brownie/network/middlewares/geth_poa.py
@@ -10,6 +10,7 @@ from brownie.network.middlewares import BrownieMiddlewareABC
 class GethPOAMiddleware(BrownieMiddlewareABC):
     @classmethod
     def get_layer(cls, w3: Web3, network_type: str) -> Optional[int]:
+        # On Polygon networks, anvil in forked development mode doesn't throw ExtraDataLengthError on the first block.
         block_idents = ("latest",) if network_type == "live" else (0, "latest")
         try:
             for block_ident in block_idents:


### PR DESCRIPTION
### What I did
On Polygon networks, anvil in forked development mode doesn't throw `ExtraDataLengthError` on the first block. So, I changed the GethPOAMiddleware to try both the first block and latest block. This is similar to apeworx implementation here:
https://github.com/ApeWorX/ape-hardhat/pull/133

Related issue: #1762

### How I did it

### How to verify it
ran anvil locally
```
anvil --accounts 10 --fork-url <REDACTED> --gas-limit 12000000 --port 8545 --chain-id 137 &
```

connect web to anvil
```
web3.connect('http://localhost:8545')
```

verify we hit the exception on latest block, but not on first block
```
>>> try:
...     web3.eth.get_block("latest")
... except Exception as e:
...     print(type(e))
... 
eth_getBlockByNumber
<class 'web3.exceptions.ExtraDataLengthError'>
```

```
>>> try:
...     web3.eth.get_block(0)
... except Exception as e:
...     print(type(e))
... 
eth_getBlockByNumber
AttributeDict({'hash': HexBytes('0xa9c28ce2141b56c474f1dc504bee9b01eb1bd7d1a507580d5519d4437a97de1b'), 'parentHash': HexBytes('0x0000000000000000000000000000000000000000000000000000000000000000'), 'sha3Uncles': HexBytes('0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347'), 'miner': '0x0000000000000000000000000000000000000000', 'stateRoot': HexBytes('0x654f28d19b44239d1012f27038f1f71b3d4465dc415a382fb2b7009cba1527c8'), 'transactionsRoot': HexBytes('0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421'), 'receiptsRoot': HexBytes('0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421'), 'logsBloom': HexBytes('0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'), 'difficulty': 1, 'number': 0, 'gasLimit': 10000000, 'gasUsed': 0, 'timestamp': 1590824836, 'totalDifficulty': 1, 'extraData': HexBytes('0x'), 'mixHash': HexBytes('0x0000000000000000000000000000000000000000000000000000000000000000'), 'nonce': HexBytes('0x0000000000000000'), 'uncles': [], 'transactions': [], 'size': 508})
```

### Checklist

- [X ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [N/A] I have updated the documentation
- [ ] I have added an entry to the changelog
