### PR TITLE
ci: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/pip-compile.yaml
+++ b/.github/workflows/pip-compile.yaml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.head_ref }}  # Check out the PR branch
 


### PR DESCRIPTION
Hey ! GitHub‑hosted runners now use Node 20, so checkout v4 is required
This PR updates all workflows to actions/checkout@v4 , no functional changes expected