### PR TITLE
feat(test): run tests verbosely

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,13 +21,13 @@ deps =
     docs-{local,external}: sphinx_rtd_theme
     docs-{local,external}: pygments_lexer_solidity
 commands =
-    py{310,311,312}: python -m pytest tests/ {posargs}
-    evm-byzantium: python -m pytest tests/ --evm 0.4.22,0.4.26,0.5.0,0.5.17,0.6.3,0.6.9 byzantium 0,10000
-    evm-petersburg: python -m pytest tests/ --evm 0.5.5,0.5.17,0.6.3,0.6.9 petersburg 0,10000
-    evm-istanbul: python -m pytest tests/ --evm 0.5.13,0.5.17,0.6.3,0.6.9 istanbul 0,10000
-    evm-latest: python -m pytest tests/ --evm latest byzantium,petersburg,istanbul 0,200,10000
-    pmtest: python -m pytest tests/ --target pm -n 0
-    plugintest: python -m pytest tests/test/plugin --target plugin -n 0
+    py{310,311,312}: python -m pytest tests/ {posargs} -v
+    evm-byzantium: python -m pytest tests/ --evm 0.4.22,0.4.26,0.5.0,0.5.17,0.6.3,0.6.9 byzantium 0,10000 -v
+    evm-petersburg: python -m pytest tests/ --evm 0.5.5,0.5.17,0.6.3,0.6.9 petersburg 0,10000 -v
+    evm-istanbul: python -m pytest tests/ --evm 0.5.13,0.5.17,0.6.3,0.6.9 istanbul 0,10000 -v
+    evm-latest: python -m pytest tests/ --evm latest byzantium,petersburg,istanbul 0,200,10000 -v
+    pmtest: python -m pytest tests/ --target pm -n 0 -v
+    plugintest: python -m pytest tests/test/plugin --target plugin -n 0 -v
     docs-local: sphinx-build {posargs:-E} -b html docs dist/docs -n -q --color
     docs-external: sphinx-build -b linkcheck docs dist/docs -n -q --color
 


### PR DESCRIPTION
### What I did
One of the test failures in the runner shows:
```
    def test_getitem_negative_index(devnetwork, accounts, chain, web3):
        block = chain[-1]
>       assert block == web3.eth.get_block("latest")
E       AssertionError: assert AttributeDict...'uncles': []}) == AttributeDict...drawals': []})
E         Use -v to get the full diff
```

so I decided to modify the test runner so the tests fail verbosely
Related issue: #

### How I did it
added the -v flag to each test command in tox.ini

### How to verify it
the tests will run on this PR