### PR TITLE
chore(cicd): remove deprecated caches from release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,30 +81,8 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Cache .mypy_cache
-        uses: actions/cache@v4
-        with:
-          path: .mypy_cache
-          key: mypy-cache-${{ runner.os }}-${{ hashFiles('**/*.py', 'pyproject.toml') }}
-
       - name: Install cibuildwheel
         run: python -m pip install --upgrade pip setuptools wheel cibuildwheel
-
-      - name: Restore ccache cache
-        id: restore-ccache
-        if: runner.os != 'Windows'
-        uses: actions/cache/restore@v4
-        with:
-          path: ~/.cache/ccache
-          key: ccache-${{ runner.os }}-${{ hashFiles('setup.py', 'pyproject.toml') }}-${{ hashFiles('**/*.h', '**/*.c', '**/*.py') }}
-          restore-keys: ccache-${{ runner.os }}-${{ hashFiles('setup.py', 'pyproject.toml') }}-
-
-      - name: Install ccache (Linux)
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y ccache
-      - name: Install ccache (MacOS)
-        if: runner.os == 'MacOS'
-        run: brew install ccache
 
       - name: Build wheels
         env:
@@ -116,8 +94,6 @@ jobs:
           CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_archs_windows || '' }}
           # Which wheels to build for Linux (manylinux vs. musllinux)
           CIBW_BUILD: ${{ matrix.cibw_build || '' }}
-          # use ccache for speed
-          CC: ccache gcc
         run: python -m cibuildwheel --output-dir wheelhouse
 
       - name: Upload wheels
@@ -125,13 +101,6 @@ jobs:
         with:
           name: ${{ matrix.artifact_name }}
           path: wheelhouse/*.whl
-
-      - name: Save ccache cache
-        if: runner.os != 'Windows'
-        uses: actions/cache/save@v4
-        with:
-          path: ~/.cache/ccache
-          key: ccache-${{ runner.os }}-${{ hashFiles('setup.py', 'pyproject.toml') }}-${{ hashFiles('**/*.h', '**/*.c', '**/*.py') }}
 
   publish_sdist_and_wheels:
     name: Publish wheels to PyPI


### PR DESCRIPTION
These are not actually working the way they were intended, since everything is built in isolated environments. This means we never have a cache hit and it just makes the workflow needlessly cluttered.