### PR TITLE
fix: remove deprecated license classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,6 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "Topic :: Software Development :: Build Tools",
-        "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
## Summary
- Remove the deprecated MIT license Trove classifier from `setup.py`.
- Keep the existing SPDX-compatible `license="MIT"` metadata unchanged.

## Rationale
Modern setuptools warns that license classifiers should be removed in favor of SPDX license expressions. This avoids that packaging warning without changing package behavior.

## Details
- Removed `License :: OSI Approved :: MIT License` from `classifiers`.
- Did not change package versions, dependencies, lockfiles, or generated files.
- Validation:
  - `rg -n "License :: OSI Approved :: MIT License" setup.py pyproject.toml setup.cfg`
  - `python setup.py egg_info --egg-base /tmp/brownie-egg-info`
  - `git diff --check origin/master..HEAD`