### PR TITLE
fix(test): add ConnectionError handler in _reconnect helper

### DIFF
--- a/tests/network/contract/test_persistence.py
+++ b/tests/network/contract/test_persistence.py
@@ -54,4 +54,12 @@ def _disconnect(network) -> None:
 
 def _reconnect(network) -> None:
     # I expect an intermittent err here eventually so I'm making this handler now.
-    network.connect("mainnet")
+    try:
+        network.connect("mainnet")
+    except ConnectionError as e:
+        if str(e) == "Already connected to network 'mainnet'":
+            # This happens in the test runners sometimes, we're not too concerned with why or how to fix.
+            # It's probably just a silly race condition due to parallel testing.
+            pass
+        else:
+            raise


### PR DESCRIPTION
This fixes that race condition we've been chasing, in one place anyway

### What I did

Related issue: #

### How I did it

### How to verify it

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
