### PR TITLE
fix(test): add handler for race condition in `network` fixture setup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ black==25.1.0
     # via -r requirements.in
 cbor2==5.6.5
     # via vyper
-cchecksum==0.2.2
+cchecksum==0.2.5
     # via -r requirements.in
 certifi==2025.1.31
     # via requests
@@ -132,7 +132,7 @@ multidict==6.4.3
     # via
     #   aiohttp
     #   yarl
-mypy-extensions==1.0.0
+mypy-extensions==1.1.0
     # via black
 packaging==23.2
     # via

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -268,13 +268,21 @@ def history():
 @pytest.fixture
 def network():
     if brownie.network.is_connected():
-        brownie.network.disconnect(False)
+        try:
+            brownie.network.disconnect(False)
+        except ConnectionError:
+            # This can sometimes occur during setup but we don't really care why or how. 
+            # Probably a race condition, maybe fixable with fixture isolation.
+            pass
+            
     yield brownie.network
+    
     if brownie.network.is_connected():
         try:
             brownie.network.disconnect(False)
         except ConnectionError:
             # This can sometimes occur during teardown but we don't really care why or how
+            # Probably a race condition, maybe fixable with fixture isolation.
             pass
 
 


### PR DESCRIPTION
Maybe a better solution here would be a threading.Lock? 