### PR TITLE
fix: Broken links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,7 +126,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.19.0](https://github.com/eth-brownie/brownie/tree/v1.19.0) - 2022-05-29
 ### Added
-- Initial support for [Anvil](https://github.com/foundry-rs/foundry/tree/master/anvil), a blazing-fast local testnet node implementation in Rust ([#1541](https://github.com/eth-brownie/brownie/pull/1541))
+- Initial support for [Anvil](https://github.com/foundry-rs/foundry/tree/master/crates/anvil), a blazing-fast local testnet node implementation in Rust ([#1541](https://github.com/eth-brownie/brownie/pull/1541))
 - Support configurable initial wallet balance, chain id, and gas limit.
 
 ### Fixed

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -114,9 +114,9 @@ If you have updated your brownie version from older versions, hardhat networks w
 Using Brownie with Anvil
 ==========================
 
-`Anvil <https://github.com/foundry-rs/foundry/tree/master/anvil>`_ is a blazing-fast local testnet node implementation in Rust. Anvil may be used as an alternative to Ganache within Brownie.
+`Anvil <https://github.com/foundry-rs/foundry/tree/master/crates/anvil>`_ is a blazing-fast local testnet node implementation in Rust. Anvil may be used as an alternative to Ganache within Brownie.
 
-To use Anvil with Brownie, you must first `follow their steps to install Anvil <https://github.com/foundry-rs/foundry/tree/master/anvil#installation>`_.
+To use Anvil with Brownie, you must first `follow their steps to install Anvil <https://github.com/foundry-rs/foundry/tree/master/crates/anvil#installation>`_.
 
 Once installed, include the ``--network anvil`` or ``--network anvil-fork`` flag to run Brownie with Anvil. For example, to launch the console:
 


### PR DESCRIPTION
### What I did

Replaced occurrences of `https://github.com/foundry-rs/foundry/tree/master/anvil` with `https://github.com/foundry-rs/foundry/tree/master/crates/anvil`.

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [x] I have updated the documentation
