### PR TITLE
fix(cicd): let gh runner force push to compile branch

### DIFF
--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -44,7 +44,7 @@ jobs:
         git checkout -b compile-c-files-auto
         git add .
         git commit -m "chore: compile C files for source control"
-        git push origin compile-c-files-auto
+        git push --force origin compile-c-files-auto
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v5


### PR DESCRIPTION
### What I did

Related issue: #

### How I did it

### How to verify it

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog
