### PR TITLE
chore: refactor events with `map`

### DIFF
--- a/brownie/network/event.py
+++ b/brownie/network/event.py
@@ -91,7 +91,7 @@ class EventDict:
 
     def count(self, name: str) -> int:
         """EventDict.count(name) -> integer -- return number of occurrences of name"""
-        return len([i.name for i in self._ordered if i.name == name])
+        return len([None for i in self._ordered if i.name == name])
 
     def items(self) -> List:
         """EventDict.items() -> a list object providing a view on EventDict's items"""
@@ -492,7 +492,7 @@ def _decode_logs(logs: List, contracts: Optional[Dict] = None) -> EventDict:
         if log_slice[-1] == logs[-1]:
             break
 
-    events = [format_event(i) for i in events]
+    events = map(format_event, events)
     return EventDict(events)
 
 
@@ -527,7 +527,7 @@ def _decode_trace(trace: Sequence, initial_address: str) -> EventDict:
     events = eth_event.decode_traceTransaction(
         trace, _topics, allow_undecoded=True, initial_address=initial_address
     )
-    events = [format_event(i) for i in events]
+    events = map(format_event, events)
     return EventDict(events)
 
 

--- a/brownie/network/event.py
+++ b/brownie/network/event.py
@@ -492,8 +492,7 @@ def _decode_logs(logs: List, contracts: Optional[Dict] = None) -> EventDict:
         if log_slice[-1] == logs[-1]:
             break
 
-    events = map(format_event, events)
-    return EventDict(events)
+    return EventDict(map(format_event, events))
 
 
 def _decode_ds_note(log, contract):  # type: ignore
@@ -527,8 +526,7 @@ def _decode_trace(trace: Sequence, initial_address: str) -> EventDict:
     events = eth_event.decode_traceTransaction(
         trace, _topics, allow_undecoded=True, initial_address=initial_address
     )
-    events = map(format_event, events)
-    return EventDict(events)
+    return EventDict(map(format_event, events))
 
 
 # dictionary of event topic ABIs specific to a single contract deployment

--- a/brownie/network/event.py
+++ b/brownie/network/event.py
@@ -91,7 +91,7 @@ class EventDict:
 
     def count(self, name: str) -> int:
         """EventDict.count(name) -> integer -- return number of occurrences of name"""
-        return len([None for i in self._ordered if i.name == name])
+        return sum(i.name == name for i in self._ordered)
 
     def items(self) -> List:
         """EventDict.items() -> a list object providing a view on EventDict's items"""


### PR DESCRIPTION
### What I did

This PR will eliminate 1 list comprehension and x-2 global name lookups, where x is the number of logs in the iterable, per _decode_logs call

Might seem silly but profiling showed we spent an inordinate amount of time on these lines.

Related issue: #

### How I did it

### How to verify it

### Checklist

- [x] I have confirmed that my PR passes all linting checks
