### PR TITLE
fix(docs): correct typos in API and core documentation

### DIFF
--- a/docs/api-project.rst
+++ b/docs/api-project.rst
@@ -127,7 +127,7 @@ Module Methods
     * ``project_path``: Path to the project. If ``None``, attempts to find one using ``check_for_project('.')``.
     * ``name``: Name to assign to the project. If None, the name is generated from the name of the project folder.
 
-    Returns a :func:`Project <brownie.project.main.Project>` object. The same object is also available from within the ``project`` module namespce.
+    Returns a :func:`Project <brownie.project.main.Project>` object. The same object is also available from within the ``project`` module namespace.
 
     .. code-block:: python
 

--- a/docs/api-test.rst
+++ b/docs/api-test.rst
@@ -45,7 +45,7 @@ These fixtures provide access to objects related to the project being tested.
 
 .. py:attribute:: fixtures.state_machine
 
-    Session scope. Yields the :func:`state_machine <stateful.state_machine>` method, used to launc rule-based state machine tests.
+    Session scope. Yields the :func:`state_machine <stateful.state_machine>` method, used to launch rule-based state machine tests.
 
 .. py:attribute:: fixtures.web3
 

--- a/docs/core-gas.rst
+++ b/docs/core-gas.rst
@@ -115,7 +115,7 @@ Available Gas Strategies
 
 .. py:class:: brownie.network.gas.strategies.GasNowStrategy(speed="fast")
 
-    Simple gas strategy for determing a price using the `GasNow <https://www.gasnow.org/>`_ API.
+    Simple gas strategy for determining a price using the `GasNow <https://www.gasnow.org/>`_ API.
 
     * ``speed``: The gas price to use based on the API call. Options are rapid, fast, standard and slow.
 

--- a/docs/core-transactions.rst
+++ b/docs/core-transactions.rst
@@ -237,7 +237,7 @@ Each step in the trace includes the following data:
 Call Traces
 -----------
 
-When dealing with complex transactions the trace can be thousands of steps long - it can be challenging to know where to begin examining it. Brownie provides the :func:`TransactionReceipt.call_trace <TransactionReceipt.call_trace>` method to view a complete map of every jump that occured in the transaction:
+When dealing with complex transactions the trace can be thousands of steps long - it can be challenging to know where to begin examining it. Brownie provides the :func:`TransactionReceipt.call_trace <TransactionReceipt.call_trace>` method to view a complete map of every jump that occurred in the transaction:
 
 .. code-block:: python
 
@@ -264,7 +264,7 @@ Each line shows the following information:
 
     ContractName.functionName (external call opcode) start:stop [internal / total gas used]
 
-Where ``start`` and ``stop`` are the indexes of :func:`TransactionReceipt.trace <TransactionReceipt.trace>` where the function was entered and exited. :func:`TransactionReceipt.call_trace <TransactionReceipt.call_trace>` provides an initial high level overview of the transaction execution path, which helps you to examine the individual trace steps in a more targetted manner and determine where things went wrong in a complex transaction.
+Where ``start`` and ``stop`` are the indexes of :func:`TransactionReceipt.trace <TransactionReceipt.trace>` where the function was entered and exited. :func:`TransactionReceipt.call_trace <TransactionReceipt.call_trace>` provides an initial high level overview of the transaction execution path, which helps you to examine the individual trace steps in a more targeted manner and determine where things went wrong in a complex transaction.
 
 Functions that terminated with ``REVERT`` or ``INVALID`` opcodes are highlighted in red.
 


### PR DESCRIPTION
- Fixed typo namespce → namespace in docs/api-project.rst

- Fixed typo launc → launch in docs/api-test.rst

- Fixed typo determing → determining in docs/core-gas.rst

- Fixed typo occured → occurred and targetted → targeted in docs/core-transactions.rst