### PR TITLE
feat: implement cchecksum for ~2x faster checksumming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `include` kwarg for address strategy, type-dependent strategy overloads ([#1780](https://github.com/eth-brownie/brownie/pull/1780))
 
+### Changed
+- replace `eth_utils.to_checksum_address` with `cchecksum.to_checksum_address` for ~2x faster checksumming ([#1796](https://github.com/eth-brownie/brownie/pull/1796))
+
 ### Fixed
 - ds-note decoding ([#1781](https://github.com/eth-brownie/brownie/pull/1781))
 - "Dropped without known replacement" tx race condition ([#1782](https://github.com/eth-brownie/brownie/pull/1782))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/eth-brownie/brownie)
+### Changed
+- replace `eth_utils.to_checksum_address` with `cchecksum.to_checksum_address` for ~2x faster checksumming ([#1796](https://github.com/eth-brownie/brownie/pull/1796))
 
 ## [1.20.7](https://github.com/eth-brownie/brownie/tree/v1.20.7) - 2025-01-07
 ### Added
@@ -21,9 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.20.6](https://github.com/eth-brownie/brownie/tree/v1.20.6) - 2024-06-22
 ### Added
 - `include` kwarg for address strategy, type-dependent strategy overloads ([#1780](https://github.com/eth-brownie/brownie/pull/1780))
-
-### Changed
-- replace `eth_utils.to_checksum_address` with `cchecksum.to_checksum_address` for ~2x faster checksumming ([#1796](https://github.com/eth-brownie/brownie/pull/1796))
 
 ### Fixed
 - ds-note decoding ([#1781](https://github.com/eth-brownie/brownie/pull/1781))

--- a/brownie/convert/datatypes.py
+++ b/brownie/convert/datatypes.py
@@ -9,6 +9,7 @@ try:
 except ImportError:
     DecimalOverrideException = BaseException  # regular catch blocks shouldn't catch
 
+import cchecksum
 import eth_utils
 from hexbytes import HexBytes
 
@@ -205,7 +206,7 @@ class EthAddress(str):
             converted_value = HexBytes(value).hex()
         converted_value = eth_utils.add_0x_prefix(str(converted_value))  # type: ignore
         try:
-            converted_value = eth_utils.to_checksum_address(converted_value)
+            converted_value = cchecksum.to_checksum_address(converted_value)
         except ValueError:
             raise ValueError(f"'{value}' is not a valid ETH address") from None
         return super().__new__(cls, converted_value)  # type: ignore

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,5 @@
 black>=20.8b1
+cchecksum>=0.0.3
 eip712
 eth-abi
 eth-account

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,8 @@ black==24.2.0
     # via -r requirements.in
 cbor2==5.6.2
     # via vyper
+cchecksum==0.0.4
+    # via -r requirements.in
 certifi==2024.2.2
     # via requests
 charset-normalizer==3.3.2
@@ -68,6 +70,7 @@ eth-rlp==1.0.1
     # via eth-account
 eth-typing==3.5.2
     # via
+    #   cchecksum
     #   eip712
     #   eth-abi
     #   eth-keys
@@ -76,6 +79,7 @@ eth-typing==3.5.2
 eth-utils==2.3.1
     # via
     #   -r requirements.in
+    #   cchecksum
     #   eip712
     #   eth-abi
     #   eth-account

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ black==24.2.0
     # via -r requirements.in
 cbor2==5.6.2
     # via vyper
-cchecksum==0.0.4
+cchecksum==0.0.7
     # via -r requirements.in
 certifi==2024.2.2
     # via requests


### PR DESCRIPTION
### What I did
I saw a low-hanging-fruit optimization opportunity in eth_utils.to_checksum_address

I re-implemented eth_utils.to_checksum_address in c [here](https://github.com/BobTheBuidler/cchecksum), published a lib to pypi, dropped the drop-in replacement into brownie

Related issue: #

### How I did it

### How to verify it

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [x] I have added an entry to the changelog
