### PR TITLE
fix: type error

### DIFF
--- a/brownie/utils/docopt.py
+++ b/brownie/utils/docopt.py
@@ -709,7 +709,7 @@ def _parse_options(docstring: str) -> list[_Option]:
     (-\S)
     """
     parts = re.split(option_start, docstring, flags=re.M | re.I | re.VERBOSE)[1:]
-    return list(map(_Option.parse, map(sum, zip(parts[::2], parts[1::2]))))
+    return list(map(_Option.parse, map("".join, zip(parts[::2], parts[1::2]))))
 
 
 def _lint_docstring(sections: _DocSections):


### PR DESCRIPTION
### What I did
I thought 2 numbers were being added, so I summed
I was wrong, they were strings
sum is type error

Related issue: #

### How I did it
now I join

### How to verify it
you join too

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [x] I have updated the documentation
- [x] I have added an entry to the changelog
