### PR TITLE
perf: speed up stream downloads

### DIFF
--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -77,6 +77,7 @@ from brownie.utils import notify
 
 BUILD_FOLDERS: Final = "contracts", "deployments", "interfaces"
 MIXES_URL: Final = "https://github.com/brownie-mix/{}-mix/archive/{}.zip"
+DOWNLOAD_CHUNK_SIZE: Final = 1024 * 1024
 
 GITIGNORE: Final = """__pycache__
 .env
@@ -1093,11 +1094,11 @@ def _stream_download(
 
     total_size = int(response.headers.get("content-length", 0))
     progress_bar = tqdm(total=total_size, unit="iB", unit_scale=True)
-    content = b""
+    content = bytearray()
 
-    for data in response.iter_content(1024, decode_unicode=True):
+    for data in response.iter_content(DOWNLOAD_CHUNK_SIZE):
         progress_bar.update(len(data))
-        content += data
+        content.extend(data)
     progress_bar.close()
 
     with zipfile.ZipFile(BytesIO(content)) as zf:


### PR DESCRIPTION
## Summary
- use 1 MiB chunks for project zip stream downloads instead of 1 KiB chunks
- accumulate streamed bytes with bytearray.extend() instead of repeated immutable bytes concatenation

## Context
This is the same hot-path shape fixed in ApeWorX/py-solc-x#170, where a progress-enabled real compiler download improved from 74.143s to 1.693s on the same uncached 35.7 MB payload.

Brownie compiler installs do not hit this path because Solidity and Vyper installs call their installer libraries with show_progress=False. This patch targets Brownie's own project/mix/dependency zip downloader, which still had the 1 KiB progress loop.

## Tests
- python -m py_compile brownie/project/main.py
- git diff --check
