### PR TITLE
fix(test): race condition in testing runners when calling project.load

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -146,15 +146,19 @@ def _copy_all(src_folder, dest_folder):
 # project fixtures
 
 
+_project_lock = threading.Lock()
+
+
 # creates a temporary folder and sets it as the working directory
 @pytest.fixture
 def project(tmp_path):
-    original_path = os.getcwd()
-    os.chdir(tmp_path)
-    yield brownie.project
-    os.chdir(original_path)
-    for p in brownie.project.get_loaded_projects():
-        p.close(False)
+    with _project_lock:
+        original_path = os.getcwd()
+        os.chdir(tmp_path)
+        yield brownie.project
+        os.chdir(original_path)
+        for p in brownie.project.get_loaded_projects():
+            p.close(False)
 
 
 # yields a newly initialized Project that is not loaded


### PR DESCRIPTION
### What I did

Related issue: #

### How I did it

### How to verify it

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
