### PR TITLE
FIX: sepolia-ETH API endpoint needs `/api` suffix, ref https://ethereum.stackexchange.com/a/147268

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/eth-brownie/brownie)
+### Fixed
+- API endpoint of Sepolia-ETH (Infura) changed to `https://api-sepolia.etherscan.io/api` (with `/api` suffix)
 
 ## [1.20.6](https://github.com/eth-brownie/brownie/tree/v1.20.6) - 2024-06-22
 ### Added

--- a/brownie/data/network-config.yaml
+++ b/brownie/data/network-config.yaml
@@ -26,7 +26,7 @@ live:
         chainid: 11155111
         id: sepolia
         host: https://sepolia.infura.io/v3/$WEB3_INFURA_PROJECT_ID
-        explorer: https://api-sepolia.etherscan.io/
+        explorer: https://api-sepolia.etherscan.io/api
         provider: infura
       - name: Goerli (Infura)
         chainid: 5


### PR DESCRIPTION
### What I did
Fixed the API endpoint configuration of Sepolia-ETH (Infura)

Related issue: None

### How I did it
Adding `/api` suffix

### How to verify it
Just deploy any contract onto Sepolia-ETH with `publish_source=True` param.
e.g.  https://github.com/koyo922/learn-web3/blob/main/updraft_course/brownie_fund_me/scripts/deploy.py#L8

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [x] I have added an entry to the changelog

![image](https://github.com/user-attachments/assets/00269f3f-7c9f-4f0b-9469-fc327dae50aa)
![image](https://github.com/user-attachments/assets/68e528d5-6fba-4689-a7e9-ab320a0ebb00)

