### PR TITLE
docs: clarify compiled runtime contract for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Agent Requirements
+
+All agents must follow these rules:
+
+brownie is always compiled. PyPI wheels are compiled, setup compiles the project, and tests/CI must validate compiled extensions. Do not invent or reason from an interpreted `.py` runtime path; tracked `.py` files are mypyc source inputs.


### PR DESCRIPTION
Makes the always-compiled package contract explicit so future agents do not infer an interpreted runtime path.