### PR TITLE
Rename _with_attr to with_attrs in VirtualMachineError class

### DIFF
--- a/brownie/exceptions.py
+++ b/brownie/exceptions.py
@@ -152,11 +152,11 @@ class VirtualMachineError(Exception):
             msg = f"{msg}\n{self.source}"
         return str(msg)
 
-    def _with_attr(self, **kwargs) -> "VirtualMachineError":
+    def with_attrs(self, **kwargs) -> "VirtualMachineError":
         for key, value in kwargs.items():
             setattr(self, key, value)
         if self.revert_msg == "Failed assertion":
-            self.revert_msg = self.dev_revert_msg or self.revert_msg  # type: ignore
+            self.revert_msg = self.dev_revert_msg or self.revert_msg
         return self
 
 


### PR DESCRIPTION
Renamed method to better reflect its functionality (handles multiple attributes)
Improved adherence to Python naming conventions
Removed redundant type ignore comment