### PR TITLE
fix(mypy): _Singleton metaclass typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,13 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/eth-brownie/brownie)
+### Fixed
+- singleton metaclass instance typing ([#1888](https://github.com/eth-brownie/brownie/pull/1888))
+
 ### Changed
+- compile half of the libarary to C with mypyc ([#1875](https://github.com/eth-brownie/brownie/pull/1875))
 - optimize EventDict.__contains__ and .count ([#1868](https://github.com/eth-brownie/brownie/pull/1868))
+- implement faster-eth-utils ([#1885](https://github.com/eth-brownie/brownie/pull/1885))
 
 ## [1.21.0](https://github.com/eth-brownie/brownie/tree/v1.21.0) - 2025-05-23
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/eth-brownie/brownie)
 ### Fixed
+- typing for *args and **kwargs ([#1870](https://github.com/eth-brownie/brownie/pull/1870))
 - singleton metaclass instance typing ([#1888](https://github.com/eth-brownie/brownie/pull/1888))
+- various other minor typing issues
 
 ### Changed
 - compile half of the libarary to C with mypyc ([#1875](https://github.com/eth-brownie/brownie/pull/1875))

--- a/brownie/_singleton.py
+++ b/brownie/_singleton.py
@@ -7,6 +7,8 @@ class _Singleton(type):
     _instances: Dict = {}
 
     def __call__(cls, *args, **kwargs):
+        # NOTE counterintuitively, when you supply type hints for a metaclass call method,
+        #      it breaks the standard typing for the created instances. Do not add types here.
         if cls not in cls._instances:
             cls._instances[cls] = super(_Singleton, cls).__call__(*args, **kwargs)
         return cls._instances[cls]

--- a/brownie/_singleton.py
+++ b/brownie/_singleton.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# mypy: disable-error-code="untyped-def"
 from typing import Dict
 
 

--- a/brownie/_singleton.py
+++ b/brownie/_singleton.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 # mypy: disable-error-code="untyped-def"
-from typing import Any, Dict
+from typing import Dict
 
 
 class _Singleton(type):

--- a/brownie/_singleton.py
+++ b/brownie/_singleton.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+# mypy: disable-error-code="untyped-def"
 from typing import Any, Dict
 
 
@@ -6,7 +7,7 @@ class _Singleton(type):
 
     _instances: Dict = {}
 
-    def __call__(cls, *args: Any, **kwargs: Any) -> Any:
+    def __call__(cls, *args, **kwargs):
         if cls not in cls._instances:
             cls._instances[cls] = super(_Singleton, cls).__call__(*args, **kwargs)
         return cls._instances[cls]


### PR DESCRIPTION
counterintuitively, when you supply type hints for a metaclass' call method, it breaks typing for the created instances which all resolve to the `__call__` method's return type (currently `Any`)

This PR allows all singleton-based classes to type correctly.

### What I did

Related issue: #

### How I did it

### How to verify it
clone it and mouseover the instances in your IDE

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
