### PR TITLE
fix: correct typos in Brownie codebase

### DIFF
--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -451,7 +451,7 @@ class ContractContainer(_ContractBase):
             "compilerversion": f"v{contract_info['compiler_version']}",
             "optimizationUsed": 1 if contract_info["optimizer_enabled"] else 0,
             "runs": contract_info["optimizer_runs"],
-            "constructorArguements": constructor_arguments,
+            "constructorArguments": constructor_arguments,
             "licenseType": license_code,
         }
         response = requests.post(

--- a/brownie/network/gas/strategies.py
+++ b/brownie/network/gas/strategies.py
@@ -115,7 +115,7 @@ class ExponentialScalingStrategy(TimeGasStrategy):
 
 class GasNowStrategy(SimpleGasStrategy):
     """
-    Gas strategy for determing a price using the GasNow API.
+    Gas strategy for determining a price using the GasNow API.
 
     GasNow returns 4 possible prices:
 

--- a/brownie/network/state.py
+++ b/brownie/network/state.py
@@ -126,7 +126,7 @@ class TxHistory(metaclass=_Singleton):
         Arguments
         ---------
         key : Callable, optional
-            An optional function to filter with. It should expect one agument and return
+            An optional function to filter with. It should expect one argument and return
             True or False.
 
         Keyword Arguments
@@ -153,7 +153,7 @@ class TxHistory(metaclass=_Singleton):
         Arguments
         ---------
         key : Callable, optional
-            An optional function to filter with. It should expect one agument and return
+            An optional function to filter with. It should expect one argument and return
             True or False.
 
         Keyword Arguments


### PR DESCRIPTION
- contract.py: fixed "constructorArguements" → "constructorArguments"
- strategies.py: fixed docstring typo "determing" → "determining"
- state.py: fixed docstring typo "agument" → "argument" (two occurrences)