### PR TITLE
fix: bump eth-event to 1.2.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.11.17
+aiohttp==3.11.18
     # via web3
 aiosignal==1.3.2
     # via aiohttp

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ eth-account==0.11.3
     #   -r requirements.in
     #   eip712
     #   web3
-eth-event==1.2.5
+eth-event==1.2.6
     # via -r requirements.in
 eth-hash[pycryptodome]==0.7.1
     # via


### PR DESCRIPTION
### What I did

Related issue: #

### How I did it

### How to verify it

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
