### PR TITLE
chore: update changelog with most recent benchmark result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/eth-brownie/brownie)
 ### Changed
-- replace `eth_utils.to_checksum_address` with `cchecksum.to_checksum_address` for ~2x faster checksumming ([#1796](https://github.com/eth-brownie/brownie/pull/1796))
+- replace `eth_utils.to_checksum_address` with `cchecksum.to_checksum_address` for ~8x faster checksumming ([#1796](https://github.com/eth-brownie/brownie/pull/1796))
 
 ## [1.20.7](https://github.com/eth-brownie/brownie/tree/v1.20.7) - 2025-01-07
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/eth-brownie/brownie)
+### Fixed
+- GethPOAMiddleware on Polygon networks with anvil fork ([#1791](https://github.com/eth-brownie/brownie/pull/1791))
+
 ### Changed
 - replace `eth_utils.to_checksum_address` with `cchecksum.to_checksum_address` for ~8x faster checksumming ([#1796](https://github.com/eth-brownie/brownie/pull/1796))
 


### PR DESCRIPTION
It was 2x at release but its 8x now :) 

I also added something to the release notes for #1791 