### PR TITLE
fix: support forked pull requests in ci

### DIFF
--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -29,7 +29,7 @@ jobs:
           pyproject.toml
           setup.py
         ccache: 'true'
-        push-source: 'true'
-        normalize-source: 'true'
+        push-source: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+        normalize-source: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         trigger-branch-name: ${{ github.head_ref || github.ref_name }}
         commit-message: "chore: compile C files for source control"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,7 +25,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.head_ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.head_ref || github.ref_name }}
       - name: Lint All The Things
         uses: BobTheBuidler/lint-all-the-things@v0.0.4
         with:

--- a/.github/workflows/pip-compile.yaml
+++ b/.github/workflows/pip-compile.yaml
@@ -17,7 +17,8 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
-        ref: ${{ github.head_ref }}  # Check out the PR branch
+        repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+        ref: ${{ github.head_ref || github.ref_name }}  # Check out the PR branch
 
     - name: Set up Python
       uses: actions/setup-python@v4


### PR DESCRIPTION
## Summary
- check out fork PR branches from the head repository in lint and pip-compile workflows
- keep mypycify source pushback for same-repo PRs and pushes, but disable it for fork PRs

## Context
Fork PRs currently fail before project code runs because some workflows fetch `${{ github.head_ref }}` from `eth-brownie/brownie`, while the branch only exists on the contributor fork. This showed up on https://github.com/eth-brownie/brownie/pull/2146 where `lint-all-the-things` and `pip-compile` failed during checkout.

The compile workflow has the same fork-branch assumption through the mypycify source pushback path. For fork PRs this patch still lets compile run, but skips the normalization/push step that cannot write back to the upstream repository.

## Validation
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }; puts "workflow yaml parses"' .github/workflows/*.yaml`\n- `git diff --check`