### PR TITLE
fix(test): network.disconnect race condition

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ black==25.1.0
     # via -r requirements.in
 cbor2==5.6.5
     # via vyper
-cchecksum==0.2.5
+cchecksum==0.2.6
     # via -r requirements.in
 certifi==2025.1.31
     # via requests
@@ -120,7 +120,7 @@ iniconfig==2.1.0
     # via pytest
 jsonschema==4.23.0
     # via web3
-jsonschema-specifications==2024.10.1
+jsonschema-specifications==2025.4.1
     # via jsonschema
 lark==1.2.2
     # via vyper

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -291,7 +291,11 @@ def network():  # sourcery skip: use-contextlib-suppress
 
 @pytest.fixture
 def connect_to_mainnet(network):
-    network.connect("mainnet")
+    try:
+        network.connect("mainnet")
+    except ConnectionError:
+        network.disconnect()
+        network.connect("mainnet")
     yield network
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -269,15 +269,23 @@ def history():
 _network_lock = threading.Lock()
 
 @pytest.fixture
-def network():
+def network():  # sourcery skip: use-contextlib-suppress
     with _network_lock:
         if brownie.network.is_connected():
-            brownie.network.disconnect(False)
-                
+            try:
+                brownie.network.disconnect(False)
+            except ConnectionError:
+                # This can sometimes occur during setup but we don't really care why or how. 
+                pass
+
         yield brownie.network
         
         if brownie.network.is_connected():
-            brownie.network.disconnect(False)
+            try:
+                brownie.network.disconnect(False)
+            except ConnectionError:
+                # This can sometimes occur during teardown but we don't really care why or how
+                pass
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -268,6 +268,7 @@ def history():
 
 _network_lock = threading.Lock()
 
+
 @pytest.fixture
 def network():  # sourcery skip: use-contextlib-suppress
     with _network_lock:
@@ -275,11 +276,11 @@ def network():  # sourcery skip: use-contextlib-suppress
             try:
                 brownie.network.disconnect(False)
             except ConnectionError:
-                # This can sometimes occur during setup but we don't really care why or how. 
+                # This can sometimes occur during setup but we don't really care why or how.
                 pass
 
         yield brownie.network
-        
+
         if brownie.network.is_connected():
             try:
                 brownie.network.disconnect(False)


### PR DESCRIPTION
### What I did
The threading.Lock we added did not fully solve our issue, so I readded the try: except ConnectionError: block that we removed when we added the lock

Related issue: #

### How I did it

### How to verify it

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
