### PR TITLE
Add BattleChain mainnet (626) and testnet (627)

### DIFF
--- a/brownie/data/network-config.yaml
+++ b/brownie/data/network-config.yaml
@@ -224,6 +224,18 @@ live:
         host: https://mainnet.base.org
         id: base-main
         name: Base mainnet
+  - name: BattleChain
+    networks:
+      - chainid: 626
+        explorer: https://block-explorer-api.battlechain.com/api
+        host: https://mainnet.battlechain.com
+        id: battlechain-main
+        name: BattleChain Mainnet
+      - chainid: 627
+        explorer: https://block-explorer-api.testnet.battlechain.com/api
+        host: https://testnet.battlechain.com
+        id: battlechain-test
+        name: BattleChain Testnet
 
 
 


### PR DESCRIPTION
Adds a `BattleChain` network family under `live:` with mainnet (626) and testnet (627).

ZKsync-based Ethereum L2; the `explorer` field points at the matter-labs/block-explorer Etherscan-compatible API.