### PR TITLE
feat(mypy): network constant types

### DIFF
--- a/brownie/network/__init__.py
+++ b/brownie/network/__init__.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 
+from typing import Final
 
 from .account import Accounts
 from .main import (  # NOQA 401
@@ -19,7 +20,7 @@ from .web3 import web3
 __all__ = ["accounts", "chain", "history", "rpc", "web3"]
 __console_dir__ = ["connect", "disconnect", "show_active", "is_connected", "gas_limit", "gas_price"]
 
-accounts = Accounts()
-rpc = Rpc()
-history = TxHistory()
-chain = Chain()
+accounts: Final[Accounts] = Accounts()
+rpc: Final[Rpc] = Rpc()
+history: Final[TxHistory] = TxHistory()
+chain: Final[Chain] = Chain()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -24,7 +24,7 @@ bump2version==1.0.1
     # via bumpversion
 bumpversion==0.6.0
     # via -r requirements-dev.in
-cachetools==5.5.2
+cachetools==6.0.0
     # via tox
 certifi==2025.4.26
     # via
@@ -49,7 +49,7 @@ coverage[toml]==7.8.2
     # via
     #   -r requirements-dev.in
     #   pytest-cov
-cryptography==45.0.2
+cryptography==45.0.3
     # via secretstorage
 distlib==0.3.9
     # via virtualenv
@@ -58,7 +58,7 @@ docutils==0.21.2
     #   readme-renderer
     #   sphinx
     #   sphinx-rtd-theme
-eth-retry==0.3.4
+eth-retry==0.3.5
     # via -r requirements-dev.in
 filelock==3.18.0
     # via
@@ -177,7 +177,7 @@ pytest==6.2.5
     #   pytest-mock
 pytest-cov==6.1.1
     # via -r requirements-dev.in
-pytest-mock==3.14.0
+pytest-mock==3.14.1
     # via -r requirements-dev.in
 readme-renderer==44.0
     # via twine
@@ -244,7 +244,7 @@ wheel==0.45.1
     #   -c /home/runner/work/brownie/brownie/requirements.txt
     #   -r requirements-dev.in
     #   pip-tools
-zipp==3.21.0
+zipp==3.22.0
     # via
     #   -c /home/runner/work/brownie/brownie/requirements.txt
     #   importlib-metadata

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.11.18
+aiohttp==3.12.2
     # via web3
 aiosignal==1.3.2
     # via aiohttp
@@ -118,7 +118,7 @@ importlib-metadata==8.7.0
     # via vyper
 iniconfig==2.1.0
     # via pytest
-jsonschema==4.23.0
+jsonschema==4.24.0
     # via web3
 jsonschema-specifications==2025.4.1
     # via jsonschema
@@ -262,5 +262,5 @@ wrapt==1.17.2
     # via -r requirements.in
 yarl==1.20.0
     # via aiohttp
-zipp==3.21.0
+zipp==3.22.0
     # via importlib-metadata


### PR DESCRIPTION
this PR should make the types visible downstream ie in downstream repos importing them from the main `__init__.py`

### What I did

Related issue: #

### How I did it

### How to verify it

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
